### PR TITLE
feat: Phase 1 — make the project reachable (public read-only demo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1>Infrasight - Real-Time IoT Building Monitoring Dashboard</h1>
 
 <p>
-  <a href="https://infrasight.aseck.dev/">
+  <a href="https://www.infrasight.org/">
     <img src="https://img.shields.io/badge/Live%20Preview-000000?style=for-the-badge&logo=vercel&logoColor=white">
   </a>
 

--- a/__tests__/integration/api/auth.integration.test.ts
+++ b/__tests__/integration/api/auth.integration.test.ts
@@ -466,15 +466,16 @@ describe('Authentication Integration Tests', () => {
     });
 
     describe('GET /api/v2/audit', () => {
-      it('should return 403 when member', async () => {
+      // Audit trails are read-only and carry no secrets, so members — including
+      // read-only demo visitors — are allowed to read them.
+      it('should allow member', async () => {
         mockAuthenticated(testUserId, testEmail, 'org:member');
         const request = createMockGetRequest('/api/v2/audit');
         const response = await getAudit(request);
-        const data = await parseResponse<{ success: boolean; error: { code: string } }>(response);
+        const data = await parseResponse<{ success: boolean }>(response);
 
-        expect(response.status).toBe(403);
-        expect(data.success).toBe(false);
-        expect(data.error.code).toBe('FORBIDDEN');
+        expect(response.status).toBe(200);
+        expect(data.success).toBe(true);
       });
 
       it('should allow admin', async () => {

--- a/__tests__/integration/api/device-history.integration.test.ts
+++ b/__tests__/integration/api/device-history.integration.test.ts
@@ -8,6 +8,11 @@
 import { NextRequest } from 'next/server';
 import DeviceV2 from '@/models/v2/DeviceV2';
 import { createDeviceInput, resetCounters } from '../../setup/factories';
+import {
+  mockAuthAsAdmin,
+  mockAuthAsMember,
+  mockAuthAsUnauthenticated,
+} from '../../setup/auth-helpers';
 
 // Import the route handler
 import { GET } from '@/app/api/v2/devices/[id]/history/route';
@@ -39,6 +44,9 @@ const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 describe('Device History API Integration Tests', () => {
   beforeEach(() => {
     resetCounters();
+    // Restore the default role; helpers below replace the mock implementation, which
+    // would otherwise leak into later tests.
+    mockAuthAsAdmin();
   });
 
   // ==========================================================================
@@ -409,6 +417,33 @@ describe('Device History API Integration Tests', () => {
         expect(response.status).toBe(200);
         const createdEntry = data.data.find(h => ('action' in h ? h.action === 'created' : false));
         expect(createdEntry?.changes).toBeDefined();
+      });
+    });
+
+    describe('Access control', () => {
+      // Audit history is read-only and carries no secrets, so members (including
+      // read-only demo visitors) are allowed to read it.
+      it('should allow a member to read device history', async () => {
+        mockAuthAsMember();
+
+        const deviceData = createDeviceInput({ _id: 'history_device_member' });
+        await DeviceV2.create(deviceData);
+
+        const request = createMockGetRequest('history_device_member');
+        const params = Promise.resolve({ id: 'history_device_member' });
+        const response = await GET(request, { params });
+
+        expect(response.status).toBe(200);
+      });
+
+      it('should reject an unauthenticated request', async () => {
+        mockAuthAsUnauthenticated();
+
+        const request = createMockGetRequest('history_device_anon');
+        const params = Promise.resolve({ id: 'history_device_anon' });
+        const response = await GET(request, { params });
+
+        expect(response.status).toBe(401);
       });
     });
   });

--- a/__tests__/setup/factories.ts
+++ b/__tests__/setup/factories.ts
@@ -29,7 +29,7 @@ import type {
  */
 let deviceCounter = 0;
 let _readingCounter = 0;
-const _readingV2Counter = 0;
+let readingV2Counter = 0;
 
 /**
  * Reset counters (for test isolation)

--- a/__tests__/unit/components/NotFound.test.tsx
+++ b/__tests__/unit/components/NotFound.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import NotFound from '@/app/not-found';
+
+jest.mock('next/link', () => {
+  const Link = ({ href, children, ...rest }: React.ComponentProps<'a'>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  );
+  Link.displayName = 'Link';
+  return Link;
+});
+
+jest.mock('lucide-react', () => ({
+  Compass: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="compass" {...props} />,
+  LayoutDashboard: (props: React.SVGProps<SVGSVGElement>) => (
+    <svg data-testid="dashboard-icon" {...props} />
+  ),
+  Monitor: (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="monitor-icon" {...props} />,
+}));
+
+describe('NotFound', () => {
+  it('should offer a route back into the app', () => {
+    render(<NotFound />);
+
+    const dashboardLink = screen.getByRole('link', { name: /dashboard/i });
+    expect(dashboardLink).toHaveAttribute('href', '/');
+  });
+
+  it('should link to devices so a mistyped device URL has somewhere to go', () => {
+    render(<NotFound />);
+
+    expect(screen.getByRole('link', { name: /devices/i })).toHaveAttribute('href', '/devices');
+  });
+
+  it('should use theme tokens so it renders correctly in dark mode', () => {
+    const { container } = render(<NotFound />);
+    const markup = container.innerHTML;
+
+    // The previous implementation hardcoded bg-gray-100 and text-blue-500, which ignored
+    // the theme entirely and rendered as an unstyled page in dark mode.
+    expect(markup).not.toMatch(/bg-gray-\d/);
+    expect(markup).not.toMatch(/text-blue-\d/);
+    expect(markup).toMatch(/bg-background/);
+  });
+});

--- a/__tests__/unit/lib/admin-action.test.ts
+++ b/__tests__/unit/lib/admin-action.test.ts
@@ -1,0 +1,109 @@
+/**
+ * useAdminAction Hook Tests
+ *
+ * Governs whether an admin-gated control is rendered, and whether it is rendered
+ * disabled so read-only demo visitors can see that the feature exists.
+ */
+
+import { useAuth } from '@clerk/nextjs';
+import { useAdminAction } from '@/lib/auth/rbac-client';
+
+jest.mock('@clerk/nextjs', () => ({
+  useAuth: jest.fn(),
+}));
+
+const mockedUseAuth = useAuth as jest.MockedFunction<typeof useAuth>;
+
+/** Shape the hook reads; the full Clerk return type is much wider. */
+type AuthState = Pick<ReturnType<typeof useAuth>, 'isLoaded' | 'isSignedIn' | 'orgRole' | 'orgSlug'>;
+
+const setAuth = (state: AuthState) =>
+  mockedUseAuth.mockReturnValue(state as ReturnType<typeof useAuth>);
+
+describe('useAdminAction', () => {
+  const originalDemoMode = process.env.NEXT_PUBLIC_DEMO_MODE;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.NEXT_PUBLIC_DEMO_MODE;
+  });
+
+  afterEach(() => {
+    if (originalDemoMode === undefined) delete process.env.NEXT_PUBLIC_DEMO_MODE;
+    else process.env.NEXT_PUBLIC_DEMO_MODE = originalDemoMode;
+  });
+
+  function mockAdmin() {
+    setAuth({
+      isLoaded: true,
+      isSignedIn: true,
+      orgRole: 'org:admin',
+      orgSlug: 'users',
+    });
+  }
+
+  function mockMember() {
+    setAuth({
+      isLoaded: true,
+      isSignedIn: true,
+      orgRole: 'org:member',
+      orgSlug: 'users',
+    });
+  }
+
+  function mockAnonymous() {
+    setAuth({
+      isLoaded: true,
+      isSignedIn: false,
+      orgRole: null,
+      orgSlug: null,
+    });
+  }
+
+  it('should render the control enabled for an admin', () => {
+    mockAdmin();
+
+    const action = useAdminAction();
+
+    expect(action.visible).toBe(true);
+    expect(action.disabled).toBe(false);
+    expect(action.tooltip).toBeUndefined();
+  });
+
+  it('should render the control disabled for an anonymous demo visitor', () => {
+    process.env.NEXT_PUBLIC_DEMO_MODE = 'true';
+    mockAnonymous();
+
+    const action = useAdminAction();
+
+    expect(action.visible).toBe(true);
+    expect(action.disabled).toBe(true);
+    expect(action.tooltip).toMatch(/read-only demo/i);
+  });
+
+  it('should hide the control from a signed-in member when not in demo mode', () => {
+    mockMember();
+
+    const action = useAdminAction();
+
+    expect(action.visible).toBe(false);
+  });
+
+  it('should keep the control enabled for a real admin even while demo mode is on', () => {
+    process.env.NEXT_PUBLIC_DEMO_MODE = 'true';
+    mockAdmin();
+
+    const action = useAdminAction();
+
+    expect(action.visible).toBe(true);
+    expect(action.disabled).toBe(false);
+  });
+
+  it('should hide the control from an anonymous visitor when demo mode is off', () => {
+    mockAnonymous();
+
+    const action = useAdminAction();
+
+    expect(action.visible).toBe(false);
+  });
+});

--- a/__tests__/unit/lib/auth.test.ts
+++ b/__tests__/unit/lib/auth.test.ts
@@ -382,4 +382,118 @@ describe('Auth Module', () => {
       expect(handler).not.toHaveBeenCalled();
     });
   });
+
+  // ==========================================================================
+  // Demo mode
+  // ==========================================================================
+
+  describe('demo mode', () => {
+    const originalDemoMode = process.env.DEMO_MODE;
+
+    afterEach(() => {
+      if (originalDemoMode === undefined) delete process.env.DEMO_MODE;
+      else process.env.DEMO_MODE = originalDemoMode;
+    });
+
+    /** Simulate an anonymous visitor: no Clerk session at all. */
+    function mockAnonymousVisitor() {
+      const { auth, currentUser } = require('@clerk/nextjs/server');
+      auth.mockResolvedValue({
+        userId: null,
+        orgId: null,
+        orgSlug: null,
+        orgRole: null,
+      });
+      currentUser.mockResolvedValue(null);
+    }
+
+    it('should grant an anonymous visitor a member-role context when demo mode is on', async () => {
+      process.env.DEMO_MODE = 'true';
+      mockAnonymousVisitor();
+
+      const { getAuthContext } = require('@/lib/auth');
+      const context = await getAuthContext();
+
+      expect(context.userId).toBe('demo');
+      expect(context.orgRole).toBe('org:member');
+    });
+
+    it('should let an anonymous visitor read when demo mode is on', async () => {
+      process.env.DEMO_MODE = 'true';
+      mockAnonymousVisitor();
+
+      const { requireOrgMembership } = require('@/lib/auth');
+      const context = await requireOrgMembership();
+
+      expect(context.orgRole).toBe('org:member');
+    });
+
+    it('should block an anonymous visitor from admin actions when demo mode is on', async () => {
+      process.env.DEMO_MODE = 'true';
+      mockAnonymousVisitor();
+
+      const { requireAdmin } = require('@/lib/auth');
+
+      await expect(requireAdmin()).rejects.toThrow('Admin role required');
+    });
+
+    it('should reject an anonymous visitor when demo mode is off', async () => {
+      delete process.env.DEMO_MODE;
+      mockAnonymousVisitor();
+
+      const { getAuthContext } = require('@/lib/auth');
+
+      await expect(getAuthContext()).rejects.toThrow('Authentication required');
+    });
+
+    describe('isDemoReadableMethod()', () => {
+      it('should allow GET so visitors can browse pages and read APIs', () => {
+        const { isDemoReadableMethod } = require('@/lib/auth');
+
+        expect(isDemoReadableMethod('GET')).toBe(true);
+        expect(isDemoReadableMethod('HEAD')).toBe(true);
+      });
+
+      it('should refuse every mutating method', () => {
+        const { isDemoReadableMethod } = require('@/lib/auth');
+
+        for (const method of ['POST', 'PATCH', 'PUT', 'DELETE']) {
+          expect(isDemoReadableMethod(method)).toBe(false);
+        }
+      });
+
+      it('should refuse unknown methods rather than defaulting open', () => {
+        const { isDemoReadableMethod } = require('@/lib/auth');
+
+        expect(isDemoReadableMethod('TRACE')).toBe(false);
+        expect(isDemoReadableMethod('')).toBe(false);
+      });
+    });
+
+    it('should not downgrade a real signed-in admin while demo mode is on', async () => {
+      process.env.DEMO_MODE = 'true';
+
+      const { auth, currentUser } = require('@clerk/nextjs/server');
+      auth.mockResolvedValue({
+        userId: 'user_admin',
+        orgId: 'org_123',
+        orgSlug: 'users',
+        orgRole: 'org:admin',
+      });
+      currentUser.mockResolvedValue({
+        id: 'user_admin',
+        fullName: 'Admin User',
+        firstName: 'Admin',
+        lastName: 'User',
+        primaryEmailAddressId: 'email_admin',
+        emailAddresses: [{ id: 'email_admin', emailAddress: 'admin@example.com' }],
+      });
+
+      const { requireAdmin } = require('@/lib/auth');
+      const context = await requireAdmin();
+
+      expect(context.userId).toBe('user_admin');
+      expect(context.orgRole).toBe('org:admin');
+    });
+  });
 });

--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -7,12 +7,12 @@ import GenerateReportModal from '@/components/GenerateReportModal';
 import { Select } from '@/components/ui/select';
 import { BarChart3, FileText } from 'lucide-react';
 import { useMetadata } from '@/lib/query/hooks';
-import { useRbac } from '@/lib/auth/rbac-client';
+import { useAdminAction } from '@/lib/auth/rbac-client';
 
 export default function AnalyticsPage() {
   const [selectedFloor, setSelectedFloor] = useState<number | 'all'>('all');
   const [reportModalOpen, setReportModalOpen] = useState(false);
-  const { isAdmin } = useRbac();
+  const reportAction = useAdminAction();
 
   // Fetch metadata with React Query
   const { data: metadata } = useMetadata();
@@ -45,10 +45,12 @@ export default function AnalyticsPage() {
           {/* Actions */}
           <div className="flex items-center gap-3">
             {/* Generate Report button (admin only) */}
-            {isAdmin && (
+            {reportAction.visible && (
               <button
                 onClick={() => setReportModalOpen(true)}
-                className="flex gap-2 px-4 py-2 bg-cyan-500 hover:bg-cyan-600 text-white rounded-lg text-sm font-medium transition-colors"
+                disabled={reportAction.disabled}
+                title={reportAction.tooltip}
+                className="flex gap-2 px-4 py-2 bg-cyan-500 hover:bg-cyan-600 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-cyan-500"
               >
                 <FileText className="h-4 w-4" />
                 Generate Report

--- a/app/api/v2/audit/route.ts
+++ b/app/api/v2/audit/route.ts
@@ -13,7 +13,7 @@ import { getOffsetPaginationParams, calculateOffsetPagination } from '@/lib/api/
 import { z } from 'zod';
 import { validateQuery } from '@/lib/validations/validator';
 import { paginationSchema, dateRangeSchema } from '@/lib/validations/common.validation';
-import { requireAdmin } from '@/lib/auth';
+import { requireOrgMembership } from '@/lib/auth';
 
 // ============================================================================
 // Validation Schema
@@ -66,7 +66,9 @@ interface AuditEntry {
 
 export async function GET(request: NextRequest) {
   return withErrorHandler(async () => {
-    await requireAdmin();
+    // Audit trails are read-only and carry no secrets, so members (including read-only
+    // demo visitors) may read them.
+    await requireOrgMembership();
     await dbConnect();
 
     const searchParams = request.nextUrl.searchParams;

--- a/app/api/v2/devices/[id]/history/route.ts
+++ b/app/api/v2/devices/[id]/history/route.ts
@@ -16,7 +16,7 @@ import { validateInput, validateQuery } from '@/lib/validations/validator';
 import { withErrorHandler, ApiError, ErrorCodes } from '@/lib/errors';
 import { jsonPaginated } from '@/lib/api/response';
 import { getOffsetPaginationParams, calculateOffsetPagination } from '@/lib/api/pagination';
-import { requireAdmin } from '@/lib/auth';
+import { requireOrgMembership } from '@/lib/auth';
 
 // ============================================================================
 // History Entry Type
@@ -35,7 +35,9 @@ interface HistoryEntry {
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   return withErrorHandler(async () => {
-    await requireAdmin();
+    // Audit history is read-only and carries no secrets, so members (including read-only
+    // demo visitors) may read it.
+    await requireOrgMembership();
     await dbConnect();
 
     const { id } = await params;

--- a/app/devices/page.tsx
+++ b/app/devices/page.tsx
@@ -22,7 +22,7 @@ import { toast } from 'react-toastify';
 import { useDevicesList } from '@/lib/query/hooks';
 import { queryKeys } from '@/lib/query/queryClient';
 import { v2Api } from '@/lib/api/v2-client';
-import { useRbac } from '@/lib/auth/rbac-client';
+import { useAdminAction, useRbac } from '@/lib/auth/rbac-client';
 
 import {
   DeviceStatusCards,
@@ -58,6 +58,7 @@ export default function DevicesPage() {
   const [deviceToDelete, setDeviceToDelete] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const { isAdmin } = useRbac();
+  const createDeviceAction = useAdminAction();
 
   // Fetch all devices with React Query (cached, shared across components)
   const { data: devices = [], isLoading, error: fetchError } = useDevicesList();
@@ -270,10 +271,12 @@ export default function DevicesPage() {
               Manage connected IoT endpoints across all zones.
             </p>
           </div>
-          {isAdmin && (
+          {createDeviceAction.visible && (
             <Button
               className='w-full sm:w-auto bg-blue-600 hover:bg-blue-700 text-white'
               onClick={() => setCreateModalOpen(true)}
+              disabled={createDeviceAction.disabled}
+              title={createDeviceAction.tooltip}
             >
               <Plus className='h-4 w-4 mr-2' />
               Add Device

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import './globals.css';
 import { ClerkThemeProvider } from '@/components/clerk-theme-provider';
 import { ThemeProvider } from '@/components/theme-provider';
 import TopNav from '@/components/TopNav';
+import DemoBanner from '@/components/DemoBanner';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { queryClient } from '@/lib/query/queryClient';
@@ -46,6 +47,7 @@ export default function RootLayout({
           >
             <ClerkThemeProvider>
               <PusherProvider>
+                <DemoBanner />
                 <TopNav />
                 <main className="min-h-screen">{children}</main>
                 <ToastContainer

--- a/app/maintenance/page.tsx
+++ b/app/maintenance/page.tsx
@@ -9,7 +9,7 @@ import ScheduleServiceModal from '@/components/ScheduleServiceModal';
 import ScheduleList from '@/components/ScheduleList';
 import DeviceDetailModal from '@/components/DeviceDetailModal';
 import { useMaintenanceForecast, useDevicesList } from '@/lib/query/hooks';
-import { useRbac } from '@/lib/auth/rbac-client';
+import { useAdminAction } from '@/lib/auth/rbac-client';
 
 // ============================================================================
 // CONSTANTS
@@ -25,7 +25,7 @@ const CALIBRATION_THRESHOLD_DAYS = 90;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 export default function MaintenancePage() {
-  const { isAdmin } = useRbac();
+  const scheduleAction = useAdminAction();
   const [isScheduleModalOpen, setIsScheduleModalOpen] = useState(false);
   const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
 
@@ -162,10 +162,12 @@ export default function MaintenancePage() {
               Track device maintenance schedules, health status, and upcoming service needs.
             </p>
           </div>
-          {isAdmin && (
+          {scheduleAction.visible && (
             <Button
               className="w-full sm:w-auto bg-blue-600 hover:bg-blue-700 text-white"
               onClick={() => setIsScheduleModalOpen(true)}
+              disabled={scheduleAction.disabled}
+              title={scheduleAction.tooltip}
             >
               <Plus className="h-4 w-4 mr-2" />
               Schedule Service

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,13 +1,36 @@
 import Link from 'next/link';
+import { Compass, LayoutDashboard, Monitor } from 'lucide-react';
 
 export default function NotFound() {
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100">
-      <h2 className="text-2xl font-bold mb-4">Not Found</h2>
-      <p className="mb-4">Could not find requested resource</p>
-      <Link href="/" className="text-blue-500 hover:underline">
-        Return Home
-      </Link>
+    <div className="flex flex-col items-center justify-center min-h-screen bg-background px-4 text-center">
+      <div className="flex h-14 w-14 items-center justify-center rounded-full bg-muted mb-6">
+        <Compass className="h-7 w-7 text-muted-foreground" aria-hidden="true" />
+      </div>
+
+      <p className="text-sm font-medium text-muted-foreground mb-2">404</p>
+      <h1 className="text-2xl font-bold text-foreground mb-2">This page does not exist</h1>
+      <p className="text-muted-foreground max-w-md mb-8">
+        The page you are looking for may have been moved, or the device you are after may have
+        been removed.
+      </p>
+
+      <div className="flex flex-col sm:flex-row items-center gap-3">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium transition-colors hover:bg-primary/90"
+        >
+          <LayoutDashboard className="h-4 w-4" aria-hidden="true" />
+          Back to dashboard
+        </Link>
+        <Link
+          href="/devices"
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-border text-foreground text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+        >
+          <Monitor className="h-4 w-4" aria-hidden="true" />
+          Browse devices
+        </Link>
+      </div>
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,12 +13,12 @@ import { useHealthAnalytics, useMaintenanceForecast, useAnomalies } from '@/lib/
 import { AlertTriangle, FileText, Gauge, Monitor, Zap } from 'lucide-react';
 import { useState } from 'react';
 import { useUser } from '@clerk/nextjs';
-import { useRbac } from '@/lib/auth/rbac-client';
+import { useAdminAction } from '@/lib/auth/rbac-client';
 
 export default function Home() {
   // User info from Clerk
   const { user } = useUser();
-  const { isAdmin } = useRbac();
+  const reportAction = useAdminAction();
 
   // Data fetching with React Query (automatic caching, deduplication)
   const { data: health, isLoading } = useHealthAnalytics();
@@ -86,10 +86,12 @@ export default function Home() {
           {/* Actions */}
           <div className="flex items-center justify-end gap-3">
             {/* Generate Report button */}
-            {isAdmin && (
+            {reportAction.visible && (
               <button
                 onClick={() => setReportModalOpen(true)}
-                className="flex gap-2 px-4 py-2 bg-cyan-500 hover:bg-cyan-600 text-white rounded-lg text-sm font-medium transition-colors"
+                disabled={reportAction.disabled}
+                title={reportAction.tooltip}
+                className="flex gap-2 px-4 py-2 bg-cyan-500 hover:bg-cyan-600 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-cyan-500"
               >
                 <FileText className="h-4 w-4" />
                 Generate Report

--- a/components/DemoBanner.tsx
+++ b/components/DemoBanner.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState } from 'react';
+import { Github, X } from 'lucide-react';
+import { isDemoModeClient } from '@/lib/auth/rbac-client';
+
+const REPO_URL = 'https://github.com/Amadou-dot/infrasight';
+
+/**
+ * Identifies a deployment as a public read-only demo.
+ *
+ * Renders nothing outside demo mode, so it is safe to mount unconditionally in the
+ * root layout.
+ */
+export default function DemoBanner() {
+  const [dismissed, setDismissed] = useState(false);
+
+  if (!isDemoModeClient() || dismissed) return null;
+
+  return (
+    <div className="w-full border-b border-border bg-muted/50 px-4 py-2 text-sm">
+      <div className="mx-auto flex max-w-7xl items-center justify-between gap-3">
+        <p className="text-muted-foreground">
+          <span className="font-medium text-foreground">Read-only demo.</span>{' '}
+          <span className="hidden sm:inline">
+            Browse freely — actions that change data are disabled.
+          </span>
+        </p>
+
+        <div className="flex items-center gap-1">
+          <a
+            href={REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 font-medium text-foreground transition-colors hover:bg-accent"
+          >
+            <Github className="h-4 w-4" aria-hidden="true" />
+            <span className="hidden sm:inline">Source</span>
+          </a>
+          <button
+            type="button"
+            onClick={() => setDismissed(true)}
+            aria-label="Dismiss demo banner"
+            className="inline-flex items-center rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/example.env
+++ b/example.env
@@ -86,3 +86,11 @@ NEXT_PUBLIC_CLERK_ALLOWED_ORG_SLUGS=users
 # Cron Route Authentication (required)
 # Secret token for /api/v2/cron/simulate endpoint. Configure the same value in your scheduler (for example, n8n).
 SEED_SECRET=
+
+# Public Read-Only Demo (optional)
+# When "true", anonymous visitors may browse the app and read GET APIs without signing in.
+# Writes stay blocked: the synthetic demo context carries the org:member role, and every
+# mutation goes through requireAdmin(). Both values must be set to enable demo mode.
+# Leave unset for a normal private deployment.
+DEMO_MODE=false
+NEXT_PUBLIC_DEMO_MODE=false

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -51,12 +51,60 @@ function assertOrgRole(orgRole: string | null): asserts orgRole is OrgRole {
 }
 
 // ============================================================================
+// DEMO MODE
+// ============================================================================
+
+/**
+ * Whether this deployment is a public read-only demo.
+ *
+ * When enabled, anonymous visitors are granted a synthetic `org:member` context so
+ * they can browse the app without signing up. Writes remain blocked because every
+ * mutation goes through `requireAdmin()`, which rejects the member role.
+ */
+export function isDemoMode(): boolean {
+  return process.env.DEMO_MODE === 'true';
+}
+
+/**
+ * Whether a request method is safe to serve to an anonymous demo visitor.
+ *
+ * Allow-list rather than deny-list: anything not explicitly read-only is refused, so a
+ * method we have not considered fails closed.
+ */
+export function isDemoReadableMethod(method: string): boolean {
+  return method === 'GET' || method === 'HEAD';
+}
+
+const DEMO_USER: AuthenticatedUser = {
+  userId: 'demo',
+  email: null,
+  fullName: 'Demo Visitor',
+  firstName: 'Demo',
+  lastName: 'Visitor',
+};
+
+function createDemoAuthContext(): AuthContext {
+  return {
+    userId: DEMO_USER.userId,
+    user: { ...DEMO_USER },
+    orgId: 'demo',
+    orgSlug: 'demo',
+    orgRole: 'org:member',
+  };
+}
+
+// ============================================================================
 // RBAC HELPERS
 // ============================================================================
 
 export async function getAuthContext(): Promise<AuthContext> {
-  const authResult = await requireAuth();
   const sessionAuth = await auth();
+
+  // Anonymous visitors on a demo deployment get read-only access. A real session
+  // always takes precedence, so signed-in users keep their actual role.
+  if (!sessionAuth.userId && isDemoMode()) return createDemoAuthContext();
+
+  const authResult = await requireAuth();
 
   assertAllowedOrg(sessionAuth.orgSlug ?? null);
   assertOrgRole(sessionAuth.orgRole ?? null);

--- a/lib/auth/rbac-client.tsx
+++ b/lib/auth/rbac-client.tsx
@@ -26,6 +26,40 @@ function getAllowedOrgSlugs(): string[] {
     .map(value => value.toLowerCase());
 }
 
+/** Whether this deployment is a public read-only demo. */
+export function isDemoModeClient(): boolean {
+  return process.env.NEXT_PUBLIC_DEMO_MODE === 'true';
+}
+
+const DEMO_TOOLTIP = 'Admin only · this is a read-only demo';
+
+export interface AdminActionState {
+  /** Whether to render the control at all. */
+  visible: boolean;
+  /** Whether the control should be rendered in a disabled state. */
+  disabled: boolean;
+  /** Explanation to surface on hover, set only when the control is disabled. */
+  tooltip?: string;
+}
+
+/**
+ * Governs an admin-gated control.
+ *
+ * Outside demo mode this behaves like a plain `isAdmin` check. On a demo deployment the
+ * control is rendered disabled instead of hidden, so visitors can see that features like
+ * device creation and report generation exist rather than encountering a UI that appears
+ * to have nothing in it.
+ */
+export function useAdminAction(): AdminActionState {
+  const { isAdmin } = useRbac();
+
+  if (isAdmin) return { visible: true, disabled: false };
+
+  if (isDemoModeClient()) return { visible: true, disabled: true, tooltip: DEMO_TOOLTIP };
+
+  return { visible: false, disabled: true };
+}
+
 export function useRbac(): RbacState {
   const { isLoaded, isSignedIn, orgRole, orgSlug } = useAuth();
   const allowedOrgs = getAllowedOrgSlugs();

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,5 +1,6 @@
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
 import { NextResponse } from 'next/server';
+import { isDemoMode, isDemoReadableMethod } from '@/lib/auth';
 
 const isPublicRoute = createRouteMatcher([
   '/sign-in(.*)',
@@ -15,26 +16,39 @@ const allowedOrgSlugs = (process.env.CLERK_ALLOWED_ORG_SLUGS || 'users')
   .map(value => value.trim().toLowerCase())
   .filter(Boolean);
 
+function jsonError(code: string, message: string, status: number) {
+  return NextResponse.json({ success: false, error: { code, message } }, { status });
+}
+
 export default clerkMiddleware(async (auth, request) => {
   // Skip auth protection in E2E testing mode
   if (isE2ETestingMode) return;
 
-  if (!isPublicRoute(request)) {
-    await auth.protect();
+  if (isPublicRoute(request)) return;
 
-    const session = await auth();
-    const orgSlug = session.orgSlug?.toLowerCase() || null;
-    if (!orgSlug || (allowedOrgSlugs.length > 0 && !allowedOrgSlugs.includes(orgSlug))) {
-      // API routes get a JSON 403 error; page routes get a redirect
-      if (request.nextUrl.pathname.startsWith('/api/')) 
-        return NextResponse.json(
-          { success: false, error: { code: 'FORBIDDEN', message: 'Organization membership required' } },
-          { status: 403 }
-        );
-      
-      const url = new URL('/unauthorized', request.url);
-      return NextResponse.redirect(url);
-    }
+  const session = await auth();
+  const isApiRoute = request.nextUrl.pathname.startsWith('/api/');
+
+  // Public read-only demo: anonymous visitors may read. A real session always takes
+  // precedence, so signed-in users still fall through to the org and role checks below.
+  if (!session.userId && isDemoMode() && isDemoReadableMethod(request.method)) return;
+
+  // Signed-out. Send page requests to sign-in rather than letting Clerk rewrite to a 404,
+  // which left visitors with no indication that a sign-in page existed at all.
+  if (!session.userId) {
+    if (isApiRoute) return jsonError('UNAUTHORIZED', 'Authentication required', 401);
+
+    const signInUrl = new URL('/sign-in', request.url);
+    signInUrl.searchParams.set('redirect_url', request.url);
+    return NextResponse.redirect(signInUrl);
+  }
+
+  const orgSlug = session.orgSlug?.toLowerCase() || null;
+  if (!orgSlug || (allowedOrgSlugs.length > 0 && !allowedOrgSlugs.includes(orgSlug))) {
+    // API routes get a JSON 403 error; page routes get a redirect
+    if (isApiRoute) return jsonError('FORBIDDEN', 'Organization membership required', 403);
+
+    return NextResponse.redirect(new URL('/unauthorized', request.url));
   }
 });
 


### PR DESCRIPTION
Implements all six Phase 1 issues: the project is now reachable by a stranger in one click.

Closes #82, closes #83, closes #84, closes #85, closes #86, closes #87.

## The headline problem

Signed-out visitors received a **404 on every protected route**. `auth.protect()` rewrites
rather than redirects when given no `unauthenticatedUrl`, so anyone opening the site saw an
unstyled "Could not find requested resource" page and had no way to discover that a sign-in
page even existed.

## What changed

**Sign-in redirect (#82).** Page requests now 307 to `/sign-in` with the original
destination preserved in `redirect_url`. API requests get a 401 JSON body rather than an
HTML 404.

**Read-only demo mode (#85).** `DEMO_MODE` / `NEXT_PUBLIC_DEMO_MODE` let anonymous
visitors browse the app and read GET APIs with no signup. The synthetic context carries
`org:member`, so writes are blocked by `requireAdmin()` — the guard that already protects
every mutation. Middleware independently refuses non-GET methods, so blocking holds at
both layers. Both env vars default off; an existing deployment behaves exactly as before.

**Audit reads relaxed (#86).** `GET /api/v2/audit` and `GET /api/v2/devices/[id]/history`
move to `requireOrgMembership()`. Both are read-only and carry no secrets, and
`AuditLogViewer` renders inside `DeviceDetailModal` — without this a demo visitor opening
any device would hit a failed panel. `GET /api/v2/metrics` stays admin-only.

**Demo affordances (#87).** `useAdminAction()` renders the four showcase controls — Add
Device, Schedule Service, and both Generate Report buttons — disabled with a tooltip
instead of hidden, so visitors can see the features exist. Destructive controls and the
deleted-devices page stay hidden. `DemoBanner` identifies the deployment and links to the
repo; it returns `null` outside demo mode.

**Styled 404 (#84).** Replaced hardcoded `bg-gray-100` / `text-blue-500` with theme
tokens, so it works in dark mode and matches the app.

**README link (#83).** `infrasight.aseck.dev` returned `DEPLOYMENT_NOT_FOUND`; now points
at `www.infrasight.org`.

## Drive-by fix

`__tests__/setup/factories.ts` — commit 4ece5b4 renamed `let readingV2Counter` to
`const _readingV2Counter` but left two usages on the old name. Under ES module strict mode
the assignment in `resetCounters()` threw a `ReferenceError`, so **every suite calling it in
`beforeEach` was failing** — 20 test files, including all 17 tests in
`device-history.integration.test.ts`. This had to be fixed to verify anything else here.

## Verification

Full suite, typecheck, lint, production build, and a live server in both modes.

```
Test Suites: 78 passed, 78 total
Tests:       2091 passed, 2091 total
```

Runtime behaviour against a running server:

| Request | Demo on | Demo off |
| --- | --- | --- |
| `/`, `/devices`, `/analytics` | 200 | 307 → `/sign-in?redirect_url=…` |
| `GET /api/v2/devices` | 200 | 401 |
| `POST /api/v2/devices` | 401 | 401 |
| `DELETE /api/v2/devices/:id` | 401 | 401 |
| `GET /api/v2/audit` | 200 | 401 |
| `GET /api/v2/metrics` | 403 | 401 |

Typecheck errors went 41 → 39 (the `factories.ts` fix cleared two); no new ones. Lint is
clean on all changed files. `next build` succeeds.

## One deviation from the spec

The issue predicted anonymous `POST /api/v2/devices` would return **403**; it returns
**401**. Middleware rejects the unauthenticated request before it reaches the route's
`requireAdmin()`, and 401 is the more accurate status for a request carrying no
credentials. The route-level 403 path is still covered by unit tests.

## Deploying

Set `DEMO_MODE=true` and `NEXT_PUBLIC_DEMO_MODE=true` in the production environment. Until
both are set, this PR changes only the 404-to-redirect behaviour and the audit relaxation.
