### PR TITLE
Lower ReadingV2 TTL to 7 days

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 
 The migration from v1 to v2 is **complete**. All code now uses v2 exclusively:
 
-- **V2 Collections**: `devices_v2`, `readings_v2` (enhanced with audit trails, health metrics, compliance, 90-day TTL), `schedules_v2` (maintenance scheduling)
+- **V2 Collections**: `devices_v2`, `readings_v2` (enhanced with audit trails, health metrics, compliance, 7-day TTL), `schedules_v2` (maintenance scheduling)
 - **V2 API**: All endpoints under `/api/v2/`
 - **V1 Deprecated**: All v1 files moved to `_deprecated` folders and excluded from TypeScript compilation
 
@@ -23,7 +23,7 @@ Readings use MongoDB timeseries with **critical constraints**:
 - `timeField: 'timestamp'`, `metaField: 'metadata'`, `granularity: 'seconds'`
 - `metadata` field is the bucketing key—keep **LOW CARDINALITY** (device_id, type, unit, source only)
 - Cannot modify schema fields after creation without recreating collection
-- TTL: 90 days (`expireAfterSeconds`)
+- TTL: 7 days (`expireAfterSeconds`)
 - **15 Device/Reading Types**: temperature, humidity, occupancy, power, co2, pressure, light, motion, air_quality, water_flow, gas, vibration, voltage, current, energy
 - **35 Reading Units**: Comprehensive unit support (celsius, fahrenheit, kelvin, percent, ppm, watts, volts, lux, etc.)
 
@@ -280,7 +280,7 @@ The v2 API provides 25 comprehensive endpoints organized into 8 categories:
 
 ```
 models/
-  v2/DeviceV2.ts, ReadingV2.ts    # Production models (90-day TTL, audit trails)
+  v2/DeviceV2.ts, ReadingV2.ts    # Production models (7-day TTL, audit trails)
   v2/ScheduleV2.ts                # Maintenance scheduling model (status machine, audit trails)
   v1 (deprecated)/                 # Archived v1 models (excluded from compilation)
 lib/

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 ### V2 Enhancements
 
-- **90-Day Data Retention**: Automatic TTL-based cleanup of historical readings
+- **7-Day Data Retention**: Automatic TTL-based cleanup of historical readings
 - **Comprehensive Audit Trails**: Complete change history for all devices
 - **Device Health Scoring**: Calculated health metrics with predictive indicators
 - **Predictive Maintenance**: Forecasting for maintenance scheduling

--- a/docs/api-v2.md
+++ b/docs/api-v2.md
@@ -1441,7 +1441,7 @@ Rate limit headers:
 
 - Complete API rewrite with Zod validation
 - MongoDB timeseries collections for readings
-- 90-day TTL on readings
+- 7-day TTL on readings
 - Comprehensive audit trails
 - Device health metrics
 - Predictive maintenance analytics

--- a/docs/models-v2.md
+++ b/docs/models-v2.md
@@ -35,7 +35,7 @@ Infrasight V2 uses MongoDB with Mongoose ODM for data persistence. The system co
 | Collection    | Model     | Type       | Purpose                           |
 | ------------- | --------- | ---------- | --------------------------------- |
 | `devices_v2`  | DeviceV2  | Standard   | Device registry with audit trails |
-| `readings_v2` | ReadingV2 | Timeseries | Sensor readings with 90-day TTL   |
+| `readings_v2` | ReadingV2 | Timeseries | Sensor readings with 7-day TTL    |
 
 ### Key Characteristics
 
@@ -43,7 +43,7 @@ Infrasight V2 uses MongoDB with Mongoose ODM for data persistence. The system co
 - **Soft Deletes**: Devices support soft deletion via `audit.deleted_at`
 - **Timeseries Collections**: Readings use MongoDB's native timeseries collection feature
 - **Audit Trails**: Complete change tracking on devices
-- **90-Day TTL**: Readings automatically expire after 90 days
+- **7-Day TTL**: Readings automatically expire after 7 days
 
 ---
 
@@ -336,7 +336,7 @@ DeviceV2Schema.pre('findOneAndUpdate', function () {
     metaField: 'metadata',       // Required: Bucketing key
     granularity: 'seconds'       // Optimization hint
   },
-  expireAfterSeconds: 7776000    // 90-day TTL
+  expireAfterSeconds: 604800     // 7-day TTL
 }
 ```
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -612,7 +612,7 @@ pnpm create-indexes-v2
 
 #### TTL Cleanup (Automatic)
 
-Readings collection has automatic TTL cleanup (90 days). No manual action required.
+Readings collection has automatic TTL cleanup (7 days). No manual action required.
 
 #### Index Rebuild (Monthly)
 

--- a/lib/deprecated/DEPRECATION_NOTICE.md
+++ b/lib/deprecated/DEPRECATION_NOTICE.md
@@ -30,7 +30,7 @@ The migration from v1 to v2 has been completed:
 | `devices` (v1) | Deprecated - read-only archive |
 | `readings` (v1) | Deprecated - will TTL expire (7-day) |
 | `devices_v2` | Active - production |
-| `readings_v2` | Active - production (90-day TTL) |
+| `readings_v2` | Active - production (7-day TTL) |
 
 ## Do Not
 

--- a/models/v2/ReadingV2.ts
+++ b/models/v2/ReadingV2.ts
@@ -287,8 +287,8 @@ const ReadingV2Schema = new Schema<IReadingV2>(
       metaField: 'metadata',
       granularity: 'seconds',
     },
-    // TTL: 90 days (7,776,000 seconds)
-    expireAfterSeconds: 7776000,
+    // TTL: 7 days (604,800 seconds)
+    expireAfterSeconds: 604800,
   }
 );
 
@@ -428,7 +428,7 @@ export interface IReadingV2Model extends Model<IReadingV2> {
 /**
  * ReadingV2 Model
  * Collection: readings_v2 (MongoDB Timeseries)
- * TTL: 90 days
+ * TTL: 7 days
  */
 const ReadingV2: IReadingV2Model =
   (mongoose.models.ReadingV2 as IReadingV2Model) ||


### PR DESCRIPTION
## Summary
- Lower `readings_v2` TTL from 90 days to 7 days (`expireAfterSeconds`: 7776000 → 604800) in `models/v2/ReadingV2.ts`
- Update all documentation references to the TTL (`CLAUDE.md`, `README.md`, `docs/api-v2.md`, `docs/models-v2.md`, `docs/runbook.md`, `lib/deprecated/DEPRECATION_NOTICE.md`)

This supports moving the n8n simulate cron from once-daily to every 2 minutes (per `docs/superpowers/specs/2026-07-30-portfolio-completeness-design.md` §2.3) without the readings collection growing unbounded. `collMod` has already been run against the production collection to apply the new TTL in place.

## Test plan
- [x] `npx tsc --noEmit` — no new errors introduced (pre-existing unrelated test-file errors only)
- [x] Verified no test asserts the old TTL value
- [x] Confirm n8n cron cadence is updated to every 2 minutes to match this retention window