### PR TITLE
feat: Phase 2 — replace fabricated dashboard values with real data

### DIFF
--- a/__tests__/unit/components/DashboardStatCards.test.tsx
+++ b/__tests__/unit/components/DashboardStatCards.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Dashboard Stat Card Tests
+ *
+ * The dashboard used to hardcode its energy total ("4.2 MWh") and all four trend deltas,
+ * so every arrow was fiction and never moved. These tests pin that the energy card is
+ * derived from the API, and that cards with no historical series show no trend at all
+ * rather than an invented one.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Home from '@/app/page';
+
+const mockUseEnergyAnalytics = jest.fn();
+const mockUseHealthAnalytics = jest.fn();
+
+jest.mock('@/lib/query/hooks', () => ({
+  useEnergyAnalytics: (...args: unknown[]) => mockUseEnergyAnalytics(...args),
+  useHealthAnalytics: (...args: unknown[]) => mockUseHealthAnalytics(...args),
+  useMaintenanceForecast: () => ({ data: { summary: { maintenance_overdue: [] } } }),
+  useAnomalies: () => ({ data: [] }),
+}));
+
+jest.mock('@clerk/nextjs', () => ({
+  useUser: () => ({ user: { firstName: 'Sam' } }),
+}));
+
+jest.mock('@/lib/auth/rbac-client', () => ({
+  useAdminAction: () => ({ visible: false, disabled: true }),
+}));
+
+// Child widgets each fetch their own data; they are not what these tests are about.
+jest.mock('@/components/DeviceDetailModal', () => () => null);
+jest.mock('@/components/GenerateReportModal', () => () => null);
+jest.mock('@/components/dashboard', () => {
+  const Actual = jest.requireActual('@/components/dashboard');
+  return {
+    ...Actual,
+    AnomalyDetectionChart: () => null,
+    CriticalIssuesPanel: () => null,
+    MaintenanceWidget: () => null,
+    SystemHealthWidget: () => null,
+  };
+});
+
+/** Locate a stat card by its title so we can assert on that card alone. */
+function statCard(title: string): HTMLElement {
+  const card = screen.getByText(title).closest('div[class*="bg-card"]');
+  if (!card) throw new Error(`No stat card found for "${title}"`);
+  return card as HTMLElement;
+}
+
+function energyResponse(currentTotal: number, percentageChange: number | null) {
+  return {
+    data: {
+      comparison: {
+        summary: {
+          current_total: currentTotal,
+          comparison_total: 0,
+          percentage_change: percentageChange,
+          trend: percentageChange === null ? 'no_data' : 'increase',
+        },
+      },
+    },
+    isLoading: false,
+  };
+}
+
+describe('Dashboard stat cards', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseHealthAnalytics.mockReturnValue({
+      data: {
+        summary: { total_devices: 500, health_score: 87 },
+        alerts: {
+          offline_devices: { count: 3 },
+          error_devices: { count: 1 },
+          low_battery_devices: { count: 2 },
+        },
+      },
+      isLoading: false,
+    });
+    mockUseEnergyAnalytics.mockReturnValue(energyResponse(29723.38, 11.27));
+  });
+
+  it('should show the energy total from the API, formatted', () => {
+    render(<Home />);
+
+    expect(screen.getByText('29.7 MWh')).toBeInTheDocument();
+    expect(screen.queryByText('4.2 MWh')).not.toBeInTheDocument();
+  });
+
+  it('should request a summed energy total with a comparison period', () => {
+    render(<Home />);
+
+    expect(mockUseEnergyAnalytics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'energy',
+        aggregation: 'sum',
+        compare_with: 'previous_period',
+      })
+    );
+  });
+
+  it('should show rising consumption as an increase, coloured as bad news', () => {
+    render(<Home />);
+    const card = statCard('Energy Usage');
+
+    expect(card).toHaveTextContent('+11.3%');
+    expect(card).toHaveTextContent('↗');
+    expect(card.querySelector('.bg-red-500\\/10')).toBeInTheDocument();
+  });
+
+  it('should colour falling consumption as good news', () => {
+    mockUseEnergyAnalytics.mockReturnValue(energyResponse(21000, -8.4));
+
+    render(<Home />);
+    const card = statCard('Energy Usage');
+
+    expect(card).toHaveTextContent('-8.4%');
+    expect(card.querySelector('.bg-green-500\\/10')).toBeInTheDocument();
+  });
+
+  it.each(['Total Devices', 'Active Alerts', 'Efficiency Score'])(
+    'should show no trend on %s, which has no historical series',
+    title => {
+      render(<Home />);
+      const card = statCard(title);
+
+      expect(card.querySelector('.bg-green-500\\/10')).not.toBeInTheDocument();
+      expect(card.querySelector('.bg-red-500\\/10')).not.toBeInTheDocument();
+    }
+  );
+
+  it('should omit the energy trend when the API reports no comparison data', () => {
+    mockUseEnergyAnalytics.mockReturnValue(energyResponse(0, null));
+
+    render(<Home />);
+    const card = statCard('Energy Usage');
+
+    expect(card.querySelector('.bg-green-500\\/10')).not.toBeInTheDocument();
+    expect(card.querySelector('.bg-red-500\\/10')).not.toBeInTheDocument();
+  });
+
+  it('should show a placeholder rather than NaN when energy data is missing', () => {
+    mockUseEnergyAnalytics.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<Home />);
+
+    expect(statCard('Energy Usage')).toHaveTextContent('—');
+  });
+});

--- a/__tests__/unit/components/StatCard.test.tsx
+++ b/__tests__/unit/components/StatCard.test.tsx
@@ -50,6 +50,28 @@ describe('StatCard', () => {
     expect(screen.getByText('-5%')).toBeInTheDocument();
   });
 
+  // Direction and sentiment are independent: energy consumption rising is an increase
+  // (up arrow) but not a good thing (red). Conflating the two made the arrow lie.
+  it('points the arrow up for a rise that is bad news', () => {
+    const { container } = render(
+      <StatCard {...defaultProps} trend={{ value: 11.3, isPositive: false }} />
+    );
+
+    expect(screen.getByText('+11.3%')).toBeInTheDocument();
+    expect(screen.getByText('↗')).toBeInTheDocument();
+    expect(container.querySelector('.bg-red-500\\/10')).toBeInTheDocument();
+  });
+
+  it('points the arrow down for a fall that is good news', () => {
+    const { container } = render(
+      <StatCard {...defaultProps} trend={{ value: -8.4, isPositive: true }} />
+    );
+
+    expect(screen.getByText('-8.4%')).toBeInTheDocument();
+    expect(screen.getByText('↘')).toBeInTheDocument();
+    expect(container.querySelector('.bg-green-500\\/10')).toBeInTheDocument();
+  });
+
   it('calls onClick when clicked', () => {
     const onClick = jest.fn();
     render(<StatCard {...defaultProps} onClick={onClick} />);

--- a/__tests__/unit/lib/format-energy.test.ts
+++ b/__tests__/unit/lib/format-energy.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Energy Formatting Tests
+ *
+ * The dashboard previously hardcoded "4.2 MWh". Readings are summed in kilowatt-hours,
+ * so the raw total needs scaling to a readable unit.
+ */
+
+import { formatEnergy } from '@/lib/utils/format-energy';
+
+describe('formatEnergy', () => {
+  it('should keep small totals in kilowatt-hours', () => {
+    expect(formatEnergy(0)).toBe('0 kWh');
+    expect(formatEnergy(842)).toBe('842 kWh');
+    expect(formatEnergy(999)).toBe('999 kWh');
+  });
+
+  it('should scale to megawatt-hours at a thousand', () => {
+    expect(formatEnergy(1000)).toBe('1.0 MWh');
+    expect(formatEnergy(29723.38)).toBe('29.7 MWh');
+  });
+
+  it('should scale to gigawatt-hours at a million', () => {
+    expect(formatEnergy(1_000_000)).toBe('1.0 GWh');
+    expect(formatEnergy(2_450_000)).toBe('2.5 GWh');
+  });
+
+  it('should round kilowatt-hours to whole numbers', () => {
+    // Fractional kWh is noise at this scale.
+    expect(formatEnergy(842.6)).toBe('843 kWh');
+  });
+
+  it('should handle negative totals rather than producing NaN', () => {
+    expect(formatEnergy(-500)).toBe('-500 kWh');
+    expect(formatEnergy(-29723.38)).toBe('-29.7 MWh');
+  });
+
+  it('should return a placeholder for values that are not finite', () => {
+    // The API can legitimately return no data; the card should show a dash, not "NaN MWh".
+    expect(formatEnergy(Number.NaN)).toBe('—');
+    expect(formatEnergy(Number.POSITIVE_INFINITY)).toBe('—');
+  });
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,11 +9,20 @@ import {
   StatCard,
   SystemHealthWidget,
 } from '@/components/dashboard';
-import { useHealthAnalytics, useMaintenanceForecast, useAnomalies } from '@/lib/query/hooks';
+import {
+  useHealthAnalytics,
+  useMaintenanceForecast,
+  useAnomalies,
+  useEnergyAnalytics,
+} from '@/lib/query/hooks';
 import { AlertTriangle, FileText, Gauge, Monitor, Zap } from 'lucide-react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useUser } from '@clerk/nextjs';
 import { useAdminAction } from '@/lib/auth/rbac-client';
+import { formatEnergy } from '@/lib/utils/format-energy';
+
+/** Window used for the energy total and its period-over-period comparison. */
+const ENERGY_WINDOW_HOURS = 24;
 
 export default function Home() {
   // User info from Clerk
@@ -24,6 +33,22 @@ export default function Home() {
   const { data: health, isLoading } = useHealthAnalytics();
   const { data: forecast } = useMaintenanceForecast({ days_ahead: 7 });
   const { data: _anomalies } = useAnomalies({ limit: 100 });
+
+  // Recomputed only when the window rolls over, so the query key stays stable across
+  // renders instead of refetching on every tick.
+  const energyRange = useMemo(() => {
+    const end = new Date();
+    const start = new Date(end.getTime() - ENERGY_WINDOW_HOURS * 60 * 60 * 1000);
+    return { startDate: start.toISOString(), endDate: end.toISOString() };
+  }, []);
+
+  const { data: energy, isLoading: energyLoading } = useEnergyAnalytics({
+    ...energyRange,
+    type: 'energy',
+    aggregation: 'sum',
+    granularity: 'hour',
+    compare_with: 'previous_period',
+  });
 
   // Modal state
   const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
@@ -39,15 +64,22 @@ export default function Home() {
     (forecast?.summary?.maintenance_overdue?.length ?? 0);
   const healthScore = health?.summary?.health_score ?? 0;
 
-  // Calculate energy usage (mock for now since we don't have real aggregated energy data)
-  // In a real scenario, this would come from an energy analytics endpoint
-  const energyUsage = '4.2 MWh';
+  // Energy consumed over the window, summed from real readings.
+  const energySummary = energy?.comparison?.summary;
+  const energyUsage = energySummary ? formatEnergy(energySummary.current_total) : '—';
 
-  // Calculate trends (mock - would need historical data for real trends)
-  const devicesTrend = { value: 12, isPositive: true };
-  const alertsTrend = { value: 2, isPositive: false };
-  const efficiencyTrend = { value: 1, isPositive: false };
-  const energyTrend = { value: 5, isPositive: false };
+  // Only energy has a historical series to compare against. Device counts, alert counts,
+  // and the health score are all computed from current state with nothing stored to
+  // compare to, so those cards show no trend rather than an invented one.
+  const percentageChange = energySummary?.percentage_change;
+  const energyTrend =
+    typeof percentageChange === 'number' && energySummary?.trend !== 'no_data'
+      ? {
+          value: Number(percentageChange.toFixed(1)),
+          // Consumption rising is bad news; the arrow still follows the real direction.
+          isPositive: percentageChange < 0,
+        }
+      : undefined;
 
   const handleDeviceClick = (deviceId: string) => {
     setSelectedDeviceId(deviceId);
@@ -109,7 +141,6 @@ export default function Home() {
           icon={Monitor}
           iconColor="text-cyan-400"
           iconBgColor="bg-cyan-500/20"
-          trend={devicesTrend}
         />
         <StatCard
           title="Active Alerts"
@@ -117,7 +148,6 @@ export default function Home() {
           icon={AlertTriangle}
           iconColor="text-red-400"
           iconBgColor="bg-red-500/20"
-          trend={alertsTrend}
         />
         <StatCard
           title="Efficiency Score"
@@ -125,11 +155,10 @@ export default function Home() {
           icon={Gauge}
           iconColor="text-green-400"
           iconBgColor="bg-green-500/20"
-          trend={efficiencyTrend}
         />
         <StatCard
           title="Energy Usage"
-          value={energyUsage}
+          value={energyLoading ? '—' : energyUsage}
           icon={Zap}
           iconColor="text-yellow-400"
           iconBgColor="bg-yellow-500/20"

--- a/components/dashboard/StatCard.tsx
+++ b/components/dashboard/StatCard.tsx
@@ -10,7 +10,9 @@ interface StatCardProps {
   iconColor: string;
   iconBgColor: string;
   trend?: {
+    /** Signed percentage change. Its sign determines the arrow direction. */
     value: number;
+    /** Whether the change is good news. Determines colour, independently of direction. */
     isPositive: boolean;
   };
   onClick?: () => void;
@@ -52,9 +54,9 @@ export default function StatCard({
             trend.isPositive ? 'bg-green-500/10 text-green-400' : 'bg-red-500/10 text-red-400'
           )}
         >
-          <span>{trend.isPositive ? '↗' : '↘'}</span>
+          <span>{trend.value >= 0 ? '↗' : '↘'}</span>
           <span>
-            {trend.isPositive ? '+' : ''}
+            {trend.value > 0 ? '+' : ''}
             {trend.value}%
           </span>
         </div>

--- a/lib/api/v2-client.ts
+++ b/lib/api/v2-client.ts
@@ -279,6 +279,8 @@ export interface EnergyAnalyticsQuery {
   include_invalid?: boolean;
   groupBy?: 'device' | 'floor' | 'room' | 'type' | 'department' | 'building';
   group_by?: 'device' | 'floor' | 'room' | 'type' | 'department' | 'building';
+  /** Request a period-over-period comparison; populates `comparison` in the response. */
+  compare_with?: 'previous_period' | 'same_period_last_week' | 'same_period_last_month';
 }
 
 export interface EnergyAnalyticsResult {

--- a/lib/utils/format-energy.ts
+++ b/lib/utils/format-energy.ts
@@ -1,0 +1,18 @@
+/**
+ * Format an energy total for display.
+ *
+ * Readings are summed in kilowatt-hours, which reaches five or six digits across a
+ * building's worth of devices. This scales to the largest unit that keeps the number
+ * readable.
+ */
+export function formatEnergy(kilowattHours: number): string {
+  if (!Number.isFinite(kilowattHours)) return '—';
+
+  const magnitude = Math.abs(kilowattHours);
+
+  if (magnitude >= 1_000_000) return `${(kilowattHours / 1_000_000).toFixed(1)} GWh`;
+  if (magnitude >= 1_000) return `${(kilowattHours / 1_000).toFixed(1)} MWh`;
+
+  // Fractional kilowatt-hours are noise at building scale.
+  return `${Math.round(kilowattHours)} kWh`;
+}


### PR DESCRIPTION
Completes Phase 2. Closes #88, closes #89. (#90 was resolved by raising the n8n interval
to 2 minutes and applying the 7-day TTL.)

## The problem

`app/page.tsx` hardcoded its energy total and every trend delta:

```typescript
const energyUsage = '4.2 MWh';

const devicesTrend    = { value: 12, isPositive: true };
const alertsTrend     = { value: 2,  isPositive: false };
const efficiencyTrend = { value: 1,  isPositive: false };
const energyTrend     = { value: 5,  isPositive: false };
```

Four trend arrows, none of which had ever moved, on the first screen a visitor sees.

## Energy is now real

`/api/v2/analytics/energy` already implemented `compare_with`, and the client already
typed the `comparison` response — the dashboard simply never called it. Wiring it up
needed only `compare_with` added to `EnergyAnalyticsQuery`.

The card now sums real readings over a rolling 24-hour window and takes its trend from the
API's `percentage_change`. Against live production data:

```
current_total    : 37721.26   ->  card renders "37.7 MWh"
percentage_change: 41.21      ->  trend renders "+41.2%"  ↗ red
```

## The other three lose their arrows

Device counts, alert counts, and the health score are all computed from current state, with
no stored history to compare against. Per the design decision in the spec, they show no
trend rather than an invented one — a card with no arrow is honest; one with a frozen arrow
is not.

A device trend **was** considered and rejected on evidence. The list endpoint does support
`date_filter_field=created_at`, but:

```
created in last  7d: 0
created in last 30d: 0
created in last 40d: 18
total:               500
```

The seed script sets `created_at` 30–365 days back, so any recent window renders a
permanently frozen `0%` — no more informative than the fabricated value it replaced.

## StatCard: direction and sentiment were conflated

`isPositive` previously drove both the arrow *and* the colour. Those are independent:
energy consumption rising is an **increase** (up arrow) but **bad news** (red). Under the
old coupling, rising consumption would have drawn a *down* arrow.

Arrow direction now comes from the sign of `value`; colour still comes from `isPositive`.
Both existing StatCard tests pass unchanged.

## Verification

```
Test Suites: 81 passed, 81 total
Tests:       2118 passed, 2118 total
```

Nine new dashboard tests plus two new StatCard cases and six for the energy formatter.

Because the dashboard tests were written after the wiring, I verified they are actually
load-bearing by temporarily reintroducing both original bugs — the hardcoded `'4.2 MWh'`
and a fabricated device trend. Exactly the three tests that should fail did, and the other
six correctly stayed green. Restored afterwards.

Lint clean; typecheck unchanged at 39 pre-existing errors.
