### PR TITLE
Randomize simulated anomaly graph data

### DIFF
--- a/__tests__/unit/lib/anomaly-chart.test.ts
+++ b/__tests__/unit/lib/anomaly-chart.test.ts
@@ -1,0 +1,38 @@
+import { buildAnomalyDetectionChartData } from '@/lib/utils/anomaly-chart';
+
+describe('buildAnomalyDetectionChartData', () => {
+  it('uses hourly totals and anomaly trends instead of flattening every normal bucket', () => {
+    const data = buildAnomalyDetectionChartData({
+      endDate: new Date('2026-04-02T06:37:00Z'),
+      hours: 3,
+      totals: [
+        { time_bucket: '2026-04-02T04:00:00', count: 90 },
+        { time_bucket: '2026-04-02T05:00:00', count: 80 },
+        { time_bucket: '2026-04-02T06:00:00', count: 120 },
+      ],
+      trends: [
+        { time_bucket: '2026-04-02T04:00:00', count: 5 },
+        { time_bucket: '2026-04-02T05:00:00', count: 18 },
+        { time_bucket: '2026-04-02T06:00:00', count: 2 },
+      ],
+    });
+
+    expect(data.map(point => point.normal)).toEqual([85, 62, 118]);
+    expect(data.map(point => point.anomaly)).toEqual([5, 18, 2]);
+  });
+
+  it('fills missing buckets and clamps normal values at zero', () => {
+    const data = buildAnomalyDetectionChartData({
+      endDate: new Date('2026-04-02T06:10:00Z'),
+      hours: 2,
+      totals: [{ time_bucket: '2026-04-02T06:00:00', count: 4 }],
+      trends: [{ time_bucket: '2026-04-02T06:00:00', count: 7 }],
+    });
+
+    expect(data).toHaveLength(2);
+    expect(data[0].normal).toBe(0);
+    expect(data[0].anomaly).toBe(0);
+    expect(data[1].normal).toBe(0);
+    expect(data[1].anomaly).toBe(7);
+  });
+});

--- a/__tests__/unit/lib/severity.test.ts
+++ b/__tests__/unit/lib/severity.test.ts
@@ -64,7 +64,7 @@ describe('calculateDeviceSeverity', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
-    jest.setSystemTime(new Date('2025-06-15T12:00:00Z'));
+    jest.setSystemTime(new Date('2025-06-15T12:00:00Z').getTime());
   });
 
   afterEach(() => {
@@ -270,7 +270,7 @@ describe('getSeverityIcon', () => {
 describe('isWithinDays', () => {
   beforeEach(() => {
     jest.useFakeTimers();
-    jest.setSystemTime(new Date('2025-06-15T12:00:00Z'));
+    jest.setSystemTime(new Date('2025-06-15T12:00:00Z').getTime());
   });
 
   afterEach(() => {
@@ -305,7 +305,7 @@ describe('isWithinDays', () => {
 describe('getDaysUntil', () => {
   beforeEach(() => {
     jest.useFakeTimers();
-    jest.setSystemTime(new Date('2025-06-15T12:00:00Z'));
+    jest.setSystemTime(new Date('2025-06-15T12:00:00Z').getTime());
   });
 
   afterEach(() => {
@@ -337,7 +337,7 @@ describe('getDaysUntil', () => {
 describe('formatRelativeDate', () => {
   beforeEach(() => {
     jest.useFakeTimers();
-    jest.setSystemTime(new Date('2025-06-15T12:00:00Z'));
+    jest.setSystemTime(new Date('2025-06-15T12:00:00Z').getTime());
   });
 
   afterEach(() => {
@@ -369,7 +369,7 @@ describe('formatRelativeDate', () => {
 describe('isPast', () => {
   beforeEach(() => {
     jest.useFakeTimers();
-    jest.setSystemTime(new Date('2025-06-15T12:00:00Z'));
+    jest.setSystemTime(new Date('2025-06-15T12:00:00Z').getTime());
   });
 
   afterEach(() => {
@@ -396,7 +396,7 @@ describe('isPast', () => {
 describe('categorizeDevicesBySeverity', () => {
   beforeEach(() => {
     jest.useFakeTimers();
-    jest.setSystemTime(new Date('2025-06-15T12:00:00Z'));
+    jest.setSystemTime(new Date('2025-06-15T12:00:00Z').getTime());
   });
 
   afterEach(() => {
@@ -426,7 +426,7 @@ describe('categorizeDevicesBySeverity', () => {
 describe('getDeviceSeverityCounts', () => {
   beforeEach(() => {
     jest.useFakeTimers();
-    jest.setSystemTime(new Date('2025-06-15T12:00:00Z'));
+    jest.setSystemTime(new Date('2025-06-15T12:00:00Z').getTime());
   });
 
   afterEach(() => {

--- a/__tests__/unit/lib/simulationReadings.test.ts
+++ b/__tests__/unit/lib/simulationReadings.test.ts
@@ -1,0 +1,50 @@
+import {
+  calculateAnomalyProbability,
+  type SimulatedDevice,
+  type SimulationProfile,
+} from '@/lib/simulation/readings';
+
+describe('calculateAnomalyProbability', () => {
+  const profile: SimulationProfile = {
+    anomalyBaseRate: 0.03,
+    burstMultiplier: 1.4,
+    volatility: 1,
+  };
+
+  it('boosts hotspot floors and types without exceeding the upper clamp', () => {
+    const baseDevice: SimulatedDevice = {
+      _id: 'device_001',
+      type: 'temperature',
+      location: { building_id: 'b1', floor: 2, room_name: '201' },
+    };
+
+    const baseProbability = calculateAnomalyProbability(baseDevice, profile);
+    const boostedProbability = calculateAnomalyProbability(baseDevice, {
+      ...profile,
+      anomalyBaseRate: 0.08,
+      burstMultiplier: 4,
+      hotspotType: 'temperature',
+      hotspotFloor: 2,
+    });
+
+    expect(boostedProbability).toBeGreaterThan(baseProbability);
+    expect(boostedProbability).toBeLessThanOrEqual(0.24);
+  });
+
+  it('keeps motion sensors less noisy than power sensors under the same profile', () => {
+    const powerDevice: SimulatedDevice = {
+      _id: 'device_power',
+      type: 'power',
+      location: { building_id: 'b1', floor: 3, room_name: '301' },
+    };
+    const motionDevice: SimulatedDevice = {
+      _id: 'device_motion',
+      type: 'motion',
+      location: { building_id: 'b1', floor: 3, room_name: '302' },
+    };
+
+    expect(calculateAnomalyProbability(powerDevice, profile)).toBeGreaterThan(
+      calculateAnomalyProbability(motionDevice, profile)
+    );
+  });
+});

--- a/__tests__/unit/lib/v2-client-coverage.test.ts
+++ b/__tests__/unit/lib/v2-client-coverage.test.ts
@@ -334,12 +334,14 @@ describe('analyticsApi.anomalies', () => {
       startDate: '2024-01-01',
       endDate: '2024-01-31',
       minScore: 0.7,
+      bucketGranularity: 'hour',
       limit: 50,
     });
 
     const calledUrl = mockFetch.mock.calls[0][0] as string;
-    expect(calledUrl).toContain('deviceId=device_001');
-    expect(calledUrl).toContain('minScore=0.7');
+    expect(calledUrl).toContain('device_id=device_001');
+    expect(calledUrl).toContain('min_score=0.7');
+    expect(calledUrl).toContain('bucket_granularity=hour');
     expect(calledUrl).toContain('limit=50');
   });
 });

--- a/app/api/v2/cron/simulate/route.ts
+++ b/app/api/v2/cron/simulate/route.ts
@@ -2,221 +2,13 @@ import crypto from 'crypto';
 import dbConnect from '@/lib/db';
 import { pusherServer } from '@/lib/pusher';
 import DeviceV2 from '@/models/v2/DeviceV2';
-import ReadingV2, { type ReadingType, type ReadingUnit } from '@/models/v2/ReadingV2';
+import ReadingV2 from '@/models/v2/ReadingV2';
 import { type NextRequest, NextResponse } from 'next/server';
 import { logger } from '@/lib/monitoring';
-
-// ============================================================================
-// VALUE GENERATORS BY DEVICE TYPE
-// ============================================================================
-
-interface GeneratedReading {
-  value: number;
-  unit: ReadingUnit;
-  isAnomaly: boolean;
-}
-
-/**
- * Generate realistic values for each device type
- */
-function generateValueForType(type: ReadingType): GeneratedReading {
-  // 5% chance of anomaly
-  const isAnomaly = Math.random() < 0.05;
-
-  let value: number;
-  let unit: ReadingUnit;
-
-  switch (type) {
-    case 'temperature':
-      // Normal: 18-28°C, Anomaly: 30-40°C or 5-15°C
-      value = isAnomaly
-        ? Math.random() > 0.5
-          ? 30 + Math.random() * 10
-          : 5 + Math.random() * 10
-        : 18 + Math.random() * 10;
-      unit = 'celsius';
-      break;
-
-    case 'humidity':
-      // Normal: 30-70%, Anomaly: 10-20% or 80-95%
-      value = isAnomaly
-        ? Math.random() > 0.5
-          ? 80 + Math.random() * 15
-          : 10 + Math.random() * 10
-        : 30 + Math.random() * 40;
-      unit = 'percent';
-      break;
-
-    case 'occupancy':
-      // Normal: 0-50 people, Anomaly: 80-150
-      value = isAnomaly ? 80 + Math.floor(Math.random() * 70) : Math.floor(Math.random() * 50);
-      unit = 'count';
-      break;
-
-    case 'power':
-      // Normal: 100-5000W, Anomaly: 8000-15000W
-      value = isAnomaly ? 8000 + Math.random() * 7000 : 100 + Math.random() * 4900;
-      unit = 'watts';
-      break;
-
-    case 'co2':
-      // Normal: 400-1000ppm, Anomaly: 1500-3000ppm
-      value = isAnomaly ? 1500 + Math.random() * 1500 : 400 + Math.random() * 600;
-      unit = 'ppm';
-      break;
-
-    case 'pressure':
-      // Normal: 1000-1030 hPa, Anomaly: 950-980 or 1040-1060
-      value = isAnomaly
-        ? Math.random() > 0.5
-          ? 1040 + Math.random() * 20
-          : 950 + Math.random() * 30
-        : 1000 + Math.random() * 30;
-      unit = 'hpa';
-      break;
-
-    case 'light':
-      // Normal: 100-1000 lux, Anomaly: 0-50 or 1500-3000
-      value = isAnomaly
-        ? Math.random() > 0.5
-          ? 1500 + Math.random() * 1500
-          : Math.random() * 50
-        : 100 + Math.random() * 900;
-      unit = 'lux';
-      break;
-
-    case 'motion':
-      // Binary: 0 or 1 (70% no motion, 30% motion)
-      value = Math.random() > 0.7 ? 1 : 0;
-      unit = 'boolean';
-      break;
-
-    case 'air_quality':
-      // Normal: 0-100 AQI (ppm), Anomaly: 150-300
-      value = isAnomaly ? 150 + Math.random() * 150 : Math.random() * 100;
-      unit = 'ppm';
-      break;
-
-    case 'water_flow':
-      // Normal: 0.5-50 L/min, Anomaly: 80-150 or 0
-      value = isAnomaly
-        ? Math.random() > 0.3
-          ? 80 + Math.random() * 70
-          : 0
-        : 0.5 + Math.random() * 49.5;
-      unit = 'liters_per_minute';
-      break;
-
-    case 'gas':
-      // Normal: 0-100ppm, Anomaly: 200-500ppm
-      value = isAnomaly ? 200 + Math.random() * 300 : Math.random() * 100;
-      unit = 'ppm';
-      break;
-
-    case 'vibration':
-      // Normal: 0-2, Anomaly: 5-10
-      value = isAnomaly ? 5 + Math.random() * 5 : Math.random() * 2;
-      unit = 'raw';
-      break;
-
-    case 'voltage':
-      // Normal: 110-240V, Anomaly: 90-105 or 250-280
-      value = isAnomaly
-        ? Math.random() > 0.5
-          ? 250 + Math.random() * 30
-          : 90 + Math.random() * 15
-        : 110 + Math.random() * 130;
-      unit = 'volts';
-      break;
-
-    case 'current':
-      // Normal: 0.1-15A, Anomaly: 20-50A
-      value = isAnomaly ? 20 + Math.random() * 30 : 0.1 + Math.random() * 14.9;
-      unit = 'amperes';
-      break;
-
-    case 'energy':
-      // Normal: 0-100 kWh, Anomaly: 150-300 kWh
-      value = isAnomaly ? 150 + Math.random() * 150 : Math.random() * 100;
-      unit = 'kilowatt_hours';
-      break;
-
-    default:
-      value = Math.random() * 100;
-      unit = 'raw';
-  }
-
-  return {
-    value: parseFloat(value.toFixed(2)),
-    unit,
-    isAnomaly,
-  };
-}
-
-/**
- * Generate random context data for a reading
- */
-function generateContext() {
-  return {
-    battery_level: 20 + Math.floor(Math.random() * 80), // 20-100%
-    signal_strength: -90 + Math.floor(Math.random() * 60), // -90 to -30 dBm
-  };
-}
-
-/**
- * Generate quality metrics for a reading
- */
-function generateQuality(isAnomaly: boolean) {
-  const isValid = Math.random() > 0.02; // 2% invalid readings
-  return {
-    is_valid: isValid,
-    confidence_score: parseFloat((0.85 + Math.random() * 0.15).toFixed(2)), // 0.85-1.0
-    validation_flags: [] as string[],
-    is_anomaly: isAnomaly,
-    anomaly_score: isAnomaly
-      ? parseFloat((0.5 + Math.random() * 0.5).toFixed(2)) // 0.5-1.0 for anomalies
-      : parseFloat((Math.random() * 0.3).toFixed(2)), // 0-0.3 for normal
-  };
-}
-
-// ============================================================================
-// READING GENERATION
-// ============================================================================
-
-async function generateReadings() {
-  await dbConnect();
-
-  // Fetch all active V2 devices
-  const devices = await DeviceV2.findActive();
-  const readings = [];
-  const timestamp = new Date();
-
-  for (const device of devices) {
-    const { value, unit, isAnomaly } = generateValueForType(device.type as ReadingType);
-    const rawValue = value + (Math.random() * 1 - 0.5); // Slight variation for raw value
-    const calibrationOffset = parseFloat((Math.random() * 0.5 - 0.25).toFixed(2));
-
-    readings.push({
-      metadata: {
-        device_id: device._id,
-        type: device.type,
-        unit: unit,
-        source: 'simulation' as const,
-      },
-      timestamp: timestamp,
-      value: value,
-      quality: generateQuality(isAnomaly),
-      context: generateContext(),
-      processing: {
-        raw_value: parseFloat(rawValue.toFixed(2)),
-        calibration_offset: calibrationOffset,
-        ingested_at: new Date(),
-      },
-    });
-  }
-
-  return readings;
-}
+import {
+  generateSimulatedReadings,
+  type SimulatedDevice,
+} from '@/lib/simulation/readings';
 
 // ============================================================================
 // API ROUTE HANDLER
@@ -245,8 +37,14 @@ export async function GET(request: NextRequest) {
   
 
   try {
+    await dbConnect();
+
+    const devices = await DeviceV2.findActive()
+      .select({ _id: 1, type: 1, location: 1 })
+      .lean<SimulatedDevice[]>();
+
     // 1. Generate mock data
-    const newReadings = await generateReadings();
+    const newReadings = generateSimulatedReadings(devices);
 
     if (newReadings.length === 0)
       return NextResponse.json(
@@ -271,7 +69,7 @@ export async function GET(request: NextRequest) {
     }
 
     // Count anomalies for response
-    const anomalyCount = newReadings.filter(r => r.quality.is_anomaly).length;
+    const anomalyCount = newReadings.filter(r => r.quality?.is_anomaly === true).length;
 
     return NextResponse.json({
       success: true,

--- a/components/dashboard/AnomalyDetectionChart.tsx
+++ b/components/dashboard/AnomalyDetectionChart.tsx
@@ -1,16 +1,10 @@
 'use client';
 
-import { v2Api } from '@/lib/api/v2-client';
-import { useAnomalies } from '@/lib/query/hooks';
+import { useAnomalies, useEnergyAnalytics } from '@/lib/query/hooks';
+import { buildAnomalyDetectionChartData } from '@/lib/utils/anomaly-chart';
 import { Loader2 } from 'lucide-react';
-import { useEffect, useState, useMemo } from 'react';
+import { useMemo } from 'react';
 import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
-
-interface ChartDataPoint {
-  time: string;
-  normal: number;
-  anomaly: number;
-}
 
 interface AnomalyDetectionChartProps {
   hours?: number;
@@ -19,7 +13,7 @@ interface AnomalyDetectionChartProps {
 export default function AnomalyDetectionChart({ hours = 6 }: AnomalyDetectionChartProps) {
   // Calculate time range - memoize to prevent infinite re-renders
   // Round to nearest minute to avoid constant changes
-  const { startDateISO, endDateISO, startDate } = useMemo(() => {
+  const { startDateISO, endDateISO, endDate } = useMemo(() => {
     const now = new Date();
     // Round down to nearest minute to stabilize the value
     now.setSeconds(0, 0);
@@ -28,97 +22,46 @@ export default function AnomalyDetectionChart({ hours = 6 }: AnomalyDetectionCha
     return {
       startDateISO: start.toISOString(),
       endDateISO: end.toISOString(),
-      startDate: start,
+      endDate: end,
     };
   }, [hours]);
 
   // Fetch anomalies with React Query
   const {
     data: anomaliesData,
-    isLoading,
+    isLoading: isLoadingAnomalies,
     error: fetchError,
   } = useAnomalies({
     startDate: startDateISO,
     endDate: endDateISO,
-    limit: 1000,
+    bucketGranularity: 'hour',
+    limit: 1,
   });
 
-  // Fetch readings total for normal count calculation (still need this one call)
-  const [totalReadings, setTotalReadings] = useState(0);
-  const [readingsError, setReadingsError] = useState<string | null>(null);
+  const {
+    data: totalReadingsData,
+    isLoading: isLoadingTotals,
+    error: totalsError,
+  } = useEnergyAnalytics({
+    startDate: startDateISO,
+    endDate: endDateISO,
+    granularity: 'hour',
+    aggregationType: 'count',
+    includeInvalid: true,
+  });
 
-  const error = fetchError ? 'Failed to load data' : readingsError;
-
-  useEffect(() => {
-    const fetchReadingsTotal = async () => {
-      try {
-        const readingsRes = await v2Api.readings.list({
-          startDate: startDateISO,
-          endDate: endDateISO,
-          limit: 1,
-        });
-        setTotalReadings(readingsRes.pagination?.total || 0);
-        setReadingsError(null);
-      } catch (err) {
-        console.error('Failed to fetch readings total:', err);
-        setReadingsError('Failed to load readings data');
-      }
-    };
-    fetchReadingsTotal();
-  }, [startDateISO, endDateISO]);
+  const isLoading = isLoadingAnomalies || isLoadingTotals;
+  const error = fetchError || totalsError ? 'Failed to load data' : null;
 
   // Process chart data
   const data = useMemo(() => {
-    if (!anomaliesData) return [];
-
-    const anomalies = anomaliesData.anomalies || [];
-
-    // Create hourly buckets using epoch hour as key for reliable matching
-    const hourlyBuckets: Map<number, { time: string; normal: number; anomaly: number }> = new Map();
-
-    // Initialize buckets for each hour (including current hour)
-    for (let i = 0; i <= hours; i++) {
-      const bucketTime = new Date(startDate.getTime() + i * 60 * 60 * 1000);
-      // Use epoch hour as key (floor to hour)
-      const epochHour = Math.floor(bucketTime.getTime() / (60 * 60 * 1000));
-      const timeLabel = bucketTime.toLocaleTimeString([], {
-        hour: '2-digit',
-        minute: '2-digit',
-      });
-      hourlyBuckets.set(epochHour, { time: timeLabel, normal: 0, anomaly: 0 });
-    }
-
-    // Count anomalies per hour
-    anomalies.forEach(a => {
-      const timestamp = new Date(a.timestamp);
-      const epochHour = Math.floor(timestamp.getTime() / (60 * 60 * 1000));
-
-      const bucket = hourlyBuckets.get(epochHour);
-      if (bucket) bucket.anomaly += 1;
+    return buildAnomalyDetectionChartData({
+      endDate,
+      hours,
+      totals: totalReadingsData?.results || [],
+      trends: anomaliesData?.trends || [],
     });
-
-    // Calculate normal readings per bucket (distribute evenly)
-    const totalAnomalies = anomaliesData.pagination?.total || anomalies.length;
-    const totalNormal = Math.max(0, totalReadings - totalAnomalies);
-    const bucketCount = hourlyBuckets.size;
-    const avgNormalPerHour = Math.floor(totalNormal / bucketCount);
-
-    hourlyBuckets.forEach(bucket => {
-      bucket.normal = avgNormalPerHour;
-    });
-
-    // Convert to chart data (sorted by time, take last 'hours' buckets)
-    const chartData: ChartDataPoint[] = Array.from(hourlyBuckets.entries())
-      .sort(([a], [b]) => a - b)
-      .slice(-hours) // Take only the last N hours
-      .map(([, bucket]) => ({
-        time: bucket.time,
-        normal: bucket.normal,
-        anomaly: bucket.anomaly,
-      }));
-
-    return chartData;
-  }, [anomaliesData, totalReadings, hours, startDate]);
+  }, [anomaliesData?.trends, totalReadingsData?.results, endDate, hours]);
 
   if (isLoading)
     return (

--- a/lib/api/v2-client.ts
+++ b/lib/api/v2-client.ts
@@ -265,21 +265,66 @@ export const readingsApi = {
 
 export interface EnergyAnalyticsQuery {
   period?: string;
+  startDate?: string;
+  endDate?: string;
+  deviceId?: string | string[];
+  device_id?: string | string[];
   floor?: number;
-  granularity?: 'minute' | 'hour' | 'day';
-  aggregationType?: 'sum' | 'avg' | 'min' | 'max';
+  granularity?: 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month';
+  aggregationType?: 'sum' | 'avg' | 'min' | 'max' | 'count';
+  aggregation?: 'sum' | 'avg' | 'min' | 'max' | 'count';
   deviceType?: string;
+  type?: string;
   includeInvalid?: boolean;
-  groupBy?: 'floor' | 'room' | 'type' | 'department';
+  include_invalid?: boolean;
+  groupBy?: 'device' | 'floor' | 'room' | 'type' | 'department' | 'building';
+  group_by?: 'device' | 'floor' | 'room' | 'type' | 'department' | 'building';
 }
 
-export interface EnergyDataPoint {
-  timestamp: string;
+export interface EnergyAnalyticsResult {
+  time_bucket: string;
   value: number;
-  quality?: {
-    validReadings: number;
-    totalReadings: number;
-    percentageValid: number;
+  count: number;
+  min_value: number;
+  max_value: number;
+  first_timestamp: string;
+  last_timestamp: string;
+  device_id?: string;
+  type?: string;
+  floor?: number;
+  room?: string;
+  building?: string;
+  department?: string;
+}
+
+export interface EnergyAnalyticsResponse {
+  results: EnergyAnalyticsResult[];
+  comparison: {
+    results: EnergyAnalyticsResult[];
+    label: string;
+    time_range: {
+      start: string;
+      end: string;
+    };
+    total_points: number;
+    summary: {
+      current_total: number;
+      comparison_total: number;
+      percentage_change: number | null;
+      trend: 'increase' | 'decrease' | 'stable' | 'no_data';
+    };
+  } | null;
+  metadata: {
+    granularity: 'second' | 'minute' | 'hour' | 'day' | 'week' | 'month';
+    aggregation_type: string;
+    total_points: number;
+    excluded_invalid: number;
+    group_by: string | null;
+    time_range: {
+      start?: string;
+      end?: string;
+    };
+    compare_with: string | null;
   };
 }
 
@@ -416,12 +461,19 @@ export interface AnomalyResponse {
       avg_score: number;
     }>;
   };
-  trends: Record<string, unknown>;
+  trends: AnomalyTrendPoint[] | null;
   filters_applied: {
     device_id: string | null;
     type: string | null;
     time_range: Record<string, unknown>;
   };
+}
+
+export interface AnomalyTrendPoint {
+  time_bucket: string;
+  count: number;
+  avg_score: number;
+  max_score: number;
 }
 
 export const analyticsApi = {
@@ -435,8 +487,23 @@ export const analyticsApi = {
    *  - includeInvalid → include_invalid
    *  - groupBy → group_by
    */
-  async energy(query: EnergyAnalyticsQuery = {}): Promise<ApiSuccessResponse<EnergyDataPoint[]>> {
-    const { period, aggregationType, deviceType, includeInvalid, groupBy, ...rest } = query;
+  async energy(
+    query: EnergyAnalyticsQuery = {}
+  ): Promise<ApiSuccessResponse<EnergyAnalyticsResponse>> {
+    const {
+      period,
+      aggregationType,
+      aggregation,
+      deviceType,
+      type,
+      includeInvalid,
+      include_invalid,
+      groupBy,
+      group_by,
+      deviceId,
+      device_id,
+      ...rest
+    } = query;
 
     // Resolve period shorthand to startDate/endDate
     const serverParams: Record<string, unknown> = { ...rest };
@@ -452,10 +519,11 @@ export const analyticsApi = {
       }
     }
 
-    if (aggregationType) serverParams.aggregation = aggregationType;
-    if (deviceType) serverParams.type = deviceType;
-    if (includeInvalid !== undefined) serverParams.include_invalid = includeInvalid;
-    if (groupBy) serverParams.group_by = groupBy;
+    if (deviceId ?? device_id) serverParams.device_id = deviceId ?? device_id;
+    if (aggregationType ?? aggregation) serverParams.aggregation = aggregationType ?? aggregation;
+    if (deviceType ?? type) serverParams.type = deviceType ?? type;
+    if (includeInvalid ?? include_invalid) serverParams.include_invalid = includeInvalid ?? include_invalid;
+    if (groupBy ?? group_by) serverParams.group_by = groupBy ?? group_by;
 
     const queryString = buildQueryString(serverParams);
     return apiCall(`/api/v2/analytics/energy${queryString}`);
@@ -476,14 +544,34 @@ export const analyticsApi = {
    */
   async anomalies(
     query: {
-      deviceId?: string;
+      deviceId?: string | string[];
+      device_id?: string | string[];
       startDate?: string;
       endDate?: string;
       minScore?: number;
+      min_score?: number;
+      bucketGranularity?: 'minute' | 'hour' | 'day' | 'week' | 'month';
+      bucket_granularity?: 'minute' | 'hour' | 'day' | 'week' | 'month';
       limit?: number;
     } = {}
   ): Promise<ApiSuccessResponse<AnomalyResponse>> {
-    const queryString = buildQueryString(query as Record<string, unknown>);
+    const {
+      deviceId,
+      device_id,
+      minScore,
+      min_score,
+      bucketGranularity,
+      bucket_granularity,
+      ...rest
+    } = query;
+    const serverParams: Record<string, unknown> = { ...rest };
+
+    if (deviceId ?? device_id) serverParams.device_id = deviceId ?? device_id;
+    if (minScore ?? min_score) serverParams.min_score = minScore ?? min_score;
+    if (bucketGranularity ?? bucket_granularity)
+      serverParams.bucket_granularity = bucketGranularity ?? bucket_granularity;
+
+    const queryString = buildQueryString(serverParams);
     return apiCall(`/api/v2/analytics/anomalies${queryString}`);
   },
 

--- a/lib/query/hooks/useAnomalies.ts
+++ b/lib/query/hooks/useAnomalies.ts
@@ -4,10 +4,11 @@ import { queryKeys } from '../queryClient';
 import type { QueryConfig } from '../types';
 
 interface UseAnomaliesParams {
-  deviceId?: string;
+  deviceId?: string | string[];
   startDate?: string;
   endDate?: string;
   minScore?: number;
+  bucketGranularity?: 'minute' | 'hour' | 'day' | 'week' | 'month';
   limit?: number;
 }
 

--- a/lib/query/hooks/useEnergyAnalytics.ts
+++ b/lib/query/hooks/useEnergyAnalytics.ts
@@ -1,11 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
-import { v2Api, type EnergyAnalyticsQuery } from '@/lib/api/v2-client';
+import {
+  v2Api,
+  type EnergyAnalyticsQuery,
+  type EnergyAnalyticsResponse,
+} from '@/lib/api/v2-client';
 import { queryKeys } from '../queryClient';
 import type { QueryConfig } from '../types';
 
 export function useEnergyAnalytics(
   params: EnergyAnalyticsQuery = {},
-  config?: QueryConfig<unknown>
+  config?: QueryConfig<EnergyAnalyticsResponse>
 ) {
   return useQuery({
     queryKey: queryKeys.analytics.energy(params as Record<string, unknown>),

--- a/lib/simulation/readings.ts
+++ b/lib/simulation/readings.ts
@@ -1,0 +1,317 @@
+import type { IDeviceV2 } from '../../models/v2/DeviceV2';
+import type { IReadingV2, ReadingType, ReadingUnit } from '../../models/v2/ReadingV2';
+
+export type SimulatedDevice = Pick<IDeviceV2, '_id' | 'type' | 'location'>;
+
+interface GeneratedReading {
+  value: number;
+  unit: ReadingUnit;
+  isAnomaly: boolean;
+  anomalyScore: number;
+}
+
+export interface SimulationProfile {
+  anomalyBaseRate: number;
+  burstMultiplier: number;
+  hotspotType?: ReadingType;
+  hotspotFloor?: number;
+  volatility: number;
+}
+
+const MIN_ANOMALY_PROBABILITY = 0.012;
+const MAX_ANOMALY_PROBABILITY = 0.24;
+
+const TYPE_SENSITIVITY: Record<ReadingType, number> = {
+  temperature: 1.05,
+  humidity: 1.0,
+  occupancy: 0.75,
+  power: 1.35,
+  co2: 1.2,
+  pressure: 0.95,
+  light: 0.85,
+  motion: 0.5,
+  air_quality: 1.15,
+  water_flow: 1.25,
+  gas: 1.4,
+  vibration: 1.35,
+  voltage: 1.15,
+  current: 1.25,
+  energy: 1.1,
+};
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function round(value: number, digits = 2) {
+  return Number(value.toFixed(digits));
+}
+
+function randomBetween(min: number, max: number) {
+  return min + Math.random() * (max - min);
+}
+
+function pickRandom<T>(values: T[]): T | undefined {
+  if (values.length === 0) return undefined;
+  return values[Math.floor(Math.random() * values.length)];
+}
+
+function getHourlyLoadFactor(hour: number) {
+  if (hour >= 7 && hour <= 9) return 1.3;
+  if (hour >= 10 && hour <= 16) return 1.1;
+  if (hour >= 17 && hour <= 20) return 1.22;
+  if (hour >= 0 && hour <= 5) return 0.82;
+  return 0.94;
+}
+
+function buildAnomalyScore(anomalyProbability: number, isAnomaly: boolean) {
+  if (isAnomaly) {
+    const severityFloor = clamp(0.56 + anomalyProbability * 1.1, 0.58, 0.9);
+    return round(randomBetween(severityFloor, 1));
+  }
+
+  const normalCeiling = clamp(0.08 + anomalyProbability * 0.8, 0.1, 0.35);
+  return round(randomBetween(0.01, normalCeiling));
+}
+
+export function createSimulationProfile(
+  devices: SimulatedDevice[],
+  timestamp: Date = new Date()
+): SimulationProfile {
+  const deviceTypes = [...new Set(devices.map(device => device.type as ReadingType))];
+  const floors = [...new Set(devices.map(device => device.location.floor))];
+  const localizedBurst = Math.random() < 0.35;
+  const systemicBurst = Math.random() < 0.18;
+
+  return {
+    anomalyBaseRate: round(
+      randomBetween(0.018, 0.048) * getHourlyLoadFactor(timestamp.getUTCHours()),
+      4
+    ),
+    burstMultiplier: systemicBurst
+      ? randomBetween(1.8, 3.4)
+      : localizedBurst
+        ? randomBetween(1.2, 2.4)
+        : randomBetween(0.7, 1.25),
+    hotspotType: localizedBurst ? pickRandom(deviceTypes) : undefined,
+    hotspotFloor: localizedBurst ? pickRandom(floors) : undefined,
+    volatility: systemicBurst ? randomBetween(0.9, 1.35) : randomBetween(0.75, 1.15),
+  };
+}
+
+export function calculateAnomalyProbability(
+  device: SimulatedDevice,
+  profile: SimulationProfile
+) {
+  const typeSensitivity = TYPE_SENSITIVITY[device.type as ReadingType] ?? 1;
+  const typeBoost = profile.hotspotType === device.type ? 1.75 : 1;
+  const floorBoost =
+    profile.hotspotFloor !== undefined && profile.hotspotFloor === device.location.floor ? 1.45 : 1;
+  const motionPenalty = device.type === 'motion' ? 0.55 : 1;
+
+  return round(
+    clamp(
+      profile.anomalyBaseRate *
+        profile.burstMultiplier *
+        typeSensitivity *
+        typeBoost *
+        floorBoost *
+        motionPenalty,
+      MIN_ANOMALY_PROBABILITY,
+      MAX_ANOMALY_PROBABILITY
+    ),
+    4
+  );
+}
+
+function generateValueForType(
+  type: ReadingType,
+  anomalyProbability: number,
+  volatility: number
+): GeneratedReading {
+  const isAnomaly = Math.random() < anomalyProbability;
+  const anomalyScore = buildAnomalyScore(anomalyProbability, isAnomaly);
+  const normalJitter = (Math.random() - 0.5) * volatility;
+
+  let value: number;
+  let unit: ReadingUnit;
+
+  switch (type) {
+    case 'temperature':
+      value = isAnomaly
+        ? Math.random() > 0.5
+          ? 30 + Math.random() * 10
+          : 5 + Math.random() * 10
+        : 18 + Math.random() * 10 + normalJitter * 1.5;
+      unit = 'celsius';
+      break;
+
+    case 'humidity':
+      value = isAnomaly
+        ? Math.random() > 0.5
+          ? 80 + Math.random() * 15
+          : 10 + Math.random() * 10
+        : 30 + Math.random() * 40 + normalJitter * 4;
+      unit = 'percent';
+      break;
+
+    case 'occupancy':
+      value = isAnomaly
+        ? 80 + Math.floor(Math.random() * 70)
+        : Math.max(0, Math.floor(Math.random() * 50 + normalJitter * 5));
+      unit = 'count';
+      break;
+
+    case 'power':
+      value = isAnomaly ? 8000 + Math.random() * 7000 : 100 + Math.random() * 4900 + normalJitter * 150;
+      unit = 'watts';
+      break;
+
+    case 'co2':
+      value = isAnomaly ? 1500 + Math.random() * 1500 : 400 + Math.random() * 600 + normalJitter * 25;
+      unit = 'ppm';
+      break;
+
+    case 'pressure':
+      value = isAnomaly
+        ? Math.random() > 0.5
+          ? 1040 + Math.random() * 20
+          : 950 + Math.random() * 30
+        : 1000 + Math.random() * 30 + normalJitter * 2;
+      unit = 'hpa';
+      break;
+
+    case 'light':
+      value = isAnomaly
+        ? Math.random() > 0.5
+          ? 1500 + Math.random() * 1500
+          : Math.random() * 50
+        : 100 + Math.random() * 900 + normalJitter * 40;
+      unit = 'lux';
+      break;
+
+    case 'motion':
+      value = Math.random() > (isAnomaly ? 0.35 : 0.7) ? 1 : 0;
+      unit = 'boolean';
+      break;
+
+    case 'air_quality':
+      value = isAnomaly ? 150 + Math.random() * 150 : Math.random() * 100 + normalJitter * 4;
+      unit = 'ppm';
+      break;
+
+    case 'water_flow':
+      value = isAnomaly
+        ? Math.random() > 0.3
+          ? 80 + Math.random() * 70
+          : 0
+        : 0.5 + Math.random() * 49.5 + normalJitter * 2;
+      unit = 'liters_per_minute';
+      break;
+
+    case 'gas':
+      value = isAnomaly ? 200 + Math.random() * 300 : Math.random() * 100 + normalJitter * 4;
+      unit = 'ppm';
+      break;
+
+    case 'vibration':
+      value = isAnomaly ? 5 + Math.random() * 5 : Math.random() * 2 + normalJitter * 0.15;
+      unit = 'raw';
+      break;
+
+    case 'voltage':
+      value = isAnomaly
+        ? Math.random() > 0.5
+          ? 250 + Math.random() * 30
+          : 90 + Math.random() * 15
+        : 110 + Math.random() * 130 + normalJitter * 4;
+      unit = 'volts';
+      break;
+
+    case 'current':
+      value = isAnomaly ? 20 + Math.random() * 30 : 0.1 + Math.random() * 14.9 + normalJitter * 0.5;
+      unit = 'amperes';
+      break;
+
+    case 'energy':
+      value = isAnomaly ? 150 + Math.random() * 150 : Math.random() * 100 + normalJitter * 5;
+      unit = 'kilowatt_hours';
+      break;
+
+    default:
+      value = Math.random() * 100;
+      unit = 'raw';
+  }
+
+  return {
+    value: round(value),
+    unit,
+    isAnomaly,
+    anomalyScore,
+  };
+}
+
+function generateContext(isAnomaly: boolean, anomalyScore: number) {
+  const anomalyPenalty = isAnomaly ? Math.round((anomalyScore - 0.5) * 30) : 0;
+
+  return {
+    battery_level: clamp(20 + Math.floor(Math.random() * 80) - anomalyPenalty, 20, 100),
+    signal_strength: clamp(-90 + Math.floor(Math.random() * 60) - anomalyPenalty, -90, -30),
+  };
+}
+
+function generateQuality(
+  isAnomaly: boolean,
+  anomalyScore: number,
+  profile: SimulationProfile
+) {
+  const confidenceFloor = clamp(
+    0.9 - (profile.volatility - 1) * 0.05 - (isAnomaly ? 0.03 : 0),
+    0.85,
+    0.97
+  );
+
+  return {
+    is_valid: Math.random() > (isAnomaly ? 0.04 : 0.02),
+    confidence_score: round(randomBetween(confidenceFloor, 1)),
+    validation_flags: [] as string[],
+    is_anomaly: isAnomaly,
+    anomaly_score: anomalyScore,
+  };
+}
+
+export function generateSimulatedReadings(
+  devices: SimulatedDevice[],
+  timestamp: Date = new Date()
+): Array<Partial<IReadingV2>> {
+  const profile = createSimulationProfile(devices, timestamp);
+
+  return devices.map(device => {
+    const anomalyProbability = calculateAnomalyProbability(device, profile);
+    const { value, unit, isAnomaly, anomalyScore } = generateValueForType(
+      device.type as ReadingType,
+      anomalyProbability,
+      profile.volatility
+    );
+    const rawValue = value + (Math.random() * (isAnomaly ? 1.6 : 1) - (isAnomaly ? 0.8 : 0.5));
+    const calibrationOffset = round(Math.random() * 0.5 - 0.25);
+
+    return {
+      metadata: {
+        device_id: device._id,
+        type: device.type,
+        unit,
+        source: 'simulation' as const,
+      },
+      timestamp,
+      value,
+      quality: generateQuality(isAnomaly, anomalyScore, profile),
+      context: generateContext(isAnomaly, anomalyScore),
+      processing: {
+        raw_value: round(rawValue),
+        calibration_offset: calibrationOffset,
+        ingested_at: new Date(),
+      },
+    };
+  });
+}

--- a/lib/utils/anomaly-chart.ts
+++ b/lib/utils/anomaly-chart.ts
@@ -1,0 +1,74 @@
+import type { AnomalyTrendPoint, EnergyAnalyticsResult } from '../api/v2-client';
+
+const HOUR_IN_MS = 60 * 60 * 1000;
+
+export interface AnomalyChartDataPoint {
+  time: string;
+  normal: number;
+  anomaly: number;
+  timestamp: string;
+}
+
+function parseTimeBucket(value: string) {
+  if (/(Z|[+-]\d{2}:?\d{2})$/.test(value)) return new Date(value);
+  if (value.includes('T')) return new Date(`${value}Z`);
+  return new Date(`${value}T00:00:00Z`);
+}
+
+function toHourBucket(date: Date) {
+  return new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), date.getUTCHours())
+  );
+}
+
+function normalizeBucketKey(value: string) {
+  return toHourBucket(parseTimeBucket(value)).toISOString();
+}
+
+export function buildAnomalyDetectionChartData({
+  endDate,
+  hours,
+  totals,
+  trends,
+}: {
+  endDate: Date;
+  hours: number;
+  totals: Array<Pick<EnergyAnalyticsResult, 'time_bucket' | 'count'>>;
+  trends: Array<Pick<AnomalyTrendPoint, 'time_bucket' | 'count'>>;
+}): AnomalyChartDataPoint[] {
+  const buckets = new Map<string, AnomalyChartDataPoint>();
+  const endBucket = toHourBucket(endDate);
+
+  for (let offset = hours - 1; offset >= 0; offset--) {
+    const bucketDate = new Date(endBucket.getTime() - offset * HOUR_IN_MS);
+    const key = bucketDate.toISOString();
+
+    buckets.set(key, {
+      timestamp: key,
+      time: bucketDate.toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+      }),
+      normal: 0,
+      anomaly: 0,
+    });
+  }
+
+  totals.forEach(total => {
+    const bucket = buckets.get(normalizeBucketKey(total.time_bucket));
+    if (!bucket) return;
+
+    bucket.normal = Math.max(0, Math.round(total.count));
+  });
+
+  trends.forEach(trend => {
+    const bucket = buckets.get(normalizeBucketKey(trend.time_bucket));
+    if (!bucket) return;
+
+    const anomalyCount = Math.max(0, Math.round(trend.count));
+    bucket.anomaly = anomalyCount;
+    bucket.normal = Math.max(0, bucket.normal - anomalyCount);
+  });
+
+  return Array.from(buckets.values());
+}

--- a/scripts/v2/simulate.ts
+++ b/scripts/v2/simulate.ts
@@ -1,220 +1,25 @@
 import dbConnect from '../../lib/db';
 import DeviceV2 from '../../models/v2/DeviceV2';
-import ReadingV2, { type ReadingUnit, type ReadingType } from '../../models/v2/ReadingV2';
-
-// ============================================================================
-// VALUE GENERATORS BY DEVICE TYPE
-// ============================================================================
-
-interface GeneratedReading {
-  value: number;
-  unit: ReadingUnit;
-  isAnomaly: boolean;
-}
-
-/**
- * Generate realistic values for each device type
- */
-function generateValueForType(type: ReadingType): GeneratedReading {
-  // 5% chance of anomaly
-  const isAnomaly = Math.random() < 0.05;
-
-  let value: number;
-  let unit: ReadingUnit;
-
-  switch (type) {
-    case 'temperature':
-      // Normal: 18-28°C, Anomaly: 30-40°C or 5-15°C
-      value = isAnomaly
-        ? Math.random() > 0.5
-          ? 30 + Math.random() * 10
-          : 5 + Math.random() * 10
-        : 18 + Math.random() * 10;
-      unit = 'celsius';
-      break;
-
-    case 'humidity':
-      // Normal: 30-70%, Anomaly: 10-20% or 80-95%
-      value = isAnomaly
-        ? Math.random() > 0.5
-          ? 80 + Math.random() * 15
-          : 10 + Math.random() * 10
-        : 30 + Math.random() * 40;
-      unit = 'percent';
-      break;
-
-    case 'occupancy':
-      // Normal: 0-50 people, Anomaly: 80-150
-      value = isAnomaly ? 80 + Math.floor(Math.random() * 70) : Math.floor(Math.random() * 50);
-      unit = 'count';
-      break;
-
-    case 'power':
-      // Normal: 100-5000W, Anomaly: 8000-15000W
-      value = isAnomaly ? 8000 + Math.random() * 7000 : 100 + Math.random() * 4900;
-      unit = 'watts';
-      break;
-
-    case 'co2':
-      // Normal: 400-1000ppm, Anomaly: 1500-3000ppm
-      value = isAnomaly ? 1500 + Math.random() * 1500 : 400 + Math.random() * 600;
-      unit = 'ppm';
-      break;
-
-    case 'pressure':
-      // Normal: 1000-1030 hPa, Anomaly: 950-980 or 1040-1060
-      value = isAnomaly
-        ? Math.random() > 0.5
-          ? 1040 + Math.random() * 20
-          : 950 + Math.random() * 30
-        : 1000 + Math.random() * 30;
-      unit = 'hpa';
-      break;
-
-    case 'light':
-      // Normal: 100-1000 lux, Anomaly: 0-50 or 1500-3000
-      value = isAnomaly
-        ? Math.random() > 0.5
-          ? 1500 + Math.random() * 1500
-          : Math.random() * 50
-        : 100 + Math.random() * 900;
-      unit = 'lux';
-      break;
-
-    case 'motion':
-      // Binary: 0 or 1 (70% no motion, 30% motion)
-      value = Math.random() > 0.7 ? 1 : 0;
-      unit = 'boolean';
-      break;
-
-    case 'air_quality':
-      // Normal: 0-100 AQI (ppm), Anomaly: 150-300
-      value = isAnomaly ? 150 + Math.random() * 150 : Math.random() * 100;
-      unit = 'ppm';
-      break;
-
-    case 'water_flow':
-      // Normal: 0.5-50 L/min, Anomaly: 80-150 or 0
-      value = isAnomaly
-        ? Math.random() > 0.3
-          ? 80 + Math.random() * 70
-          : 0
-        : 0.5 + Math.random() * 49.5;
-      unit = 'liters_per_minute';
-      break;
-
-    case 'gas':
-      // Normal: 0-100ppm, Anomaly: 200-500ppm
-      value = isAnomaly ? 200 + Math.random() * 300 : Math.random() * 100;
-      unit = 'ppm';
-      break;
-
-    case 'vibration':
-      // Normal: 0-2, Anomaly: 5-10
-      value = isAnomaly ? 5 + Math.random() * 5 : Math.random() * 2;
-      unit = 'raw';
-      break;
-
-    case 'voltage':
-      // Normal: 110-240V, Anomaly: 90-105 or 250-280
-      value = isAnomaly
-        ? Math.random() > 0.5
-          ? 250 + Math.random() * 30
-          : 90 + Math.random() * 15
-        : 110 + Math.random() * 130;
-      unit = 'volts';
-      break;
-
-    case 'current':
-      // Normal: 0.1-15A, Anomaly: 20-50A
-      value = isAnomaly ? 20 + Math.random() * 30 : 0.1 + Math.random() * 14.9;
-      unit = 'amperes';
-      break;
-
-    case 'energy':
-      // Normal: 0-100 kWh, Anomaly: 150-300 kWh
-      value = isAnomaly ? 150 + Math.random() * 150 : Math.random() * 100;
-      unit = 'kilowatt_hours';
-      break;
-
-    default:
-      value = Math.random() * 100;
-      unit = 'raw';
-  }
-
-  return {
-    value: parseFloat(value.toFixed(2)),
-    unit,
-    isAnomaly,
-  };
-}
-
-/**
- * Generate random context data for a reading
- */
-function generateContext() {
-  return {
-    battery_level: 20 + Math.floor(Math.random() * 80), // 20-100%
-    signal_strength: -90 + Math.floor(Math.random() * 60), // -90 to -30 dBm
-  };
-}
-
-/**
- * Generate quality metrics for a reading
- */
-function generateQuality(isAnomaly: boolean) {
-  const isValid = Math.random() > 0.02; // 2% invalid readings
-  return {
-    is_valid: isValid,
-    confidence_score: parseFloat((0.85 + Math.random() * 0.15).toFixed(2)), // 0.85-1.0
-    validation_flags: [] as string[],
-    is_anomaly: isAnomaly,
-    anomaly_score: isAnomaly
-      ? parseFloat((0.5 + Math.random() * 0.5).toFixed(2)) // 0.5-1.0 for anomalies
-      : parseFloat((Math.random() * 0.3).toFixed(2)), // 0-0.3 for normal
-  };
-}
-
-// ============================================================================
-// MAIN SIMULATION
-// ============================================================================
+import ReadingV2 from '../../models/v2/ReadingV2';
+import {
+  generateSimulatedReadings,
+  type SimulatedDevice,
+} from '../../lib/simulation/readings';
 
 async function generateReadings() {
   try {
     // Fetch all active V2 devices
-    const devices = await DeviceV2.findActive();
-    const readings = [];
     const timestamp = new Date();
-
-    for (const device of devices) {
-      const { value, unit, isAnomaly } = generateValueForType(device.type as ReadingType);
-      const rawValue = value + (Math.random() * 1 - 0.5); // Slight variation for raw value
-      const calibrationOffset = parseFloat((Math.random() * 0.5 - 0.25).toFixed(2));
-
-      readings.push({
-        metadata: {
-          device_id: device._id,
-          type: device.type,
-          unit: unit,
-          source: 'simulation' as const,
-        },
-        timestamp: timestamp,
-        value: value,
-        quality: generateQuality(isAnomaly),
-        context: generateContext(),
-        processing: {
-          raw_value: parseFloat(rawValue.toFixed(2)),
-          calibration_offset: calibrationOffset,
-          ingested_at: new Date(),
-        },
-      });
-    }
+    const devices = await DeviceV2.findActive()
+      .select({ _id: 1, type: 1, location: 1 })
+      .lean<SimulatedDevice[]>();
+    const readings = generateSimulatedReadings(devices, timestamp);
 
     if (readings.length > 0) {
       await ReadingV2.insertMany(readings);
 
       // Count anomalies for logging
-      const anomalyCount = readings.filter(r => r.quality.is_anomaly).length;
+      const anomalyCount = readings.filter(r => r.quality?.is_anomaly === true).length;
       console.log(
         `[${timestamp.toISOString()}] Inserted ${readings.length} readings (${anomalyCount} anomalies)`
       );


### PR DESCRIPTION
## Summary
- make simulated anomalies arrive in more varied bursts and severity bands
- reuse the shared simulation generator in both the cron route and the simulator script
- drive the anomaly chart from hourly totals and anomaly trends instead of evenly flattening normal bars

## Validation
- pnpm build
- pnpm test -- --runTestsByPath __tests__/unit/lib/anomaly-chart.test.ts __tests__/unit/lib/simulationReadings.test.ts __tests__/unit/lib/useAnomalies.test.ts __tests__/unit/lib/useEnergyAnalytics.test.ts __tests__/unit/lib/v2-client-coverage.test.ts __tests__/integration/api/simulate-cron.integration.test.ts