### PR TITLE
fix(seed): refuse to wipe a non-local database

### DIFF
--- a/__tests__/unit/scripts/db-guard.test.ts
+++ b/__tests__/unit/scripts/db-guard.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Destructive Script Guard Tests
+ *
+ * The seed script wipes devices_v2 and readings_v2 unconditionally. Since pnpm seed
+ * loads .env.local, whose MONGODB_URI points at the Atlas cluster serving the public
+ * demo, an accidental run destroys production data. These tests pin the guard that
+ * prevents it.
+ */
+
+import { isLocalDatabase, assertSafeToWipe, describeTarget } from '@/scripts/v2/db-guard';
+
+describe('isLocalDatabase', () => {
+  it('should treat loopback hosts as local', () => {
+    expect(isLocalDatabase('mongodb://localhost:27017/infrasight')).toBe(true);
+    expect(isLocalDatabase('mongodb://127.0.0.1:27017/infrasight')).toBe(true);
+    expect(isLocalDatabase('mongodb://[::1]:27017/infrasight')).toBe(true);
+  });
+
+  it('should treat a hosted cluster as remote', () => {
+    expect(isLocalDatabase('mongodb+srv://nodecluster.k9ngn2m.mongodb.net/infrasight')).toBe(
+      false
+    );
+    expect(isLocalDatabase('mongodb://db.internal.example.com:27017/infrasight')).toBe(false);
+  });
+
+  it('should not be fooled by credentials containing the word localhost', () => {
+    // The host is remote; "localhost" only appears in the password.
+    expect(isLocalDatabase('mongodb://admin:localhost@cluster.mongodb.net/infrasight')).toBe(
+      false
+    );
+  });
+
+  it('should treat an unparseable URI as remote', () => {
+    // Fail closed: if we cannot tell what we are pointed at, refuse to wipe it.
+    expect(isLocalDatabase('not-a-uri')).toBe(false);
+    expect(isLocalDatabase('')).toBe(false);
+  });
+});
+
+describe('assertSafeToWipe', () => {
+  const REMOTE = 'mongodb+srv://user:secret@nodecluster.k9ngn2m.mongodb.net/infrasight';
+  const LOCAL = 'mongodb://localhost:27017/infrasight';
+
+  it('should refuse to wipe a remote database without --force', () => {
+    expect(() => assertSafeToWipe(REMOTE, { force: false })).toThrow(/refusing/i);
+  });
+
+  it('should allow a remote wipe when --force is given', () => {
+    expect(() => assertSafeToWipe(REMOTE, { force: true })).not.toThrow();
+  });
+
+  it('should allow a local wipe without --force', () => {
+    expect(() => assertSafeToWipe(LOCAL, { force: false })).not.toThrow();
+  });
+
+  it('should name the host so the operator can see what they nearly destroyed', () => {
+    expect(() => assertSafeToWipe(REMOTE, { force: false })).toThrow(
+      /nodecluster\.k9ngn2m\.mongodb\.net/
+    );
+  });
+
+  it('should never leak credentials in the error message', () => {
+    let message = '';
+    try {
+      assertSafeToWipe(REMOTE, { force: false });
+    } catch (error) {
+      message = (error as Error).message;
+    }
+
+    expect(message).not.toContain('secret');
+    expect(message).not.toContain('user');
+  });
+});
+
+describe('describeTarget', () => {
+  it('should redact credentials so the target can be logged safely', () => {
+    const described = describeTarget('mongodb+srv://user:secret@cluster.mongodb.net/infrasight');
+
+    expect(described).toContain('cluster.mongodb.net');
+    expect(described).not.toContain('secret');
+  });
+});

--- a/scripts/v2/db-guard.ts
+++ b/scripts/v2/db-guard.ts
@@ -1,0 +1,67 @@
+/**
+ * Guard for destructive database scripts.
+ *
+ * `pnpm seed` loads `.env.local`, whose `MONGODB_URI` points at the hosted cluster
+ * serving the public demo. Without a guard, running the seed script wipes production
+ * with no prompt. These helpers make a destructive run against anything other than a
+ * local database require an explicit `--force`.
+ */
+
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+
+/**
+ * Extract the host from a MongoDB connection string, ignoring any credentials.
+ *
+ * Returns null when the URI cannot be parsed, so callers can fail closed.
+ */
+function getHost(uri: string): string | null {
+  if (!uri) return null;
+
+  try {
+    // Node's URL parser handles arbitrary schemes, including mongodb+srv://. Parsing
+    // rather than string-matching means a password containing "localhost" cannot be
+    // mistaken for a local host.
+    const { hostname } = new URL(uri);
+    return hostname || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether the connection string points at a database on this machine.
+ *
+ * Fails closed: anything unparseable is treated as remote.
+ */
+export function isLocalDatabase(uri: string): boolean {
+  const host = getHost(uri);
+  if (!host) return false;
+
+  return LOCAL_HOSTS.has(host);
+}
+
+/**
+ * A description of the connection target that is safe to print.
+ *
+ * Connection strings embed credentials, so only the host is ever surfaced.
+ */
+export function describeTarget(uri: string): string {
+  return getHost(uri) ?? '<unparseable connection string>';
+}
+
+/**
+ * Throw unless it is safe to destroy the data in the target database.
+ *
+ * @throws when the target is not local and `force` was not explicitly given.
+ */
+export function assertSafeToWipe(uri: string, options: { force: boolean }): void {
+  if (options.force || isLocalDatabase(uri)) return;
+
+  throw new Error(
+    `Refusing to wipe a non-local database.\n\n` +
+      `  Target: ${describeTarget(uri)}\n\n` +
+      `This script deletes every document in devices_v2 and readings_v2. The host above ` +
+      `is not local, so this may be the database serving the live demo.\n\n` +
+      `If you are certain, re-run with --force.`
+  );
+}

--- a/scripts/v2/seed-v2.ts
+++ b/scripts/v2/seed-v2.ts
@@ -12,6 +12,7 @@
 import mongoose from 'mongoose';
 import DeviceV2 from '../../models/v2/DeviceV2';
 import ReadingV2 from '../../models/v2/ReadingV2';
+import { assertSafeToWipe, describeTarget } from './db-guard';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 
@@ -27,8 +28,26 @@ const mongoUri: string = MONGODB_URI;
 // Configuration
 // ============================================================================
 
-const NUM_DEVICES = 500;
-const READINGS_PER_DEVICE = 25;
+/** Read a positive integer from the environment, falling back to a default. */
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    console.error(`❌ ${name} must be a positive integer, got "${raw}"`);
+    process.exit(1);
+  }
+
+  return parsed;
+}
+
+const FORCE = process.argv.includes('--force');
+const NUM_DEVICES = envInt('NUM_DEVICES', 500);
+const READINGS_PER_DEVICE = envInt('READINGS_PER_DEVICE', 25);
+
+/** Spacing between generated readings, matching the one-hour steps used below. */
+const READING_INTERVAL_MS = 60 * 60 * 1000;
 
 // ============================================================================
 // Data Generators
@@ -293,14 +312,24 @@ function generateReading(deviceId: string, type: string, timestamp: Date): unkno
 async function seed(): Promise<void> {
   console.log('🌱 Starting V2 Database Seed\n');
 
+  // Refuse to destroy a non-local database unless explicitly forced. pnpm seed loads
+  // .env.local, which points at the hosted cluster serving the live demo.
+  try {
+    assertSafeToWipe(mongoUri, { force: FORCE });
+  } catch (error) {
+    console.error(`❌ ${(error as Error).message}`);
+    process.exit(1);
+  }
+
   try {
     // Connect to MongoDB
-    console.log('📡 Connecting to MongoDB...');
+    console.log(`📡 Connecting to MongoDB (${describeTarget(mongoUri)})...`);
     await mongoose.connect(mongoUri);
     console.log('✅ Connected to MongoDB\n');
 
-    // Clear existing V2 data (optional - comment out to append)
+    // Clear existing V2 data
     console.log('🧹 Clearing existing V2 data...');
+    if (FORCE) console.log('   ⚠️  --force: wiping a non-local database');
     await DeviceV2.deleteMany({});
     await ReadingV2.deleteMany({});
     console.log('✅ Cleared existing data\n');
@@ -322,9 +351,9 @@ async function seed(): Promise<void> {
       const deviceDoc = device as { _id: string; type: string };
       const readings = [];
 
-      // Generate readings over the past 7 days
+      // Readings step backwards from now, one hour apart
       for (let i = 0; i < READINGS_PER_DEVICE; i++) {
-        const timestamp = new Date(now - i * 60 * 60 * 1000); // 1 hour apart
+        const timestamp = new Date(now - i * READING_INTERVAL_MS);
         readings.push(generateReading(deviceDoc._id, deviceDoc.type, timestamp));
       }
 
@@ -343,7 +372,7 @@ async function seed(): Promise<void> {
     console.log(`  Readings: ${totalReadings}`);
     console.log(`  Readings per device: ${READINGS_PER_DEVICE}`);
     console.log(`  Device types: ${deviceTypes.length}`);
-    console.log(`  Time range: 7 days`);
+    console.log(`  Time range: ${READINGS_PER_DEVICE} hours (1 reading/hour)`);
     console.log('='.repeat(50));
 
     console.log('\n✅ Seed completed successfully!');


### PR DESCRIPTION
## The dangerous one

`scripts/v2/seed-v2.ts` deleted every document in `devices_v2` and `readings_v2`
unconditionally — no confirmation, no environment check, no dry-run:

```typescript
// Clear existing V2 data (optional - comment out to append)
await DeviceV2.deleteMany({});
await ReadingV2.deleteMany({});
```

`pnpm seed` runs with `--env-file=.env.local`, whose `MONGODB_URI` points at the Atlas
cluster serving the live demo. So `pnpm seed` destroyed the public site's data — 500
devices and every reading — with no prompt.

That was survivable while the site was private. Since #85 made it public, it is the kind
of thing that goes wrong at the worst possible moment: someone shares the demo link, and a
re-seed run out of muscle memory empties it.

### The guard

A destructive run now requires the target host to be loopback, or an explicit `--force`.

- **Parses the URI** rather than string-matching, so a password containing `localhost`
  cannot be mistaken for a local host
- **Fails closed** — an unparseable connection string is treated as remote
- **Never prints credentials**; only the host appears in output

Verified against the real connection string:

```
$ pnpm seed
🌱 Starting V2 Database Seed

❌ Refusing to wipe a non-local database.

  Target: nodecluster.k9ngn2m.mongodb.net

This script deletes every document in devices_v2 and readings_v2. The host above
is not local, so this may be the database serving the live demo.

If you are certain, re-run with --force.

$ echo $?
1
```

## Two smaller bugs

**The env vars were dead.** `.env.local` sets `NUM_DEVICES` and `READINGS_PER_DEVICE`, but
lines 30–31 hardcoded both and never read `process.env`. Neither setting had ever done
anything. Both are now read and validated (a non-positive or non-numeric value exits with
a clear message rather than silently producing `NaN` devices).

**The summary lied about coverage.** It printed `Time range: 7 days` while generating
readings one hour apart — at the default of 25, about 25 hours. Roughly a sevenfold
overstatement. Now derived from the actual configured values.

## Verification

```
Test Suites: 79 passed, 79 total
Tests:       2101 passed, 2101 total
```

10 new tests cover the guard, including the credential-leak and fail-closed cases. Lint
clean; typecheck unchanged at 39 pre-existing errors. Behaviour confirmed end to end:
refusal exits 1, invalid env config is rejected, and a loopback URI proceeds without
`--force`.

No application code is touched — this is scripts and tests only.
