### PR TITLE
feat: Phase 4 — threshold-based alerting subsystem

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -36,6 +36,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      # ts-jest runs transpile-only, so a green test suite proves nothing about
+      # types. Everything this repo encodes as a type-level guarantee — the
+      # Redacted<T> brand that makes skipping demo-mode redaction a compile
+      # error, the AuditIdentity/BroadcastActor brands that make broadcasting an
+      # admin's email a compile error, the AssertNever exhaustiveness aliases in
+      # models/v2/AlertRuleV2.ts — is enforced by tsc and by nothing else. No
+      # continue-on-error: these are gates, not warnings.
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Lint
+        run: npx eslint .
+
       - name: Setup test environment
         run: |
           cp example.env .env.local

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ test-results
 
 # clerk configuration (can include secrets)
 /.clerk/
+.superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,62 @@ channel.bind('new-reading', (data: PusherReading) => {
 - **Data shape**: `PusherReading` has `metadata.device_id`, `value`, `timestamp`
 - **Event names**: No convention yet; common: `'new-reading'`, `'device-status'`
 
+### The Realtime Boundary (channels + authorization)
+
+There are **two** Pusher channels and they are not equivalent. Both names live in
+[lib/pusher-channels.ts](lib/pusher-channels.ts) — a dependency-free module of string constants, on
+purpose: importing them from `lib/alerting/notify.ts` would drag `lib/pusher` (which throws without
+the server-only `PUSHER_SECRET`) into browser code, and importing from `lib/pusher-context.tsx`
+would drag `pusher-js` into a route handler. **Import channel names from `lib/pusher-channels.ts`,
+never re-declare them.**
+
+| Constant | Name | Auth | Carries |
+| --- | --- | --- | --- |
+| `READINGS_CHANNEL` | `InfraSight` | none (public) | Sensor readings, published by `app/api/v2/cron/simulate/route.ts` |
+| `ALERT_CHANNEL` | `private-alerts` | `POST /api/pusher/auth` | Alert envelopes (`publishAlertEvents`, [lib/alerting/notify.ts](lib/alerting/notify.ts)) |
+
+The `private-` prefix on `ALERT_CHANNEL` is load-bearing, not cosmetic: it is what makes pusher-js
+call `channelAuthorization.endpoint` before subscribing. On a public channel anyone holding
+`NEXT_PUBLIC_PUSHER_KEY` — readable in the JS bundle by design — could stream the whole fleet's
+alert feed. Renaming it without the prefix silently removes the authorization step. Readings stay
+public because they were public before alerting existed and the simulate producer depends on it.
+
+**`POST /api/pusher/auth`** ([app/api/pusher/auth/route.ts](app/api/pusher/auth/route.ts)) is the
+authorization endpoint pusher-js calls. Three things about it are easy to break:
+
+- It is **not** in `proxy.ts`'s `isPublicRoute` list and must not be added — the middleware's
+  `/(api|trpc)(.*)` matcher is what turns a signed-out caller away. (The "Public Routes" line under
+  Authentication & RBAC below is still accurate: `/api/v2/cron/simulate` remains the only public
+  API route.)
+- It answers with the **bare** `{ auth: "<key>:<signature>" }` object from
+  `pusherServer.authorizeChannel()`, **not** `jsonSuccess()`. pusher-js parses the body itself, and
+  the `{ success, data, timestamp }` envelope reads as malformed — the subscription then fails
+  silently. This is the one documented exception to the response convention; errors still use the
+  normal envelope.
+- It signs an **allow-list** of channels (`AUTHORIZABLE_CHANNELS`), not any `private-*` name, so it
+  cannot be used as a generic signing oracle. A new private channel must be added to that set
+  deliberately.
+
+Demo mode has no alert stream: the handler rejects a demo caller explicitly, because
+`requireOrgMembership()` alone would succeed for one (`getAuthContext()` hands an anonymous visitor
+a synthetic `org:member` context). That is intended — Pusher envelopes do **not** pass through
+[lib/alerting/redact.ts](lib/alerting/redact.ts), which only covers alert/alert-rule GET responses,
+and `private-alerts` carries rule names, device ids, trigger values and resolver identities.
+
+Alert envelopes all arrive on **one** event name, `alert-event`, tagged in the payload
+(`kind: 'fired' | 'resolved' | 'storm'`), because `PusherContext` binds one callback set to one
+event name. Payloads are bounded twice — more than `ALERT_EVENT_MAX` (20) alerts, or a serialized
+body over `ALERT_EVENT_MAX_BYTES` (8 KB), degrades to a `storm` summary rather than being split or
+running into Pusher's 10 KB per-event cap.
+
+`notify.ts` swallows a Pusher trigger failure by design, so **the socket is never the only path** by
+which a surface refreshes: nothing patches alert rows into the React Query cache, so every mutation
+that can change alerts must also invalidate `queryKeys.alerts.*` (see `lib/query/hooks/useAlerts.ts`,
+and `useUpdateAlertRule` in `lib/query/hooks/useAlertRules.ts` — editing a rule's condition closes
+open episodes server-side). `useAlertsList` and `useOpenAlertCount` additionally carry a 30s
+`refetchInterval` (`REALTIME_FALLBACK_POLL_MS`) that engages **only** while the socket is
+disconnected — a fallback for a dead socket, not a substitute for the invalidations.
+
 ### V2 API Client Pattern
 
 Dashboard uses typed client wrapper ([lib/api/v2-client.ts](lib/api/v2-client.ts)):
@@ -323,6 +379,7 @@ lib/
     v2-client.ts                   # Typed client for v2 endpoints
     response.ts, pagination.ts     # Response helpers and pagination utilities
   pusher.ts                        # Server-side Pusher configuration
+  pusher-channels.ts               # Channel name constants (READINGS_CHANNEL, ALERT_CHANNEL) — no deps
   pusher-context.tsx               # Pusher React context provider (usePusherAlerts, usePusherReadings)
   alerting/                        # Alert rule evaluation, staleness sweep, Pusher notify, demo redaction
     evaluate.ts                    # Breach-aware evaluator, called by both write paths post-commit
@@ -378,6 +435,7 @@ app/
       audit/, metadata/, metrics/  # System endpoints
       cron/simulate/               # Synthetic data generator
     _v1-deprecated/                # Archived v1 routes (ignored by Next.js)
+    pusher/auth/                   # Private-channel authorization (bare Pusher payload, NOT jsonSuccess)
 proxy.ts                           # Clerk middleware for route protection (Next.js 16 renamed middleware.ts to proxy.ts)
 scripts/v2/                        # seed-v2, simulate, test-api, create-indexes, verify-indexes
 components/                        # React components (all use 'use client')
@@ -870,6 +928,7 @@ Both wrappers never throw, so an alerting failure never affects the read/write c
 - Response helpers: [lib/api/response.ts](lib/api/response.ts), [lib/api/pagination.ts](lib/api/pagination.ts)
 - API routes: [app/api/v2/](app/api/v2/)
 - Alerting: [lib/alerting/](lib/alerting/) — rule evaluation (`evaluate.ts`), staleness sweep (`sweep.ts`), Pusher notify (`notify.ts`), rule cache (`rule-cache.ts`), selector matching (`selector.ts`), demo-mode redaction (`redact.ts`)
+- Realtime boundary: [lib/pusher-channels.ts](lib/pusher-channels.ts) (channel names), [app/api/pusher/auth/route.ts](app/api/pusher/auth/route.ts) (`private-alerts` authorization) — see "The Realtime Boundary" above
 
 ### Security & Performance
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 
 The migration from v1 to v2 is **complete**. All code now uses v2 exclusively:
 
-- **V2 Collections**: `devices_v2`, `readings_v2` (enhanced with audit trails, health metrics, compliance, 7-day TTL), `schedules_v2` (maintenance scheduling)
+- **V2 Collections**: `devices_v2`, `readings_v2` (enhanced with audit trails, health metrics, compliance, 7-day TTL), `schedules_v2` (maintenance scheduling), `alert_rules_v2` + `alerts_v2` (threshold-based alerting)
 - **V2 API**: All endpoints under `/api/v2/`
 - **V1 Deprecated**: All v1 files moved to `_deprecated` folders and excluded from TypeScript compilation
 
@@ -182,7 +182,7 @@ const schedules = await v2Api.schedules.list({ status: 'scheduled' });
 const reportBlob = await v2Api.reports.generateDeviceHealth({ scope: 'all' });
 ```
 
-**Client namespaces**: `v2Api.devices`, `v2Api.readings`, `v2Api.analytics`, `v2Api.schedules`, `v2Api.reports`, `v2Api.metadata`, `v2Api.audit`
+**Client namespaces**: `v2Api.devices`, `v2Api.readings`, `v2Api.analytics`, `v2Api.schedules`, `v2Api.reports`, `v2Api.metadata`, `v2Api.audit`, `v2Api.alerts`, `v2Api.alertRules`
 
 Prefer this over raw `fetch()` for type safety.
 
@@ -213,12 +213,22 @@ const { data: anomalies } = useAnomalies({ minScore: 0.7 });
 - `useUpdateSchedule()` - Update schedule mutation
 - `useCompleteSchedule()` - Mark schedule as completed
 - `useCancelSchedule()` - Cancel schedule
+- `useAlertsList(filters)` - List alerts with filtering
+- `useAlertDetail(id, options)` - Single alert detail (optional: include device)
+- `useOpenAlertCount()` - Count of open alerts, for the TopNav badge
+- `useAcknowledgeAlert()` - Acknowledge an alert mutation
+- `useResolveAlert()` - Resolve an alert mutation
+- `useAlertRulesList(filters)` - List alert rules with filtering
+- `useAlertRuleDetail(id)` - Single alert rule detail
+- `useCreateAlertRule()` - Create alert rule mutation
+- `useUpdateAlertRule()` - Update alert rule mutation
+- `useDeleteAlertRule()` - Soft-delete alert rule mutation
 
 Hooks handle caching, refetching, and error states automatically via React Query.
 
 ## V2 API Endpoints Reference
 
-The v2 API provides 25 comprehensive endpoints organized into 8 categories:
+The v2 API provides 33 comprehensive endpoints organized into 9 categories:
 
 ### Device Management (6 endpoints)
 
@@ -251,6 +261,17 @@ The v2 API provides 25 comprehensive endpoints organized into 8 categories:
 - **PATCH /api/v2/schedules/[id]** - Update schedule (reschedule, change status/notes)
 - **DELETE /api/v2/schedules/[id]** - Cancel schedule (sets status to 'cancelled')
 
+### Alerting (8 endpoints)
+
+- **GET /api/v2/alerts** - List/filter alerts with pagination and sorting (never returns the internal `pending` status)
+- **GET /api/v2/alerts/[id]** - Get single alert (optional: include device details)
+- **PATCH /api/v2/alerts/[id]** - Acknowledge or resolve an alert
+- **GET /api/v2/alert-rules** - List alert rules with pagination, filtering
+- **POST /api/v2/alert-rules** - Create an alert rule
+- **GET /api/v2/alert-rules/[id]** - Get single alert rule
+- **PATCH /api/v2/alert-rules/[id]** - Update an alert rule
+- **DELETE /api/v2/alert-rules/[id]** - Soft delete an alert rule
+
 ### Reports (1 endpoint)
 
 - **GET /api/v2/reports/device-health** - Generate aggregate PDF report (all buildings or per-building scope)
@@ -282,6 +303,7 @@ The v2 API provides 25 comprehensive endpoints organized into 8 categories:
 models/
   v2/DeviceV2.ts, ReadingV2.ts    # Production models (7-day TTL, audit trails)
   v2/ScheduleV2.ts                # Maintenance scheduling model (status machine, audit trails)
+  v2/AlertRuleV2.ts, AlertV2.ts    # Threshold alerting models (alert_rules_v2, alerts_v2; 8 indexes total)
   v1 (deprecated)/                 # Archived v1 models (excluded from compilation)
 lib/
   db.ts                            # Global cached connection (prevents hot-reload leak)
@@ -293,7 +315,14 @@ lib/
     v2-client.ts                   # Typed client for v2 endpoints
     response.ts, pagination.ts     # Response helpers and pagination utilities
   pusher.ts                        # Server-side Pusher configuration
-  pusher-context.tsx               # Pusher React context provider
+  pusher-context.tsx               # Pusher React context provider (usePusherAlerts, usePusherReadings)
+  alerting/                        # Alert rule evaluation, staleness sweep, Pusher notify, demo redaction
+    evaluate.ts                    # Breach-aware evaluator, called by both write paths post-commit
+    sweep.ts                       # Staleness sweep (device_inactive / stale auto-resolution)
+    notify.ts                      # Bounded Pusher envelopes (publishAlertEvents)
+    rule-cache.ts                  # 60s rule cache, bucketed by reading type
+    selector.ts                    # Device selector matching + metric accessors
+    redact.ts                      # Demo-mode audit actor redaction (redactAuditForDemo)
   query/                           # React Query integration
     hooks/                         # API hooks (useDevicesList, useSchedulesList, etc.)
     queryClient.ts                 # Query client configuration
@@ -323,15 +352,20 @@ app/
     useDeviceFilterParams.ts       # Device list filter state, synced to the URL
   floor-plan/page.tsx              # Floor plan visualization
   maintenance/page.tsx             # Maintenance dashboard (+ scheduling)
+  alerts/page.tsx                  # Alerts list view
+  alerts/[id]/page.tsx             # Canonical, shareable alert detail page
+  alerts/rules/page.tsx            # Alert rule management page (admin actions gated)
   unauthorized/page.tsx            # Unauthorized org membership page
   sign-in/[[...sign-in]]/page.tsx  # Clerk sign-in page
   sign-up/[[...sign-up]]/page.tsx  # Clerk sign-up page
   api/
-    v2/                            # Production API routes (25 endpoints)
+    v2/                            # Production API routes (33 endpoints)
       devices/                     # Device CRUD + history
       readings/                    # Reading queries + ingest + latest
       analytics/                   # 5 analytics endpoints
       schedules/                   # Maintenance scheduling CRUD
+      alerts/                      # Alert list/get + acknowledge/resolve
+      alert-rules/                 # Alert rule CRUD (soft delete)
       reports/                     # PDF report generation
       audit/, metadata/, metrics/  # System endpoints
       cron/simulate/               # Synthetic data generator
@@ -340,6 +374,7 @@ proxy.ts                           # Clerk middleware for route protection (Next
 scripts/v2/                        # seed-v2, simulate, test-api, create-indexes, verify-indexes
 components/                        # React components (all use 'use client')
   dashboard/                       # Dashboard-specific widgets
+    ActiveAlertsWidget.tsx         # Open-alerts widget (built fresh, not lifted from AnomalyPanel)
     AnomalyDetectionChart.tsx      # Anomaly chart visualization
     CriticalIssuesPanel.tsx        # Critical issues panel
     MaintenanceWidget.tsx          # Maintenance summary widget
@@ -349,7 +384,15 @@ components/                        # React components (all use 'use client')
   devices/DeviceDetailView.tsx     # Shared device detail presentation (modal + page)
   devices/useDeviceDetail.ts       # Shared device detail data loading
   devices/TagInput.tsx             # Tag input component for device metadata
-  AlertsPanel.tsx                  # Anomaly alerts list (analytics page)
+  alerts/AlertDetailView.tsx       # Shared alert detail presentation (page)
+  alerts/AlertList.tsx             # Paginated alert list with filters (/alerts)
+  alerts/AlertRuleList.tsx         # Alert rule management list (/alerts/rules)
+  alerts/AlertSeverityBadge.tsx    # Severity badge (info/warning/critical)
+  alerts/AlertStatusBadge.tsx      # Status badge (firing/acknowledged/resolved)
+  alerts/AlertToaster.tsx          # Real-time toast notifications for fired/resolved alerts
+  alerts/CreateAlertRuleModal.tsx  # Alert rule creation form (admin only)
+  alerts/useAlertFilterParams.ts   # Alert list filter state, synced to the URL
+  AnomalyPanel.tsx                 # Anomaly alerts list (analytics page; renamed from AlertsPanel.tsx)
   AnomalyChart.tsx                 # Anomaly chart component
   AuditLogViewer.tsx               # Audit log viewer
   DeviceDetailModal.tsx            # Device detail modal (wraps DeviceDetailView)
@@ -482,6 +525,13 @@ function MyComponent() {
 | `/api/v2/schedules/:id` | PATCH/DELETE | `requireAdmin()` |
 | `/api/v2/reports/device-health` | GET | `requireAdmin()` |
 | `/api/v2/metadata` | GET | `requireOrgMembership()` |
+| `/api/v2/alerts` | GET | `requireOrgMembership()` |
+| `/api/v2/alerts/:id` | GET | `requireOrgMembership()` |
+| `/api/v2/alerts/:id` | PATCH | `requireAdmin()` |
+| `/api/v2/alert-rules` | GET | `requireOrgMembership()` |
+| `/api/v2/alert-rules` | POST | `requireAdmin()` |
+| `/api/v2/alert-rules/:id` | GET | `requireOrgMembership()` |
+| `/api/v2/alert-rules/:id` | PATCH/DELETE | `requireAdmin()` |
 
 ### Monitoring & Observability
 
@@ -690,6 +740,26 @@ await ScheduleV2.cancel(scheduleId, 'admin@example.com');
 
 **Service Types**: `firmware_update`, `calibration`, `emergency_fix`, `general_maintenance`
 
+**AlertRuleV2 / AlertV2 Methods:**
+
+```typescript
+// Find active (non-deleted) alert rules
+const activeRules = await AlertRuleV2.findActive({ enabled: true });
+
+// Soft delete an alert rule
+await AlertRuleV2.softDelete(ruleId, 'admin@example.com');
+
+// Atomically acknowledge a firing alert (validates status transition)
+await AlertV2.acknowledge(alertId, 'admin@example.com');
+
+// Atomically resolve a firing/acknowledged alert (validates status transition)
+await AlertV2.resolve(alertId, 'admin@example.com', 'manual');
+```
+
+**Alert Status Transitions**: `pending` (internal only, never returned by the API) -> `firing` -> `acknowledged` -> `resolved`. `resolved` is terminal. Invalid transitions throw `AlertTransitionError`.
+
+**Alert evaluation** (`lib/alerting/`) runs after both write paths (`readings/ingest`, `cron/simulate`) commit their inserts, via `safeEvaluateReadings()`/`safeSweepStaleAlerts()` — these never throw, so an alerting failure never affects the read/write contract of either route. Always call the `safe*` wrappers from `@/lib/alerting`, never `evaluateReadings()`/`sweepStaleAlerts()` directly from a route.
+
 ### Debugging Connection Issues
 
 - Check MongoDB connection: `lib/db.ts` has 5s timeout
@@ -720,7 +790,7 @@ await ScheduleV2.cancel(scheduleId, 'admin@example.com');
 
 ### Core Models & Data
 
-- V2 models: [models/v2/DeviceV2.ts](models/v2/DeviceV2.ts), [models/v2/ReadingV2.ts](models/v2/ReadingV2.ts), [models/v2/ScheduleV2.ts](models/v2/ScheduleV2.ts)
+- V2 models: [models/v2/DeviceV2.ts](models/v2/DeviceV2.ts), [models/v2/ReadingV2.ts](models/v2/ReadingV2.ts), [models/v2/ScheduleV2.ts](models/v2/ScheduleV2.ts), [models/v2/AlertRuleV2.ts](models/v2/AlertRuleV2.ts), [models/v2/AlertV2.ts](models/v2/AlertV2.ts)
 - Database connection: [lib/db.ts](lib/db.ts)
 
 ### Validation & Error Handling
@@ -735,6 +805,7 @@ await ScheduleV2.cancel(scheduleId, 'admin@example.com');
 - React Query hooks: [lib/query/hooks/](lib/query/hooks/)
 - Response helpers: [lib/api/response.ts](lib/api/response.ts), [lib/api/pagination.ts](lib/api/pagination.ts)
 - API routes: [app/api/v2/](app/api/v2/)
+- Alerting: [lib/alerting/](lib/alerting/) — rule evaluation (`evaluate.ts`), staleness sweep (`sweep.ts`), Pusher notify (`notify.ts`), rule cache (`rule-cache.ts`), selector matching (`selector.ts`), demo-mode redaction (`redact.ts`)
 
 ### Security & Performance
 
@@ -766,6 +837,7 @@ await ScheduleV2.cancel(scheduleId, 'admin@example.com');
 - Device creation: [components/devices/CreateDeviceModal.tsx](components/devices/CreateDeviceModal.tsx)
 - Schedule management: [components/ScheduleList.tsx](components/ScheduleList.tsx), [components/ScheduleServiceModal.tsx](components/ScheduleServiceModal.tsx)
 - Report generation: [components/GenerateReportModal.tsx](components/GenerateReportModal.tsx)
+- Alert management: [components/alerts/AlertList.tsx](components/alerts/AlertList.tsx), [components/alerts/AlertDetailView.tsx](components/alerts/AlertDetailView.tsx), [components/alerts/CreateAlertRuleModal.tsx](components/alerts/CreateAlertRuleModal.tsx), [components/alerts/AlertToaster.tsx](components/alerts/AlertToaster.tsx)
 
 ### Documentation
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,14 @@ All checked at import time—app fails loudly if missing:
 - `CACHE_ENABLED`, `CACHE_METADATA_TTL`, `CACHE_HEALTH_TTL`: Cache configuration
 - `SEED_SECRET`: Secret token used by your external scheduler (for example, n8n) to authenticate the `/api/v2/cron/simulate` endpoint
 
+**Optional (Alerting):**
+
+- `ALERT_STALE_AFTER_SECONDS`: Seconds of silence after which the cron-path staleness sweep closes an open alert with `resolution: 'stale'` (default `1800` = 30 minutes; see [lib/alerting/sweep.ts](lib/alerting/sweep.ts)). Must be a positive integer — a malformed or non-positive value logs a warning and falls back to the default rather than silently disabling staleness detection. Read **once at module load**, so a change needs a restart.
+
+**Optional (Public read-only demo):**
+
+- `DEMO_MODE`, `NEXT_PUBLIC_DEMO_MODE`: When both are `"true"`, anonymous visitors may browse the app and read GET APIs without signing in. Writes stay blocked (the synthetic demo context carries `org:member`, and every mutation goes through `requireAdmin()`), and alert/alert-rule audit trails are redacted for demo readers by `redactAuditForDemo` ([lib/alerting/redact.ts](lib/alerting/redact.ts)). Leave unset for a normal private deployment.
+
 **Testing:**
 
 - `E2E_TESTING`: Set to `true` to bypass auth for E2E tests
@@ -659,18 +667,50 @@ All schemas are in `lib/validations/v2/` with TypeScript type inference via `z.i
 3. Add method to `v2Api` client in `lib/api/v2-client.ts`
 4. Update types in `types/v2/api.types.ts`
 
-### Adding a New Device Type
+### Adding a New Device / Reading Type
 
 Currently supports **15 device types**: temperature, humidity, occupancy, power, co2, pressure, light, motion, air_quality, water_flow, gas, vibration, voltage, current, energy
 
-To add a new type:
+Device types and reading types are **one list**: a device of type X emits readings of type X, and `metric: 'value'` alert rules select devices by reading type. The list is copied by hand into a dozen places. Some copies fail loudly if you miss them; several **fail silently**, so work through the whole checklist. Verify with `grep -rn "water_flow" --include='*.ts' --include='*.tsx'` before you finish.
 
-1. Update `deviceTypeSchema` in both:
-   - [models/v2/DeviceV2.ts](models/v2/DeviceV2.ts) (enum array)
-   - [lib/validations/v2/device.validation.ts](lib/validations/v2/device.validation.ts) (Zod enum)
-2. Update `ReadingType` in [models/v2/ReadingV2.ts](models/v2/ReadingV2.ts) to match
-3. Add appropriate `ReadingUnit` enum values (currently 35 units supported)
-4. Update unit mapping in `/api/v2/readings/ingest/route.ts` if auto-mapping is needed
+**1. Type and schema definitions — miss one and `tsc` or Mongoose tells you.**
+
+| File | What to change | If missed |
+| ---- | -------------- | --------- |
+| [models/v2/ReadingV2.ts](models/v2/ReadingV2.ts) | `ReadingType` union **and** the `metadata.type` enum array in `MetadataSchema` | Union: `tsc` error. Enum: every insert of that type is rejected at write time |
+| [models/v2/DeviceV2.ts](models/v2/DeviceV2.ts) | `DeviceType` union **and** the `type` enum array in the schema | Same as above, for devices |
+| [models/v2/AlertRuleV2.ts](models/v2/AlertRuleV2.ts) | `READING_TYPES` | **`tsc` error** — the two `AssertNever` aliases beside it exist for exactly this. See "if missed" below for why they were added |
+| [lib/validations/v2/reading.validation.ts](lib/validations/v2/reading.validation.ts) | `readingTypeSchema` (Zod enum) | Ingest 400s the new type |
+| [lib/validations/v2/device.validation.ts](lib/validations/v2/device.validation.ts) | `deviceTypeSchema` (Zod enum) | Device create/update 400s the new type |
+| [types/v2/reading.types.ts](types/v2/reading.types.ts) | `ReadingType` (client-safe copy) | `tsc` error, via the conformance assertions |
+| [types/v2/device.types.ts](types/v2/device.types.ts) | `DeviceType` (client-safe copy) | `tsc` error, via the conformance assertions |
+| [lib/simulation/readings.ts](lib/simulation/readings.ts) | `TYPE_SENSITIVITY` **and** a `case` in `generateReading`'s switch | `tsc` error both times (`Record<ReadingType, …>`; definite assignment on `value`/`unit`) |
+
+`ReadingTypeName` in [types/v2/alert.types.ts](types/v2/alert.types.ts) is now an **alias** of `ReadingType`, not a copy — nothing to change there.
+
+**2. Units.** Add any new `ReadingUnit` values (35 today) to *all three* copies: `models/v2/ReadingV2.ts` (union + schema enum), `lib/validations/v2/reading.validation.ts` (`readingUnitSchema`), `types/v2/reading.types.ts`.
+
+**3. Silent fallbacks — nothing fails, the behaviour is just wrong.**
+
+| File | What to change | If missed |
+| ---- | -------------- | --------- |
+| [app/api/v2/readings/ingest/route.ts](app/api/v2/readings/ingest/route.ts) | `getDefaultUnit`'s unit map | Readings are stored with unit `'raw'` |
+| [scripts/v2/seed-v2.ts](scripts/v2/seed-v2.ts) | `deviceTypes`, `unitsByType`, `generateReading`'s switch | Seeded data never contains the type, and any that does gets unit `'raw'` and a nonsense value range |
+
+**4. UI lists — the type exists but is invisible.**
+
+| File | What to change | If missed |
+| ---- | -------------- | --------- |
+| [app/devices/_components/DeviceFilterModal.tsx](app/devices/_components/DeviceFilterModal.tsx) | `DEVICE_TYPES` | `tsc` error, via the conformance assertions |
+| [components/devices/CreateDeviceModal.tsx](components/devices/CreateDeviceModal.tsx) | `DEVICE_TYPES` options | **Silent** — the type cannot be chosen when creating a device |
+| [components/alerts/CreateAlertRuleModal.tsx](components/alerts/CreateAlertRuleModal.tsx) | `READING_TYPE_OPTIONS` | **Silent** — no alert rule can be scoped to the type from the UI |
+| [components/DeviceInventoryCard.tsx](components/DeviceInventoryCard.tsx) | `getDeviceIcon` / `getIconBgColor` switches | **Silent** — falls through to the generic icon |
+
+**5. Docs.** Update the type lists in [docs/models-v2.md](docs/models-v2.md), [docs/api-v2.md](docs/api-v2.md), and the "15 Device/Reading Types" line near the top of this file.
+
+**6. Re-run the guards.** `npx tsc --noEmit` covers the type-level copies; `pnpm test __tests__/unit/models/AlertRuleV2.test.ts` compares `READING_TYPES` against the Mongoose and Zod enums as sets (`tsc` cannot see inside a `new Schema({ enum: [...] })`).
+
+**Why `READING_TYPES` gets a compile-time guard and the others get a table.** `as const satisfies readonly ReadingType[]` only checks that each element *is* a `ReadingType`; it does not check that every `ReadingType` is present. An omission there used to compile clean, and then: `buildRuleBuckets` ([lib/alerting/rule-cache.ts](lib/alerting/rule-cache.ts)) seeds no bucket for the type, `evaluateReadings` looks it up with `byType.get(type) ?? []` and evaluates against zero rules, and a **fleet-wide rule** — one with no `selector.types` at all, such as the seeded "Low battery" rule — is expanded across that same list, so it stops applying to the new type too. No error, no metric, no log, and every affected rule still reads as Enabled in the UI. The `AssertNever` aliases in `models/v2/AlertRuleV2.ts` turn that into a `tsc` error naming the missing type.
 
 ### Using Model Static Methods
 
@@ -756,9 +796,33 @@ await AlertV2.acknowledge(alertId, 'admin@example.com');
 await AlertV2.resolve(alertId, 'admin@example.com', 'manual');
 ```
 
-**Alert Status Transitions**: `pending` (internal only, never returned by the API) -> `firing` -> `acknowledged` -> `resolved`. `resolved` is terminal. Invalid transitions throw `AlertTransitionError`.
+**Alert Status Transitions**:
 
-**Alert evaluation** (`lib/alerting/`) runs after both write paths (`readings/ingest`, `cron/simulate`) commit their inserts, via `safeEvaluateReadings()`/`safeSweepStaleAlerts()` — these never throw, so an alerting failure never affects the read/write contract of either route. Always call the `safe*` wrappers from `@/lib/alerting`, never `evaluateReadings()`/`sweepStaleAlerts()` directly from a route.
+```
+pending  -> firing            (breach held for for_duration_seconds)
+pending  -> DELETED           (condition cleared, or the rule's condition changed)
+firing   -> acknowledged      (an operator picked it up)
+firing   -> resolved          (legal, and the common path)
+acknowledged -> resolved
+resolved -> (terminal)
+```
+
+`acknowledged` is **not** a required step: `AlertV2.resolve()` matches `status: { $in: ['firing', 'acknowledged'] }`, and the evaluator's own auto-resolve goes straight from `firing`. Acknowledging is an operator convenience, not a gate.
+
+`pending` is internal — it is never returned by the API, raises no notification, and is **deleted rather than resolved** when it stops breaching (`deleteOne`/`deleteMany` guarded on `status: 'pending'`, in `evaluate.ts`, `sweep.ts` and `PATCH /alert-rules/[id]`). An episode that never fired is not history, and deleting it is what keeps the invariant "every visible alert has `fired_at`" true. So `pending` never reaches `resolved`.
+
+`is_open` is a denormalization of `status` (`is_open === (status !== 'resolved')`), enforced at every write path in [models/v2/AlertV2.ts](models/v2/AlertV2.ts) — a document where the two disagree stays in the partial unique dedup index forever and that (rule, device) pair can never fire again. Invalid lifecycle transitions throw `AlertTransitionError`; a status/`is_open` mismatch throws `AlertInvariantError`.
+
+**Where evaluation runs** — the two write paths are **not** symmetric:
+
+| | `POST /api/v2/readings/ingest` | `GET /api/v2/cron/simulate` |
+| --- | --- | --- |
+| `safeEvaluateReadings()` | yes, after the insert commits | yes, after the insert commits |
+| `safeSweepStaleAlerts()` | **no** | yes |
+
+The staleness sweep is one query per cron invocation, not per ingest, and it needs the set of devices that just reported — which only the cron path has. Consequence worth knowing: on an ingest-only deployment, an alert for a device that stops reporting is never closed as stale.
+
+Both wrappers never throw, so an alerting failure never affects the read/write contract of either route. Always call the `safe*` wrappers from `@/lib/alerting`, never `evaluateReadings()`/`sweepStaleAlerts()` directly from a route.
 
 ### Debugging Connection Issues
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 - **Device Health Scoring**: Calculated health metrics with predictive indicators
 - **Predictive Maintenance**: Forecasting for maintenance scheduling
 - **Maintenance Scheduling**: Create, track, and manage maintenance tasks with bulk support and status machine (scheduled/completed/cancelled)
+- **Threshold-Based Alerting**: Configurable alert rules (value/anomaly score/battery level), breach-aware evaluation, real-time Pusher delivery, and a staleness sweep for devices that stop reporting
 - **PDF Report Generation**: On-demand device health reports with per-building or all-buildings scope
 - **Temperature Correlation**: Cross-device temperature analysis
 - **Enhanced Anomaly Detection**: ML-based anomaly scoring and trends
@@ -202,11 +203,13 @@ Open [http://localhost:3000](http://localhost:3000) to view the application.
 ```
 infrasight/
 ├── app/                        # Next.js App Router
-│   ├── api/v2/                 # V2 API routes (25 endpoints)
+│   ├── api/v2/                 # V2 API routes (33 endpoints)
 │   │   ├── devices/            # Device CRUD + history
 │   │   ├── readings/           # Reading queries + ingest + latest
 │   │   ├── analytics/          # Health, energy, anomalies, forecast, correlation
 │   │   ├── schedules/          # Maintenance scheduling CRUD
+│   │   ├── alerts/             # Alert list/get + acknowledge/resolve
+│   │   ├── alert-rules/        # Alert rule CRUD (soft delete)
 │   │   ├── reports/            # PDF report generation
 │   │   ├── audit/              # Cross-device audit trail
 │   │   ├── metadata/           # System metadata
@@ -214,6 +217,7 @@ infrasight/
 │   ├── devices/                # Device list & deleted devices pages
 │   ├── analytics/              # Analytics dashboard
 │   ├── maintenance/            # Maintenance dashboard
+│   ├── alerts/                 # Alerts list, detail, and rule management pages
 │   ├── floor-plan/             # Floor plan visualization
 │   ├── settings/               # User settings
 │   ├── sign-in/                # Clerk sign-in
@@ -223,6 +227,12 @@ infrasight/
 │   ├── devices/
 │   │   ├── CreateDeviceModal.tsx    # Device creation (admin only)
 │   │   └── TagInput.tsx             # Tag input for device metadata
+│   ├── alerts/
+│   │   ├── AlertList.tsx            # Paginated alert list with filters
+│   │   ├── AlertDetailView.tsx      # Shared alert detail presentation
+│   │   ├── AlertRuleList.tsx        # Alert rule management list
+│   │   ├── AlertToaster.tsx         # Real-time toasts for fired/resolved alerts
+│   │   └── CreateAlertRuleModal.tsx # Alert rule creation (admin only)
 │   ├── ScheduleList.tsx             # Paginated schedule list
 │   ├── ScheduleServiceModal.tsx     # Schedule creation (bulk support)
 │   ├── ScheduleStatusBadge.tsx      # Status badge component
@@ -232,24 +242,28 @@ infrasight/
 ├── lib/                        # Utilities
 │   ├── api/                    # API client and response helpers
 │   ├── auth/                   # RBAC utilities (requireAdmin, requireOrgMembership)
-│   ├── cache/                  # Redis caching with invalidation
+│   ├── alerting/                # Alert rule evaluation, staleness sweep, Pusher notify
+│   ├── cache/                   # Redis caching with invalidation
 │   ├── errors/                 # Error handling
 │   ├── middleware/              # Request validation, body size, headers
-│   ├── monitoring/             # Sentry, Prometheus metrics, logging
-│   ├── query/                  # React Query hooks
-│   ├── ratelimit/              # Rate limiting config and middleware
-│   ├── redis/                  # Redis client configuration
-│   ├── validations/v2/         # Zod schemas
-│   └── db.ts                   # Database connection
+│   ├── monitoring/              # Sentry, Prometheus metrics, logging
+│   ├── query/                   # React Query hooks
+│   ├── ratelimit/               # Rate limiting config and middleware
+│   ├── redis/                   # Redis client configuration
+│   ├── validations/v2/          # Zod schemas
+│   └── db.ts                    # Database connection
 ├── models/v2/                  # Mongoose models
 │   ├── DeviceV2.ts             # Device model
 │   ├── ReadingV2.ts            # Reading model (timeseries)
-│   └── ScheduleV2.ts           # Maintenance schedule model
+│   ├── ScheduleV2.ts           # Maintenance schedule model
+│   ├── AlertRuleV2.ts          # Alert rule model (threshold conditions)
+│   └── AlertV2.ts              # Alert episode model (status machine)
 ├── scripts/v2/                 # Database scripts
 │   ├── seed-v2.ts              # Seed data
 │   └── simulate.ts             # Reading simulation
 ├── types/v2/                   # TypeScript types
-│   └── schedule.types.ts       # Schedule types
+│   ├── schedule.types.ts       # Schedule types
+│   └── alert.types.ts          # Alert / alert rule types + Pusher wire types
 ├── proxy.ts                    # Clerk middleware (route protection)
 ├── __tests__/                  # Jest test suites
 │   ├── unit/                   # Unit tests
@@ -299,6 +313,19 @@ infrasight/
 | GET    | `/api/v2/schedules/:id`   | Get schedule details |
 | PATCH  | `/api/v2/schedules/:id`   | Update schedule      |
 | DELETE | `/api/v2/schedules/:id`   | Cancel schedule      |
+
+### Alerting
+
+| Method | Endpoint                  | Description                      |
+| ------ | ------------------------- | --------------------------------- |
+| GET    | `/api/v2/alerts`          | List/filter alerts               |
+| GET    | `/api/v2/alerts/:id`      | Get alert details                 |
+| PATCH  | `/api/v2/alerts/:id`      | Acknowledge or resolve an alert   |
+| GET    | `/api/v2/alert-rules`     | List alert rules                  |
+| POST   | `/api/v2/alert-rules`     | Create an alert rule              |
+| GET    | `/api/v2/alert-rules/:id` | Get alert rule details            |
+| PATCH  | `/api/v2/alert-rules/:id` | Update an alert rule              |
+| DELETE | `/api/v2/alert-rules/:id` | Soft delete an alert rule         |
 
 ### Reports & System
 

--- a/__tests__/integration/api/alert-rules.integration.test.ts
+++ b/__tests__/integration/api/alert-rules.integration.test.ts
@@ -86,6 +86,36 @@ describe('Alert Rules API Integration Tests', () => {
       expect(response.status).toBe(200);
     });
 
+    // Proves sortBy is actually wired to SORT_FIELD_MAP rather than silently
+    // falling back to the default (audit.created_at desc). audit.created_at
+    // order (oldest -> newest) is Charlie, Alpha, Bravo — chosen so neither
+    // the created_at-asc order [Charlie, Alpha, Bravo] nor the created_at-desc
+    // order [Bravo, Alpha, Charlie] coincidentally matches the expected
+    // name-asc order [Alpha, Bravo, Charlie]. A collapsed SORT_FIELD_MAP
+    // would fall back to created_at desc and fail this assertion.
+    it('should sort by name, not silently fall back to created_at', async () => {
+      const t1 = new Date('2026-01-01T08:00:00.000Z');
+      const t2 = new Date('2026-01-01T09:00:00.000Z');
+      const t3 = new Date('2026-01-01T10:00:00.000Z');
+      const auditAt = (created_at: Date) => ({
+        created_at,
+        created_by: 'test@example.com',
+        updated_at: created_at,
+        updated_by: 'test@example.com',
+      });
+
+      await AlertRuleV2.create(createAlertRuleInput({ name: 'Charlie', audit: auditAt(t1) }));
+      await AlertRuleV2.create(createAlertRuleInput({ name: 'Alpha', audit: auditAt(t2) }));
+      await AlertRuleV2.create(createAlertRuleInput({ name: 'Bravo', audit: auditAt(t3) }));
+
+      const response = await listRules(
+        get('/api/v2/alert-rules', { sortBy: 'name', sortDirection: 'asc' })
+      );
+      const body = await parseResponse<{ data: Array<{ name: string }> }>(response);
+
+      expect(body.data.map(r => r.name)).toEqual(['Alpha', 'Bravo', 'Charlie']);
+    });
+
     // __v is Mongoose's internal version key. It is not part of
     // AlertRuleV2Response (types/v2/alert.types.ts) and must never reach a client.
     it('should not expose the internal __v field', async () => {

--- a/__tests__/integration/api/alert-rules.integration.test.ts
+++ b/__tests__/integration/api/alert-rules.integration.test.ts
@@ -3,11 +3,17 @@
  */
 
 import { NextRequest } from 'next/server';
+import type Redis from 'ioredis';
 import { Types } from 'mongoose';
+import { auth, currentUser } from '@clerk/nextjs/server';
 import AlertRuleV2 from '@/models/v2/AlertRuleV2';
-import { createAlertRuleInput, resetCounters } from '../../setup/factories';
+import AlertV2 from '@/models/v2/AlertV2';
+import { createAlertInput, createAlertRuleInput, resetCounters } from '../../setup/factories';
 import { mockAuthAsAdmin, mockAuthAsMember, mockAuthAsUnauthenticated } from '../../setup/auth-helpers';
 import * as cache from '@/lib/cache';
+import { getOrSet } from '@/lib/cache/cache';
+import { alertRulesKey } from '@/lib/cache/keys';
+import * as redisModule from '@/lib/redis/client';
 
 import { GET as listRules, POST } from '@/app/api/v2/alert-rules/route';
 import { GET as getRule, PATCH, DELETE } from '@/app/api/v2/alert-rules/[id]/route';
@@ -126,6 +132,95 @@ describe('Alert Rules API Integration Tests', () => {
 
       expect(body.data).toHaveLength(1);
       expect(body.data[0]).not.toHaveProperty('__v');
+    });
+
+    // `severity` is advertised as sortable (alert-rule.validation.ts) but was
+    // handed straight to Mongo, which sorts the raw string lexically and puts
+    // `critical` FIRST ascending / LAST descending — the exact bug already
+    // fixed on /api/v2/alerts with a $switch rank, never applied here.
+    //
+    // The seeded audit.created_at order (oldest -> newest) is warn, crit, info,
+    // chosen so that none of the wrong answers can pass by coincidence:
+    //   - rank desc (correct):  crit, warn, info
+    //   - lexical desc (bug):   warn, info, crit
+    //   - lexical asc  (bug):   crit, info, warn
+    //   - created_at desc:      info, crit, warn
+    //   - created_at asc:       warn, crit, info
+    async function seedThreeSeverities() {
+      const t1 = new Date('2026-01-01T08:00:00.000Z');
+      const t2 = new Date('2026-01-01T09:00:00.000Z');
+      const t3 = new Date('2026-01-01T10:00:00.000Z');
+      const auditAt = (created_at: Date) => ({
+        created_at,
+        created_by: 'test@example.com',
+        updated_at: created_at,
+        updated_by: 'test@example.com',
+      });
+
+      await AlertRuleV2.create(
+        createAlertRuleInput({ name: 'Warn', severity: 'warning', audit: auditAt(t1) })
+      );
+      await AlertRuleV2.create(
+        createAlertRuleInput({ name: 'Crit', severity: 'critical', audit: auditAt(t2) })
+      );
+      await AlertRuleV2.create(
+        createAlertRuleInput({ name: 'Info', severity: 'info', audit: auditAt(t3) })
+      );
+    }
+
+    it('should sort by severity rank descending, most severe first', async () => {
+      await seedThreeSeverities();
+
+      const response = await listRules(
+        get('/api/v2/alert-rules', { sortBy: 'severity', sortDirection: 'desc' })
+      );
+      const body = await parseResponse<{
+        data: Array<{ _id: string; name: string }>;
+      }>(response);
+
+      expect(body.data.map(r => r.name)).toEqual(['Crit', 'Warn', 'Info']);
+
+      // This sort is the only one that branches to AlertRuleV2.aggregate().
+      // It must serialize identically to the .lean() path every other sort
+      // uses: a bare hex-string _id, and __v projected away.
+      expect(typeof body.data[0]._id).toBe('string');
+      expect(body.data[0]._id).toMatch(/^[a-f0-9]{24}$/);
+      expect(body.data[0]).not.toHaveProperty('__v');
+    });
+
+    // Proves the rank is genuinely ORDERED (info < warning < critical), not
+    // merely "different from lexical": reversing sortDirection must reverse
+    // the whole order, not just move `critical` out of last place.
+    it('should sort by severity rank ascending, least severe first', async () => {
+      await seedThreeSeverities();
+
+      const response = await listRules(
+        get('/api/v2/alert-rules', { sortBy: 'severity', sortDirection: 'asc' })
+      );
+      const body = await parseResponse<{ data: Array<{ name: string }> }>(response);
+
+      expect(body.data.map(r => r.name)).toEqual(['Info', 'Warn', 'Crit']);
+    });
+
+    it('should keep pagination and total correct on the severity-rank branch', async () => {
+      await seedThreeSeverities();
+
+      const response = await listRules(
+        get('/api/v2/alert-rules', {
+          sortBy: 'severity',
+          sortDirection: 'desc',
+          page: '2',
+          limit: '2',
+        })
+      );
+      const body = await parseResponse<{
+        data: Array<{ name: string }>;
+        pagination: { total: number; page: number };
+      }>(response);
+
+      expect(body.data.map(r => r.name)).toEqual(['Info']);
+      expect(body.pagination.total).toBe(3);
+      expect(body.pagination.page).toBe(2);
     });
   });
 
@@ -363,6 +458,181 @@ describe('Alert Rules API Integration Tests', () => {
       const stored = await AlertRuleV2.findById(rule._id).lean();
       expect(stored!.enabled).toBe(true);
     });
+
+    // ========================================================================
+    // CONDITION CHANGES ORPHAN OPEN EPISODES
+    // ========================================================================
+    //
+    // metric/comparison/threshold are SNAPSHOTTED on the alert; last_value and
+    // resolved_value are not. Leave an open episode alone across a condition
+    // edit and the next evaluation auto-resolves it with a value measured
+    // against the NEW metric: switch a temperature rule to battery_level and
+    // the episode closes with resolved_value 87 while describeCondition()
+    // still renders "value above 30" — permanent history claiming a
+    // temperature alert cleared at 87 degrees.
+    describe('open episodes across a condition change', () => {
+      const NEW_CONDITION = {
+        metric: 'battery_level',
+        comparison: 'lt',
+        threshold: 20,
+        selector: {},
+      };
+
+      async function seedRuleWithOpenEpisode(status: 'firing' | 'acknowledged' | 'pending') {
+        const rule = await AlertRuleV2.create(
+          createAlertRuleInput({
+            metric: 'value',
+            comparison: 'gt',
+            threshold: 30,
+            selector: { types: ['temperature'] },
+          })
+        );
+        const alert = await AlertV2.create(
+          createAlertInput({
+            status,
+            rule_id: rule._id,
+            device_id: `device_${status}`,
+            metric: 'value',
+            comparison: 'gt',
+            threshold: 30,
+          })
+        );
+        return { rule, alert };
+      }
+
+      it('should close a firing episode while its own snapshot is still true', async () => {
+        const { rule, alert } = await seedRuleWithOpenEpisode('firing');
+
+        const response = await PATCH(
+          withBody(`/api/v2/alert-rules/${rule._id}`, 'PATCH', NEW_CONDITION),
+          { params: params(String(rule._id)) }
+        );
+        expect(response.status).toBe(200);
+
+        const stored = await AlertV2.findById(alert._id).lean();
+
+        expect(stored!.status).toBe('resolved');
+        expect(stored!.is_open).toBe(false);
+
+        // The snapshot is left exactly as it fired, so the episode still
+        // describes the condition it was actually raised against.
+        expect(stored!.metric).toBe('value');
+        expect(stored!.comparison).toBe('gt');
+        expect(stored!.threshold).toBe(30);
+
+        // Nothing MEASURED this episode closed, so no resolved_value may be
+        // invented — that number is the whole substance of the finding.
+        expect(stored!.resolved_value).toBeUndefined();
+
+        // 'manual' rather than 'auto': an administrator's action closed it.
+        // 'auto' renders as "back within threshold", which would be the same
+        // false history in different words.
+        expect(stored!.audit.resolution).toBe('manual');
+        expect(stored!.audit.resolved_by).toBe('admin@example.com');
+        expect(stored!.audit.resolved_at).toBeTruthy();
+
+        // A human reading the timeline must be able to tell what happened.
+        expect(stored!.audit.note).toContain('value above 30');
+        expect(stored!.audit.note).toContain('battery_level below 20');
+      });
+
+      it('should close an acknowledged episode too', async () => {
+        const { rule, alert } = await seedRuleWithOpenEpisode('acknowledged');
+
+        await PATCH(withBody(`/api/v2/alert-rules/${rule._id}`, 'PATCH', NEW_CONDITION), {
+          params: params(String(rule._id)),
+        });
+
+        const stored = await AlertV2.findById(alert._id).lean();
+        expect(stored!.status).toBe('resolved');
+        expect(stored!.is_open).toBe(false);
+      });
+
+      // `pending` is internal: it is DELETED rather than resolved everywhere
+      // else (evaluate.ts, sweep.ts), and the alerts endpoints document that
+      // every visible alert has `fired_at`. Resolving one here would make an
+      // episode that never fired permanently visible in history.
+      it('should delete a pending episode rather than resolve it', async () => {
+        const { rule, alert } = await seedRuleWithOpenEpisode('pending');
+
+        await PATCH(withBody(`/api/v2/alert-rules/${rule._id}`, 'PATCH', NEW_CONDITION), {
+          params: params(String(rule._id)),
+        });
+
+        expect(await AlertV2.findById(alert._id).lean()).toBeNull();
+      });
+
+      it('should leave resolved history untouched', async () => {
+        const rule = await AlertRuleV2.create(
+          createAlertRuleInput({ metric: 'value', comparison: 'gt', threshold: 30 })
+        );
+        const closed = await AlertV2.create(
+          createAlertInput({
+            status: 'resolved',
+            is_open: false,
+            rule_id: rule._id,
+            device_id: 'device_history',
+          })
+        );
+
+        await PATCH(withBody(`/api/v2/alert-rules/${rule._id}`, 'PATCH', NEW_CONDITION), {
+          params: params(String(rule._id)),
+        });
+
+        const stored = await AlertV2.findById(closed._id).lean();
+        expect(stored!.audit.resolution).toBe('auto');
+        expect(stored!.audit.note).toBeUndefined();
+      });
+
+      it('should not touch open episodes belonging to a different rule', async () => {
+        const { rule } = await seedRuleWithOpenEpisode('firing');
+        const bystander = await AlertV2.create(
+          createAlertInput({ status: 'firing', device_id: 'device_bystander' })
+        );
+
+        await PATCH(withBody(`/api/v2/alert-rules/${rule._id}`, 'PATCH', NEW_CONDITION), {
+          params: params(String(rule._id)),
+        });
+
+        const stored = await AlertV2.findById(bystander._id).lean();
+        expect(stored!.status).toBe('firing');
+        expect(stored!.is_open).toBe(true);
+      });
+
+      it('should leave open episodes alone for a PATCH that does not touch the condition', async () => {
+        const { rule, alert } = await seedRuleWithOpenEpisode('firing');
+
+        await PATCH(withBody(`/api/v2/alert-rules/${rule._id}`, 'PATCH', { enabled: false }), {
+          params: params(String(rule._id)),
+        });
+
+        const stored = await AlertV2.findById(alert._id).lean();
+        expect(stored!.status).toBe('firing');
+        expect(stored!.is_open).toBe(true);
+      });
+
+      // The condition group must be sent whole (Zod enforces it), so a rename
+      // that resends the unchanged values is a perfectly ordinary request.
+      // Closing every open episode for it would be a nasty surprise.
+      it('should leave open episodes alone when the condition group is resent unchanged', async () => {
+        const { rule, alert } = await seedRuleWithOpenEpisode('firing');
+
+        await PATCH(
+          withBody(`/api/v2/alert-rules/${rule._id}`, 'PATCH', {
+            name: 'Renamed but identical',
+            metric: 'value',
+            comparison: 'gt',
+            threshold: 30,
+            selector: { types: ['temperature'] },
+          }),
+          { params: params(String(rule._id)) }
+        );
+
+        const stored = await AlertV2.findById(alert._id).lean();
+        expect(stored!.status).toBe('firing');
+        expect(stored!.is_open).toBe(true);
+      });
+    });
   });
 
   describe('DELETE /api/v2/alert-rules/[id]', () => {
@@ -514,6 +784,275 @@ describe('Alert Rules API Integration Tests', () => {
 
       expect(response.status).toBe(200);
       expect(body.data.audit.created_by).toBe('admin@example.com');
+    });
+
+    // ========================================================================
+    // THE MUTATION RESPONSES
+    // ========================================================================
+    //
+    // POST and PATCH here returned audit.created_by/updated_by unredacted,
+    // unlike their `alerts/[id]` sibling. requireAdmin() keeps a demo caller
+    // out today, so the hole is inert — which is exactly why it needs a test:
+    // nothing else would notice if a future RBAC change let a demo visitor
+    // through. Rather than asserting a wrapper was called, these drive the
+    // ONE input that makes the wrap observable: an admin whose userId is the
+    // demo sentinel — precisely the context such a change would produce.
+    function mockAuthAsDemoAdmin() {
+      (auth as jest.MockedFunction<typeof auth>).mockResolvedValue({
+        userId: 'demo',
+        orgId: 'org_default',
+        orgSlug: 'users',
+        orgRole: 'org:admin',
+      } as ReturnType<typeof auth> extends Promise<infer T> ? T : never);
+
+      (currentUser as jest.MockedFunction<typeof currentUser>).mockResolvedValue({
+        id: 'demo',
+        fullName: 'Admin User',
+        firstName: 'Admin',
+        lastName: 'User',
+        primaryEmailAddressId: 'email_1',
+        emailAddresses: [{ id: 'email_1', emailAddress: 'admin@example.com' }],
+      } as Awaited<ReturnType<typeof currentUser>>);
+    }
+
+    it('should redact the audit trail on the create response', async () => {
+      mockAuthAsDemoAdmin();
+
+      const response = await POST(withBody('/api/v2/alert-rules', 'POST', VALID_BODY));
+      const body = await parseResponse<{
+        data: { audit: { created_by: string; updated_by: string } };
+      }>(response);
+
+      expect(response.status).toBe(201);
+      expect(body.data.audit.created_by).toBe('an administrator');
+      expect(body.data.audit.updated_by).toBe('an administrator');
+      expect(JSON.stringify(body)).not.toContain('@');
+    });
+
+    it('should redact the audit trail on the update response', async () => {
+      const rule = await AlertRuleV2.create(createAlertRuleInput({ audit: auditWithRealEmail() }));
+      mockAuthAsDemoAdmin();
+
+      const response = await PATCH(
+        withBody(`/api/v2/alert-rules/${rule._id}`, 'PATCH', { enabled: false }),
+        { params: params(String(rule._id)) }
+      );
+      const body = await parseResponse<{
+        data: { enabled: boolean; audit: { created_by: string; updated_by: string } };
+      }>(response);
+
+      expect(response.status).toBe(200);
+      expect(body.data.enabled).toBe(false);
+      expect(body.data.audit.created_by).toBe('an administrator');
+      expect(body.data.audit.updated_by).toBe('an administrator');
+      expect(JSON.stringify(body)).not.toContain('@');
+    });
+
+    it('should still return the real actor on a mutation by a genuine admin', async () => {
+      const rule = await AlertRuleV2.create(createAlertRuleInput({ audit: auditWithRealEmail() }));
+
+      const response = await PATCH(
+        withBody(`/api/v2/alert-rules/${rule._id}`, 'PATCH', { enabled: false }),
+        { params: params(String(rule._id)) }
+      );
+      const body = await parseResponse<{ data: { audit: { updated_by: string } } }>(response);
+
+      expect(body.data.audit.updated_by).toBe('admin@example.com');
+    });
+  });
+
+  // ==========================================================================
+  // THE CACHE REPOPULATION RACE
+  // ==========================================================================
+  //
+  // getOrSet populates the cache AFTER awaiting its fetch. A read that missed
+  // just before a rule mutation therefore lands its PRE-mutation value after
+  // invalidateAlertRules() has already run, under a fresh 60s TTL, with no
+  // self-correction short of that TTL — a disabled rule that keeps firing for
+  // up to a minute after an operator switched it off. The interleaving below
+  // is explicit rather than timing-dependent, so it can only pass because the
+  // stale write is a no-op, never because the window happened to be missed.
+  describe('alert rule cache repopulation race', () => {
+    const originalRateLimit = process.env.RATE_LIMIT_ENABLED;
+    let store: Map<string, string>;
+    let fakeRedis: {
+      get: jest.Mock;
+      setex: jest.Mock;
+      del: jest.Mock;
+      incr: jest.Mock;
+      expire: jest.Mock;
+      pipeline: jest.Mock;
+      eval: jest.Mock;
+    };
+
+    beforeEach(() => {
+      // The fake below only implements the cache's command surface; the rate
+      // limiter shares this client and would otherwise call into it too.
+      process.env.RATE_LIMIT_ENABLED = 'false';
+
+      store = new Map();
+
+      // Enough of a Redis to run BOTH halves of the stale-write guard: the
+      // value keys, the per-key epoch counters `del` bumps, and the
+      // compare-and-set `getOrSet` commits through. `eval` implements the CAS
+      // contract the Lua script encodes rather than interpreting Lua; the
+      // script text itself is verified against a real Redis (see the cache
+      // unit tests and the P4 report).
+      const server = {
+        get: jest.fn(async (key: string) => store.get(key) ?? null),
+        setex: jest.fn(async (key: string, _ttl: number, value: string) => {
+          store.set(key, value);
+          return 'OK';
+        }),
+        del: jest.fn(async (...keys: string[]) => {
+          let deleted = 0;
+          for (const key of keys) if (store.delete(key)) deleted += 1;
+          return deleted;
+        }),
+        incr: jest.fn(async (key: string) => {
+          const next = Number(store.get(key) ?? '0') + 1;
+          store.set(key, String(next));
+          return next;
+        }),
+        expire: jest.fn(async (_key: string, _seconds: number) => 1),
+        pipeline: jest.fn(() => {
+          const queued: Array<() => Promise<unknown>> = [];
+          const chain = {
+            incr(key: string) {
+              queued.push(() => server.incr(key));
+              return chain;
+            },
+            expire(key: string, seconds: number) {
+              queued.push(() => server.expire(key, seconds));
+              return chain;
+            },
+            async exec() {
+              for (const op of queued) await op();
+              return [];
+            },
+          };
+          return chain;
+        }),
+        eval: jest.fn(
+          async (
+            _script: string,
+            _numKeys: number,
+            valueKey: string,
+            epochKey: string,
+            _ttl: string,
+            value: string,
+            observedEpoch: string
+          ) => {
+            if ((store.get(epochKey) ?? '') !== observedEpoch) return 0;
+            store.set(valueKey, value);
+            return 1;
+          }
+        ),
+      };
+      fakeRedis = server;
+
+      jest.spyOn(redisModule, 'getRedisClient').mockReturnValue(fakeRedis as unknown as Redis);
+      jest.spyOn(redisModule, 'isRedisAvailable').mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      if (originalRateLimit === undefined) delete process.env.RATE_LIMIT_ENABLED;
+      else process.env.RATE_LIMIT_ENABLED = originalRateLimit;
+    });
+
+    /** Lets the test hold a fetch open across the mutation. */
+    function deferred() {
+      let resolve!: () => void;
+      const promise = new Promise<void>(r => {
+        resolve = r;
+      });
+      return { promise, resolve };
+    }
+
+    it('should drop a cache write whose value predates an invalidation', async () => {
+      const rule = await AlertRuleV2.create(createAlertRuleInput({ name: 'Racing', enabled: true }));
+
+      const fetched = deferred();
+      const release = deferred();
+
+      // 1. A read misses and starts loading the PRE-mutation rule set.
+      const inFlight = getOrSet(
+        alertRulesKey(),
+        async () => {
+          const rules = await AlertRuleV2.find({
+            enabled: true,
+            'audit.deleted_at': { $exists: false },
+          }).lean();
+          fetched.resolve();
+          await release.promise;
+          return rules;
+        },
+        { ttl: 60 }
+      );
+      await fetched.promise;
+
+      // 2. An admin disables the rule; the route invalidates the cache.
+      const response = await PATCH(
+        withBody(`/api/v2/alert-rules/${rule._id}`, 'PATCH', { enabled: false }),
+        { params: params(String(rule._id)) }
+      );
+      expect(response.status).toBe(200);
+      expect(fakeRedis.del).toHaveBeenCalledWith(alertRulesKey());
+
+      // 3. The stale read completes and tries to publish what it loaded.
+      release.resolve();
+      const stale = (await inFlight) as Array<{ enabled: boolean }>;
+
+      // It really is the pre-mutation rule set — otherwise this test would
+      // pass for the wrong reason.
+      expect(stale).toHaveLength(1);
+      expect(stale[0].enabled).toBe(true);
+
+      // getOrSet's write is fire-and-forget; give it every chance to land.
+      await new Promise(resolve => setImmediate(resolve));
+
+      // 4. It must not have landed. Not "landed and then expired" — never written.
+      expect(store.has(alertRulesKey())).toBe(false);
+      expect(fakeRedis.setex).not.toHaveBeenCalled();
+
+      // ...and the route's invalidation left the cross-process mark behind, so
+      // an instance that never saw this process's generation counter would
+      // have been refused at the CAS too.
+      expect(store.get(`${alertRulesKey()}::epoch`)).toBe('1');
+    });
+
+    // The guard must cancel stale writes, not all writes: a version check that
+    // always fails would pass the test above while permanently disabling the
+    // cache.
+    it('should still populate the cache when nothing invalidated it', async () => {
+      await AlertRuleV2.create(createAlertRuleInput({ name: 'Uncontended' }));
+
+      const rules = await getOrSet(
+        alertRulesKey(),
+        async () => AlertRuleV2.find({ enabled: true }).lean(),
+        { ttl: 60 }
+      );
+
+      expect(rules).toHaveLength(1);
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(fakeRedis.eval).toHaveBeenCalledTimes(1);
+      await expect(fakeRedis.eval.mock.results[0].value).resolves.toBe(1);
+      expect(store.has(alertRulesKey())).toBe(true);
+    });
+
+    // An invalidation that ran BEFORE the read started says nothing about the
+    // value the read went on to fetch — that value already reflects it.
+    it('should still populate the cache after an invalidation that preceded the read', async () => {
+      await AlertRuleV2.create(createAlertRuleInput({ name: 'AfterInvalidation' }));
+      await cache.invalidateAlertRules();
+
+      await getOrSet(alertRulesKey(), async () => AlertRuleV2.find({ enabled: true }).lean(), {
+        ttl: 60,
+      });
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(store.has(alertRulesKey())).toBe(true);
     });
   });
 });

--- a/__tests__/integration/api/alert-rules.integration.test.ts
+++ b/__tests__/integration/api/alert-rules.integration.test.ts
@@ -6,7 +6,7 @@ import { NextRequest } from 'next/server';
 import { Types } from 'mongoose';
 import AlertRuleV2 from '@/models/v2/AlertRuleV2';
 import { createAlertRuleInput, resetCounters } from '../../setup/factories';
-import { mockAuthAsAdmin, mockAuthAsMember } from '../../setup/auth-helpers';
+import { mockAuthAsAdmin, mockAuthAsMember, mockAuthAsUnauthenticated } from '../../setup/auth-helpers';
 import * as cache from '@/lib/cache';
 
 import { GET as listRules, POST } from '@/app/api/v2/alert-rules/route';
@@ -200,6 +200,30 @@ describe('Alert Rules API Integration Tests', () => {
       const body = await parseResponse<{ data: Record<string, unknown> }>(response);
 
       expect(body.data).not.toHaveProperty('__v');
+    });
+
+    // requireOrgMembership() guards this handler in code but, unlike the list
+    // endpoint above, had no test exercising either the member-allowed path or
+    // the unauthenticated-rejected path — a silent removal of the guard would
+    // break zero tests.
+    it('should allow a member to read a single rule', async () => {
+      mockAuthAsMember();
+      const rule = await AlertRuleV2.create(createAlertRuleInput({ name: 'MemberReadable' }));
+
+      const response = await getRule(get(`/api/v2/alert-rules/${rule._id}`), {
+        params: params(String(rule._id)),
+      });
+
+      expect(response.status).toBe(200);
+    });
+
+    it('should reject an unauthenticated request', async () => {
+      mockAuthAsUnauthenticated();
+      const id = String(new Types.ObjectId());
+
+      const response = await getRule(get(`/api/v2/alert-rules/${id}`), { params: params(id) });
+
+      expect(response.status).toBe(401);
     });
   });
 

--- a/__tests__/integration/api/alert-rules.integration.test.ts
+++ b/__tests__/integration/api/alert-rules.integration.test.ts
@@ -431,4 +431,89 @@ describe('Alert Rules API Integration Tests', () => {
       expect(stored!.audit.deleted_at).toBeUndefined();
     });
   });
+
+  // ==========================================================================
+  // DEMO MODE REDACTION (Critical finding from the whole-branch review)
+  // ==========================================================================
+  //
+  // Same contract as alerts.integration.test.ts's "demo mode redaction" block:
+  // getAuditUser() resolves audit.*_by to a real email, requireOrgMembership()
+  // lets an anonymous demo visitor read this resource, so without redaction
+  // that email would leak. Each pair proves both halves: nothing reaches a
+  // demo caller, and an authenticated admin still gets the real value.
+  describe('demo mode redaction', () => {
+    const originalDemoMode = process.env.DEMO_MODE;
+
+    afterEach(() => {
+      if (originalDemoMode === undefined) delete process.env.DEMO_MODE;
+      else process.env.DEMO_MODE = originalDemoMode;
+    });
+
+    /** Simulate an anonymous visitor on a demo deployment: no session, DEMO_MODE on. */
+    function mockDemoVisitor() {
+      process.env.DEMO_MODE = 'true';
+      mockAuthAsUnauthenticated();
+    }
+
+    function auditWithRealEmail() {
+      const now = new Date();
+      return {
+        created_at: now,
+        created_by: 'admin@example.com',
+        updated_at: now,
+        updated_by: 'admin@example.com',
+      };
+    }
+
+    it('should redact audit actor fields for a demo-mode list request', async () => {
+      mockDemoVisitor();
+      await AlertRuleV2.create(createAlertRuleInput({ audit: auditWithRealEmail() }));
+
+      const response = await listRules(get('/api/v2/alert-rules'));
+      const body = await parseResponse<unknown>(response);
+
+      expect(response.status).toBe(200);
+      // Blunt but robust: no value anywhere in the payload may contain an
+      // email address when the caller is the anonymous demo visitor.
+      expect(JSON.stringify(body)).not.toContain('@');
+    });
+
+    it('should still return the real actor to a genuinely authenticated admin (list)', async () => {
+      mockAuthAsAdmin();
+      await AlertRuleV2.create(createAlertRuleInput({ audit: auditWithRealEmail() }));
+
+      const response = await listRules(get('/api/v2/alert-rules'));
+      const body = await parseResponse<{ data: Array<{ audit: { created_by?: string } }> }>(
+        response
+      );
+
+      expect(response.status).toBe(200);
+      expect(body.data[0].audit.created_by).toBe('admin@example.com');
+    });
+
+    it('should redact audit actor fields for a demo-mode single-rule request', async () => {
+      const rule = await AlertRuleV2.create(createAlertRuleInput({ audit: auditWithRealEmail() }));
+      mockDemoVisitor();
+
+      const response = await getRule(get(`/api/v2/alert-rules/${rule._id}`), {
+        params: params(String(rule._id)),
+      });
+      const body = await parseResponse<unknown>(response);
+
+      expect(response.status).toBe(200);
+      expect(JSON.stringify(body)).not.toContain('@');
+    });
+
+    it('should still return the real actor to a genuinely authenticated admin (single rule)', async () => {
+      const rule = await AlertRuleV2.create(createAlertRuleInput({ audit: auditWithRealEmail() }));
+
+      const response = await getRule(get(`/api/v2/alert-rules/${rule._id}`), {
+        params: params(String(rule._id)),
+      });
+      const body = await parseResponse<{ data: { audit: { created_by?: string } } }>(response);
+
+      expect(response.status).toBe(200);
+      expect(body.data.audit.created_by).toBe('admin@example.com');
+    });
+  });
 });

--- a/__tests__/integration/api/alert-rules.integration.test.ts
+++ b/__tests__/integration/api/alert-rules.integration.test.ts
@@ -85,6 +85,18 @@ describe('Alert Rules API Integration Tests', () => {
       const response = await listRules(get('/api/v2/alert-rules'));
       expect(response.status).toBe(200);
     });
+
+    // __v is Mongoose's internal version key. It is not part of
+    // AlertRuleV2Response (types/v2/alert.types.ts) and must never reach a client.
+    it('should not expose the internal __v field', async () => {
+      await AlertRuleV2.create(createAlertRuleInput());
+
+      const response = await listRules(get('/api/v2/alert-rules'));
+      const body = await parseResponse<{ data: Array<Record<string, unknown>> }>(response);
+
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0]).not.toHaveProperty('__v');
+    });
   });
 
   describe('POST /api/v2/alert-rules', () => {
@@ -135,6 +147,14 @@ describe('Alert Rules API Integration Tests', () => {
       expect(response.status).toBe(403);
       expect(await AlertRuleV2.countDocuments({})).toBe(0);
     });
+
+    it('should not expose the internal __v field', async () => {
+      const response = await POST(withBody('/api/v2/alert-rules', 'POST', VALID_BODY));
+      const body = await parseResponse<{ data: Record<string, unknown> }>(response);
+
+      expect(response.status).toBe(201);
+      expect(body.data).not.toHaveProperty('__v');
+    });
   });
 
   describe('GET /api/v2/alert-rules/[id]', () => {
@@ -170,6 +190,17 @@ describe('Alert Rules API Integration Tests', () => {
       expect(response.status).toBe(404);
       expect(body.error.code).toBe('ALERT_RULE_NOT_FOUND');
     });
+
+    it('should not expose the internal __v field', async () => {
+      const rule = await AlertRuleV2.create(createAlertRuleInput());
+
+      const response = await getRule(get(`/api/v2/alert-rules/${rule._id}`), {
+        params: params(String(rule._id)),
+      });
+      const body = await parseResponse<{ data: Record<string, unknown> }>(response);
+
+      expect(body.data).not.toHaveProperty('__v');
+    });
   });
 
   describe('PATCH /api/v2/alert-rules/[id]', () => {
@@ -202,6 +233,18 @@ describe('Alert Rules API Integration Tests', () => {
 
       expect(response.status).toBe(200);
       expect(body.data.threshold).toBe(45);
+    });
+
+    it('should not expose the internal __v field', async () => {
+      const rule = await AlertRuleV2.create(createAlertRuleInput());
+
+      const response = await PATCH(
+        withBody(`/api/v2/alert-rules/${rule._id}`, 'PATCH', { enabled: false }),
+        { params: params(String(rule._id)) }
+      );
+      const body = await parseResponse<{ data: Record<string, unknown> }>(response);
+
+      expect(body.data).not.toHaveProperty('__v');
     });
 
     it('should invalidate the alert rules cache on update', async () => {

--- a/__tests__/integration/api/alert-rules.integration.test.ts
+++ b/__tests__/integration/api/alert-rules.integration.test.ts
@@ -11,12 +11,25 @@ import AlertV2 from '@/models/v2/AlertV2';
 import { createAlertInput, createAlertRuleInput, resetCounters } from '../../setup/factories';
 import { mockAuthAsAdmin, mockAuthAsMember, mockAuthAsUnauthenticated } from '../../setup/auth-helpers';
 import * as cache from '@/lib/cache';
+import * as alerting from '@/lib/alerting';
+import * as monitoring from '@/lib/monitoring';
 import { getOrSet } from '@/lib/cache/cache';
 import { alertRulesKey } from '@/lib/cache/keys';
 import * as redisModule from '@/lib/redis/client';
 
 import { GET as listRules, POST } from '@/app/api/v2/alert-rules/route';
 import { GET as getRule, PATCH, DELETE } from '@/app/api/v2/alert-rules/[id]/route';
+
+// A condition change closes open episodes, and closing them now broadcasts
+// (see closeEpisodesOrphanedByConditionChange). Mocking the underlying
+// pusherServer.trigger rather than publishAlertEvents keeps this composable
+// with the tests below that spy on publishAlertEvents itself: when the spy is
+// installed this mock is simply never reached.
+jest.mock('@/lib/pusher', () => ({
+  pusherServer: {
+    trigger: jest.fn().mockResolvedValue(undefined),
+  },
+}));
 
 function get(path: string, searchParams: Record<string, string> = {}): NextRequest {
   const url = new URL(`http://localhost:3000${path}`);
@@ -631,6 +644,166 @@ describe('Alert Rules API Integration Tests', () => {
         const stored = await AlertV2.findById(alert._id).lean();
         expect(stored!.status).toBe('firing');
         expect(stored!.is_open).toBe(true);
+      });
+
+      // ======================================================================
+      // THE CLOSE HAS TO BE VISIBLE
+      // ======================================================================
+      //
+      // Closing N episodes in the database and telling nobody is the defect
+      // this block guards. Nothing patches alert rows into the React Query
+      // cache (see useAlertsList's header comment) and refetchOnWindowFocus is
+      // off, so an unbroadcast close leaves the alerts list and the nav badge
+      // rendering every one of those episodes as firing until something else
+      // invalidates them — indefinitely on a wall display. An uncounted one
+      // leaves `alerts_resolved` short by N, which is the metric the evaluator
+      // and sweep are judged on.
+      describe('announcing the close', () => {
+        async function seedRuleWithOpenEpisodes(count: number) {
+          const rule = await AlertRuleV2.create(
+            createAlertRuleInput({
+              metric: 'value',
+              comparison: 'gt',
+              threshold: 30,
+              selector: { types: ['temperature'] },
+            })
+          );
+
+          const alerts = [];
+          for (let index = 0; index < count; index += 1)
+            alerts.push(
+              await AlertV2.create(
+                createAlertInput({
+                  status: 'firing',
+                  rule_id: rule._id,
+                  device_id: `device_open_${index}`,
+                  metric: 'value',
+                  comparison: 'gt',
+                  threshold: 30,
+                })
+              )
+            );
+
+          return { rule, alerts };
+        }
+
+        function changeCondition(ruleId: string) {
+          return PATCH(withBody(`/api/v2/alert-rules/${ruleId}`, 'PATCH', NEW_CONDITION), {
+            params: params(ruleId),
+          });
+        }
+
+        it('should broadcast every closed episode, so connected clients see them resolve', async () => {
+          const publishSpy = jest.spyOn(alerting, 'publishAlertEvents').mockResolvedValue(undefined);
+          const { rule, alerts } = await seedRuleWithOpenEpisodes(3);
+
+          const response = await changeCondition(String(rule._id));
+          expect(response.status).toBe(200);
+
+          expect(publishSpy).toHaveBeenCalledTimes(1);
+          const [fired, resolved] = publishSpy.mock.calls[0];
+
+          // Nothing FIRED here — these episodes closed.
+          expect(fired).toEqual([]);
+          expect(resolved.map(event => event._id).sort()).toEqual(
+            alerts.map(alert => String(alert._id)).sort()
+          );
+
+          for (const event of resolved) {
+            expect(event.rule_id).toBe(String(rule._id));
+            expect(event.resolution).toBe('manual');
+            expect(event.severity).toBe('warning');
+            expect(event.resolved_at).toBeTruthy();
+          }
+        });
+
+        // The same contract the manual-resolve route is held to: audit.*_by
+        // keeps the email, the broadcast carries only the opaque Clerk id.
+        // Both strings are in scope in the same handler.
+        it('should broadcast the admin user id while persisting their email', async () => {
+          const publishSpy = jest.spyOn(alerting, 'publishAlertEvents').mockResolvedValue(undefined);
+          const { rule, alerts } = await seedRuleWithOpenEpisodes(1);
+
+          await changeCondition(String(rule._id));
+
+          const [, resolved] = publishSpy.mock.calls[0];
+          const stored = await AlertV2.findById(alerts[0]._id).lean();
+
+          expect(resolved[0].actor).toBe('user_test_admin');
+          expect(resolved[0].actor).not.toContain('@');
+          expect(stored!.audit.resolved_by).toBe('admin@example.com');
+          expect(resolved[0].actor).not.toBe(stored!.audit.resolved_by);
+        });
+
+        it('should count one resolution per closed episode', async () => {
+          const recordSpy = jest.spyOn(monitoring, 'recordAlert');
+          const { rule } = await seedRuleWithOpenEpisodes(3);
+
+          await changeCondition(String(rule._id));
+
+          const resolvedCalls = recordSpy.mock.calls.filter(([event]) => event === 'resolved');
+          expect(resolvedCalls).toHaveLength(3);
+          for (const [, labels] of resolvedCalls)
+            expect(labels).toEqual({ resolution: 'manual' });
+        });
+
+        // A pending episode was never visible to a client and never counted as
+        // fired, so announcing its resolution would invent an alert.
+        it('should neither broadcast nor count a deleted pending episode', async () => {
+          const publishSpy = jest.spyOn(alerting, 'publishAlertEvents').mockResolvedValue(undefined);
+          const recordSpy = jest.spyOn(monitoring, 'recordAlert');
+          const { rule } = await seedRuleWithOpenEpisode('pending');
+
+          await changeCondition(String(rule._id));
+
+          expect(publishSpy).not.toHaveBeenCalled();
+          expect(recordSpy.mock.calls.filter(([event]) => event === 'resolved')).toHaveLength(0);
+        });
+
+        it('should say nothing at all for a PATCH that does not touch the condition', async () => {
+          const publishSpy = jest.spyOn(alerting, 'publishAlertEvents').mockResolvedValue(undefined);
+          const recordSpy = jest.spyOn(monitoring, 'recordAlert');
+          const { rule } = await seedRuleWithOpenEpisodes(2);
+
+          await PATCH(withBody(`/api/v2/alert-rules/${rule._id}`, 'PATCH', { enabled: false }), {
+            params: params(String(rule._id)),
+          });
+
+          expect(publishSpy).not.toHaveBeenCalled();
+          expect(recordSpy.mock.calls.filter(([event]) => event === 'resolved')).toHaveLength(0);
+        });
+
+        // The rule update and the episode closes are already committed by the
+        // time the broadcast runs, so a broadcast fault has nothing left to
+        // roll back and must never become a 500 — but it must not vanish
+        // either. logger.error only reaches a console line, so the Sentry
+        // escalation is what makes a permanently broken broadcast path visible
+        // while every PATCH keeps returning 200. Mirrors the same guarantee on
+        // PATCH /api/v2/alerts/[id].
+        it('should still return 200 with the episodes closed, and escalate a broadcast failure', async () => {
+          const publishSpy = jest
+            .spyOn(alerting, 'publishAlertEvents')
+            .mockRejectedValue(new Error('envelope construction exploded'));
+          const captureSpy = jest.spyOn(monitoring, 'captureException').mockReturnValue(undefined);
+
+          const { rule, alerts } = await seedRuleWithOpenEpisodes(2);
+
+          const response = await changeCondition(String(rule._id));
+          expect(response.status).toBe(200);
+
+          for (const alert of alerts) {
+            const stored = await AlertV2.findById(alert._id).lean();
+            expect(stored!.status).toBe('resolved');
+            expect(stored!.is_open).toBe(false);
+          }
+
+          expect(publishSpy).toHaveBeenCalledTimes(1);
+          expect(captureSpy).toHaveBeenCalledTimes(1);
+          expect((captureSpy.mock.calls[0][0] as Error).message).toBe(
+            'envelope construction exploded'
+          );
+          expect(captureSpy.mock.calls[0][2]).toEqual({ subsystem: 'alerting' });
+        });
       });
     });
   });

--- a/__tests__/integration/api/alert-rules.integration.test.ts
+++ b/__tests__/integration/api/alert-rules.integration.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Alert Rules API Integration Tests
+ */
+
+import { NextRequest } from 'next/server';
+import { Types } from 'mongoose';
+import AlertRuleV2 from '@/models/v2/AlertRuleV2';
+import { createAlertRuleInput, resetCounters } from '../../setup/factories';
+import { mockAuthAsAdmin, mockAuthAsMember } from '../../setup/auth-helpers';
+import * as cache from '@/lib/cache';
+
+import { GET as listRules, POST } from '@/app/api/v2/alert-rules/route';
+import { GET as getRule, PATCH, DELETE } from '@/app/api/v2/alert-rules/[id]/route';
+
+function get(path: string, searchParams: Record<string, string> = {}): NextRequest {
+  const url = new URL(`http://localhost:3000${path}`);
+  Object.entries(searchParams).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url);
+}
+
+function withBody(path: string, method: 'POST' | 'PATCH', body: unknown): NextRequest {
+  return new NextRequest(`http://localhost:3000${path}`, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function params(id: string): Promise<{ id: string }> {
+  return Promise.resolve({ id });
+}
+
+async function parseResponse<T>(response: Response): Promise<T> {
+  return response.json();
+}
+
+const VALID_BODY = {
+  name: 'High temperature',
+  metric: 'value',
+  comparison: 'gt',
+  threshold: 30,
+  severity: 'critical',
+  selector: { types: ['temperature'] },
+  for_duration_seconds: 300,
+};
+
+describe('Alert Rules API Integration Tests', () => {
+  beforeEach(() => {
+    resetCounters();
+    mockAuthAsAdmin();
+    jest.spyOn(cache, 'invalidateAlertRules');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('GET /api/v2/alert-rules', () => {
+    it('should list rules and exclude soft-deleted ones', async () => {
+      await AlertRuleV2.create(createAlertRuleInput({ name: 'Kept' }));
+      const gone = await AlertRuleV2.create(createAlertRuleInput({ name: 'Gone' }));
+      await AlertRuleV2.softDelete(String(gone._id), 'admin');
+
+      const response = await listRules(get('/api/v2/alert-rules'));
+      const body = await parseResponse<{ data: Array<{ name: string }> }>(response);
+
+      expect(response.status).toBe(200);
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].name).toBe('Kept');
+    });
+
+    it('should filter by enabled', async () => {
+      await AlertRuleV2.create(createAlertRuleInput({ name: 'On' }));
+      await AlertRuleV2.create(createAlertRuleInput({ name: 'Off', enabled: false }));
+
+      const response = await listRules(get('/api/v2/alert-rules', { enabled: 'false' }));
+      const body = await parseResponse<{ data: Array<{ name: string }> }>(response);
+
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].name).toBe('Off');
+    });
+
+    it('should allow a member to read', async () => {
+      mockAuthAsMember();
+      const response = await listRules(get('/api/v2/alert-rules'));
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe('POST /api/v2/alert-rules', () => {
+    it('should create a rule with audit and defaults', async () => {
+      const response = await POST(withBody('/api/v2/alert-rules', 'POST', VALID_BODY));
+      const body = await parseResponse<{
+        data: { _id: string; enabled: boolean; cooldown_seconds: number; audit: { created_by: string } };
+      }>(response);
+
+      expect(response.status).toBe(201);
+      expect(body.data.enabled).toBe(true);
+      expect(body.data.cooldown_seconds).toBe(300);
+      expect(body.data.audit.created_by).toBeTruthy();
+      expect(await AlertRuleV2.countDocuments({})).toBe(1);
+    });
+
+    it('should invalidate the alert rules cache on create', async () => {
+      await POST(withBody('/api/v2/alert-rules', 'POST', VALID_BODY));
+      expect(cache.invalidateAlertRules).toHaveBeenCalledTimes(1);
+    });
+
+    it("should 400 when metric is 'value' and selector.types is missing", async () => {
+      const response = await POST(
+        withBody('/api/v2/alert-rules', 'POST', { ...VALID_BODY, selector: {} })
+      );
+      const body = await parseResponse<{ error: { code: string } }>(response);
+      expect(response.status).toBe(400);
+      expect(body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('should 400 when the threshold is outside the metric bounds', async () => {
+      const response = await POST(
+        withBody('/api/v2/alert-rules', 'POST', {
+          ...VALID_BODY,
+          metric: 'anomaly_score',
+          threshold: 30,
+          selector: {},
+        })
+      );
+      const body = await parseResponse<{ error: { code: string } }>(response);
+      expect(response.status).toBe(400);
+      expect(body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('should 403 for a member', async () => {
+      mockAuthAsMember();
+      const response = await POST(withBody('/api/v2/alert-rules', 'POST', VALID_BODY));
+      expect(response.status).toBe(403);
+      expect(await AlertRuleV2.countDocuments({})).toBe(0);
+    });
+  });
+
+  describe('GET /api/v2/alert-rules/[id]', () => {
+    it('should return a single rule', async () => {
+      const rule = await AlertRuleV2.create(createAlertRuleInput({ name: 'Solo' }));
+
+      const response = await getRule(get(`/api/v2/alert-rules/${rule._id}`), {
+        params: params(String(rule._id)),
+      });
+      const body = await parseResponse<{ data: { name: string } }>(response);
+
+      expect(response.status).toBe(200);
+      expect(body.data.name).toBe('Solo');
+    });
+
+    it('should 404 for a soft-deleted rule', async () => {
+      const rule = await AlertRuleV2.create(createAlertRuleInput());
+      await AlertRuleV2.softDelete(String(rule._id), 'admin');
+
+      const response = await getRule(get(`/api/v2/alert-rules/${rule._id}`), {
+        params: params(String(rule._id)),
+      });
+      const body = await parseResponse<{ error: { code: string } }>(response);
+
+      expect(response.status).toBe(404);
+      expect(body.error.code).toBe('ALERT_RULE_NOT_FOUND');
+    });
+
+    it('should 404 for an unknown id', async () => {
+      const id = String(new Types.ObjectId());
+      const response = await getRule(get(`/api/v2/alert-rules/${id}`), { params: params(id) });
+      const body = await parseResponse<{ error: { code: string } }>(response);
+      expect(response.status).toBe(404);
+      expect(body.error.code).toBe('ALERT_RULE_NOT_FOUND');
+    });
+  });
+
+  describe('PATCH /api/v2/alert-rules/[id]', () => {
+    it('should toggle enabled', async () => {
+      const rule = await AlertRuleV2.create(createAlertRuleInput());
+
+      const response = await PATCH(
+        withBody(`/api/v2/alert-rules/${rule._id}`, 'PATCH', { enabled: false }),
+        { params: params(String(rule._id)) }
+      );
+      const body = await parseResponse<{ data: { enabled: boolean } }>(response);
+
+      expect(response.status).toBe(200);
+      expect(body.data.enabled).toBe(false);
+    });
+
+    it('should update the full condition group', async () => {
+      const rule = await AlertRuleV2.create(createAlertRuleInput());
+
+      const response = await PATCH(
+        withBody(`/api/v2/alert-rules/${rule._id}`, 'PATCH', {
+          metric: 'value',
+          comparison: 'gte',
+          threshold: 45,
+          selector: { types: ['temperature', 'humidity'] },
+        }),
+        { params: params(String(rule._id)) }
+      );
+      const body = await parseResponse<{ data: { threshold: number } }>(response);
+
+      expect(response.status).toBe(200);
+      expect(body.data.threshold).toBe(45);
+    });
+
+    it('should invalidate the alert rules cache on update', async () => {
+      const rule = await AlertRuleV2.create(createAlertRuleInput());
+
+      await PATCH(withBody(`/api/v2/alert-rules/${rule._id}`, 'PATCH', { enabled: false }), {
+        params: params(String(rule._id)),
+      });
+
+      expect(cache.invalidateAlertRules).toHaveBeenCalledTimes(1);
+    });
+
+    it('should 400 on a partial condition update', async () => {
+      const rule = await AlertRuleV2.create(createAlertRuleInput());
+
+      const response = await PATCH(
+        withBody(`/api/v2/alert-rules/${rule._id}`, 'PATCH', { threshold: 45 }),
+        { params: params(String(rule._id)) }
+      );
+      const body = await parseResponse<{ error: { code: string } }>(response);
+
+      expect(response.status).toBe(400);
+      expect(body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('should 400 on an empty body', async () => {
+      const rule = await AlertRuleV2.create(createAlertRuleInput());
+
+      const response = await PATCH(withBody(`/api/v2/alert-rules/${rule._id}`, 'PATCH', {}), {
+        params: params(String(rule._id)),
+      });
+      const body = await parseResponse<{ error: { code: string } }>(response);
+
+      expect(response.status).toBe(400);
+      expect(body.error.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('should 404 for a soft-deleted rule', async () => {
+      const rule = await AlertRuleV2.create(createAlertRuleInput());
+      await AlertRuleV2.softDelete(String(rule._id), 'admin');
+
+      const response = await PATCH(
+        withBody(`/api/v2/alert-rules/${rule._id}`, 'PATCH', { enabled: true }),
+        { params: params(String(rule._id)) }
+      );
+      const body = await parseResponse<{ error: { code: string } }>(response);
+
+      expect(response.status).toBe(404);
+      expect(body.error.code).toBe('ALERT_RULE_NOT_FOUND');
+    });
+
+    it('should 403 for a member', async () => {
+      mockAuthAsMember();
+      const rule = await AlertRuleV2.create(createAlertRuleInput());
+
+      const response = await PATCH(
+        withBody(`/api/v2/alert-rules/${rule._id}`, 'PATCH', { enabled: false }),
+        { params: params(String(rule._id)) }
+      );
+
+      expect(response.status).toBe(403);
+      const stored = await AlertRuleV2.findById(rule._id).lean();
+      expect(stored!.enabled).toBe(true);
+    });
+  });
+
+  describe('DELETE /api/v2/alert-rules/[id]', () => {
+    it('should soft delete, preserving the document', async () => {
+      const rule = await AlertRuleV2.create(createAlertRuleInput());
+
+      const response = await DELETE(get(`/api/v2/alert-rules/${rule._id}`), {
+        params: params(String(rule._id)),
+      });
+      const body = await parseResponse<{ data: { deleted: boolean } }>(response);
+
+      expect(response.status).toBe(200);
+      expect(body.data.deleted).toBe(true);
+
+      // Soft, not hard: alerts reference their rule, and hard-deleting would
+      // orphan the history that justifies every alert it ever raised.
+      const stored = await AlertRuleV2.findById(rule._id).lean();
+      expect(stored).not.toBeNull();
+      expect(stored!.audit.deleted_at).toBeTruthy();
+    });
+
+    it('should exclude the deleted rule from a subsequent list', async () => {
+      const rule = await AlertRuleV2.create(createAlertRuleInput({ name: 'ToDelete' }));
+      await AlertRuleV2.create(createAlertRuleInput({ name: 'Stays' }));
+
+      await DELETE(get(`/api/v2/alert-rules/${rule._id}`), { params: params(String(rule._id)) });
+
+      const response = await listRules(get('/api/v2/alert-rules'));
+      const body = await parseResponse<{ data: Array<{ name: string }> }>(response);
+
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].name).toBe('Stays');
+    });
+
+    it('should invalidate the alert rules cache on delete', async () => {
+      const rule = await AlertRuleV2.create(createAlertRuleInput());
+
+      await DELETE(get(`/api/v2/alert-rules/${rule._id}`), { params: params(String(rule._id)) });
+
+      expect(cache.invalidateAlertRules).toHaveBeenCalledTimes(1);
+    });
+
+    it('should 404 when already deleted', async () => {
+      const rule = await AlertRuleV2.create(createAlertRuleInput());
+      await AlertRuleV2.softDelete(String(rule._id), 'admin');
+
+      const response = await DELETE(get(`/api/v2/alert-rules/${rule._id}`), {
+        params: params(String(rule._id)),
+      });
+      const body = await parseResponse<{ error: { code: string } }>(response);
+
+      expect(response.status).toBe(404);
+      expect(body.error.code).toBe('ALERT_RULE_NOT_FOUND');
+    });
+
+    it('should 403 for a member', async () => {
+      mockAuthAsMember();
+      const rule = await AlertRuleV2.create(createAlertRuleInput());
+
+      const response = await DELETE(get(`/api/v2/alert-rules/${rule._id}`), {
+        params: params(String(rule._id)),
+      });
+
+      expect(response.status).toBe(403);
+      const stored = await AlertRuleV2.findById(rule._id).lean();
+      expect(stored!.audit.deleted_at).toBeUndefined();
+    });
+  });
+});

--- a/__tests__/integration/api/alerts.integration.test.ts
+++ b/__tests__/integration/api/alerts.integration.test.ts
@@ -95,6 +95,125 @@ describe('Alerts API Integration Tests', () => {
       expect(body.data[0].device_id).toBe('device_aaa');
     });
 
+    it('should filter by rule_id', async () => {
+      const ruleIdA = new Types.ObjectId();
+      const ruleIdB = new Types.ObjectId();
+      await AlertV2.create(
+        createAlertInput({ status: 'firing', rule_id: ruleIdA, device_id: 'device_rule_a' })
+      );
+      await AlertV2.create(
+        createAlertInput({ status: 'firing', rule_id: ruleIdB, device_id: 'device_rule_b' })
+      );
+
+      const response = await listAlerts(
+        createMockGetRequest('/api/v2/alerts', { rule_id: String(ruleIdA) })
+      );
+      const body = await parseResponse<{ data: Array<{ device_id: string }> }>(response);
+
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].device_id).toBe('device_rule_a');
+    });
+
+    // Distinct from "should default to open alerts" above: that test never
+    // passes a `status` query param at all, so it exercises the route's OWN
+    // default (which happens to also be two values), not a caller-supplied
+    // comma-separated list reaching the $in branch. Deliberately mixes an
+    // open and a closed status (excluding 'firing') so a regression to
+    // single-value-only filtering — `statuses[0]` instead of `{ $in:
+    // statuses }` — returns just one alert instead of two.
+    it('should accept a comma-separated status list via the $in branch', async () => {
+      await AlertV2.create(createAlertInput({ status: 'firing', device_id: 'device_firing' }));
+      await AlertV2.create(createAlertInput({ status: 'acknowledged', device_id: 'device_acked' }));
+      await AlertV2.create(
+        createAlertInput({ status: 'resolved', is_open: false, device_id: 'device_resolved' })
+      );
+
+      const response = await listAlerts(
+        createMockGetRequest('/api/v2/alerts', { status: 'acknowledged,resolved' })
+      );
+      const body = await parseResponse<{ data: Array<{ device_id: string }> }>(response);
+
+      expect(body.data.map(a => a.device_id).sort()).toEqual(['device_acked', 'device_resolved']);
+    });
+
+    // Same rationale as the status test above: "should filter by severity"
+    // only ever passes a single value, so it cannot tell a working $in branch
+    // from one collapsed to single-value equality.
+    it('should accept a comma-separated severity list via the $in branch', async () => {
+      await AlertV2.create(
+        createAlertInput({ status: 'firing', severity: 'critical', device_id: 'device_crit' })
+      );
+      await AlertV2.create(
+        createAlertInput({ status: 'firing', severity: 'warning', device_id: 'device_warn' })
+      );
+      await AlertV2.create(
+        createAlertInput({ status: 'firing', severity: 'info', device_id: 'device_info' })
+      );
+
+      const response = await listAlerts(
+        createMockGetRequest('/api/v2/alerts', { severity: 'critical,info' })
+      );
+      const body = await parseResponse<{ data: Array<{ device_id: string }> }>(response);
+
+      expect(body.data.map(a => a.device_id).sort()).toEqual(['device_crit', 'device_info']);
+    });
+
+    // Proves sortBy is actually wired to SORT_FIELD_MAP rather than silently
+    // falling back to the default (audit.created_at desc). Chosen orderings
+    // are deliberately NOT a coincidental match: audit.created_at order
+    // (oldest -> newest) is warning, critical, info, so a collapsed
+    // SORT_FIELD_MAP (which would fall back to created_at desc, giving
+    // info/critical/warning) cannot accidentally satisfy this assertion.
+    //
+    // Also documents an oddity, not a bug to fix here: severity sorts
+    // LEXICALLY (there is no severity-rank comparator), so descending yields
+    // warning -> info -> critical — 'critical' sorts last because 'c' < 'i' <
+    // 'w'. A user asking for "most severe first" almost certainly does not
+    // mean this. See the task report for why this is surfaced, not changed.
+    it('should sort by severity, not silently fall back to created_at', async () => {
+      const t1 = new Date('2026-01-01T08:00:00.000Z');
+      const t2 = new Date('2026-01-01T09:00:00.000Z');
+      const t3 = new Date('2026-01-01T10:00:00.000Z');
+      const auditAt = (created_at: Date) => ({
+        created_at,
+        created_by: 'system',
+        updated_at: created_at,
+        updated_by: 'system',
+      });
+
+      await AlertV2.create(
+        createAlertInput({
+          status: 'firing',
+          device_id: 'device_warn',
+          severity: 'warning',
+          audit: auditAt(t1),
+        })
+      );
+      await AlertV2.create(
+        createAlertInput({
+          status: 'firing',
+          device_id: 'device_crit',
+          severity: 'critical',
+          audit: auditAt(t2),
+        })
+      );
+      await AlertV2.create(
+        createAlertInput({
+          status: 'firing',
+          device_id: 'device_info',
+          severity: 'info',
+          audit: auditAt(t3),
+        })
+      );
+
+      const response = await listAlerts(
+        createMockGetRequest('/api/v2/alerts', { sortBy: 'severity', sortDirection: 'desc' })
+      );
+      const body = await parseResponse<{ data: Array<{ device_id: string }> }>(response);
+
+      expect(body.data.map(a => a.device_id)).toEqual(['device_warn', 'device_info', 'device_crit']);
+    });
+
     it('should paginate', async () => {
       for (let i = 0; i < 5; i++) await AlertV2.create(createAlertInput({ status: 'firing' }));
 

--- a/__tests__/integration/api/alerts.integration.test.ts
+++ b/__tests__/integration/api/alerts.integration.test.ts
@@ -7,6 +7,7 @@ import { Types } from 'mongoose';
 import AlertV2 from '@/models/v2/AlertV2';
 import DeviceV2 from '@/models/v2/DeviceV2';
 import * as alerting from '@/lib/alerting';
+import * as monitoring from '@/lib/monitoring';
 import { createAlertInput, createDeviceInput, resetCounters } from '../../setup/factories';
 import { mockAuthAsAdmin, mockAuthAsMember, mockAuthAsUnauthenticated } from '../../setup/auth-helpers';
 
@@ -125,6 +126,62 @@ describe('Alerts API Integration Tests', () => {
 
       expect(body.data).toHaveLength(1);
       expect(body.data[0].device_id).toBe('device_rule_a');
+    });
+
+    // The aggregate branch (sortBy=severity) and countDocuments read the SAME
+    // `filter`, but Mongoose casts queries and never pipelines: `rule_id` is
+    // the raw 24-hex string Zod produced, so $match compared a string against
+    // an ObjectId-typed field and matched nothing while countDocuments cast it
+    // correctly. The envelope advertised a non-zero total and shipped zero
+    // rows. `ActiveAlertsWidget` already puts the aggregate branch on the
+    // dashboard's hot path, so any rule-scoped view lands exactly here.
+    it('should return rows and an agreeing total when sortBy=severity is combined with rule_id', async () => {
+      const scopedRuleId = new Types.ObjectId();
+      const otherRuleId = new Types.ObjectId();
+
+      await AlertV2.create(
+        createAlertInput({
+          status: 'firing',
+          rule_id: scopedRuleId,
+          device_id: 'device_scoped_crit',
+          severity: 'critical',
+        })
+      );
+      await AlertV2.create(
+        createAlertInput({
+          status: 'firing',
+          rule_id: scopedRuleId,
+          device_id: 'device_scoped_info',
+          severity: 'info',
+        })
+      );
+      await AlertV2.create(
+        createAlertInput({ status: 'firing', rule_id: otherRuleId, device_id: 'device_other' })
+      );
+
+      const response = await listAlerts(
+        createMockGetRequest('/api/v2/alerts', {
+          sortBy: 'severity',
+          sortDirection: 'desc',
+          rule_id: String(scopedRuleId),
+        })
+      );
+      const body = await parseResponse<{
+        data: Array<{ device_id: string }>;
+        pagination: { total: number };
+      }>(response);
+
+      expect(response.status).toBe(200);
+      // The bug's exact signature: an empty page under a non-zero total.
+      expect(body.data.length).toBeGreaterThan(0);
+      expect(body.data.map(a => a.device_id)).toEqual([
+        'device_scoped_crit',
+        'device_scoped_info',
+      ]);
+      // Single page, so the two must agree — the count still has to be
+      // scoped to the rule, not silently widened to make them match.
+      expect(body.pagination.total).toBe(body.data.length);
+      expect(body.pagination.total).toBe(2);
     });
 
     // Distinct from "should default to open alerts" above: that test never
@@ -568,6 +625,31 @@ describe('Alerts API Integration Tests', () => {
       spy.mockRestore();
     });
 
+    // The companion to the assertion above. Both values are `string` and both
+    // are in scope in the same handler, so the interesting property is not
+    // just "actor is a user id" but that the two identities are DIFFERENT and
+    // each lands where it belongs — the audit trail keeps the email, the
+    // broadcast keeps the opaque id. Branded types make the swap a compile
+    // error; this pins the runtime side of the same contract.
+    it('should persist the email to audit.resolved_by while broadcasting only the user id', async () => {
+      const spy = jest.spyOn(alerting, 'publishAlertEvents').mockResolvedValue(undefined);
+      const alert = await AlertV2.create(createAlertInput({ status: 'firing' }));
+
+      await PATCH(
+        createMockPatchRequest(`/api/v2/alerts/${alert._id}`, { status: 'resolved' }),
+        { params: params(String(alert._id)) }
+      );
+
+      const stored = await AlertV2.findById(alert._id).lean();
+      const [, resolvedArg] = spy.mock.calls[0];
+
+      expect(stored!.audit.resolved_by).toBe('admin@example.com');
+      expect(resolvedArg[0].actor).toBe('user_test_admin');
+      expect(resolvedArg[0].actor).not.toBe(stored!.audit.resolved_by);
+
+      spy.mockRestore();
+    });
+
     it('should not expose the internal __v field on the updated alert', async () => {
       const alert = await AlertV2.create(createAlertInput({ status: 'firing' }));
 
@@ -651,6 +733,170 @@ describe('Alerts API Integration Tests', () => {
       );
 
       expect(response.status).toBe(404);
+    });
+
+    // ========================================================================
+    // THE NOTE WRITE
+    // ========================================================================
+    describe('note handling', () => {
+      function auditWithNote(note: string) {
+        const now = new Date();
+        return {
+          created_at: now,
+          created_by: 'system',
+          updated_at: now,
+          updated_by: 'system',
+          note,
+        };
+      }
+
+      // The note write used to run AFTER acknowledge()/resolve() had already
+      // committed. A throw there returned 500 — telling the operator the
+      // acknowledge had FAILED when it had not — and the natural retry then
+      // returned 422 "already acknowledged", leaving them with no way to
+      // reconcile the two answers. Writing the note first means a failure
+      // commits nothing, so the retry is clean.
+      it('should commit nothing, and stay retryable, when the note write fails', async () => {
+        const alert = await AlertV2.create(createAlertInput({ status: 'firing' }));
+        const spy = jest
+          .spyOn(AlertV2, 'updateOne')
+          .mockRejectedValueOnce(new Error('note write exploded'));
+
+        const failed = await PATCH(
+          createMockPatchRequest(`/api/v2/alerts/${alert._id}`, {
+            status: 'acknowledged',
+            note: 'Dispatching a tech',
+          }),
+          { params: params(String(alert._id)) }
+        );
+
+        expect(failed.status).toBe(500);
+
+        // The transition must NOT have committed behind the error.
+        const afterFailure = await AlertV2.findById(alert._id).lean();
+        expect(afterFailure!.status).toBe('firing');
+        expect(afterFailure!.audit.acknowledged_at).toBeUndefined();
+
+        spy.mockRestore();
+
+        // ...so the operator's natural retry succeeds, rather than hitting
+        // 422 ALERT_ALREADY_ACKNOWLEDGED for a transition they were told failed.
+        const retry = await PATCH(
+          createMockPatchRequest(`/api/v2/alerts/${alert._id}`, {
+            status: 'acknowledged',
+            note: 'Dispatching a tech',
+          }),
+          { params: params(String(alert._id)) }
+        );
+        const body = await parseResponse<{
+          data: { status: string; audit: { note?: string } };
+        }>(retry);
+
+        expect(retry.status).toBe(200);
+        expect(body.data.status).toBe('acknowledged');
+        expect(body.data.audit.note).toBe('Dispatching a tech');
+      });
+
+      // `if (note)` discarded an explicit `note: ''`, so a note could be
+      // written but never withdrawn. A presence check is what makes the field
+      // clearable; truthiness cannot express "set this to nothing".
+      it('should clear an existing note when the caller sends an empty string', async () => {
+        const alert = await AlertV2.create(
+          createAlertInput({ status: 'firing', audit: auditWithNote('Original note') })
+        );
+
+        const response = await PATCH(
+          createMockPatchRequest(`/api/v2/alerts/${alert._id}`, {
+            status: 'acknowledged',
+            note: '',
+          }),
+          { params: params(String(alert._id)) }
+        );
+
+        expect(response.status).toBe(200);
+
+        const stored = await AlertV2.findById(alert._id).lean();
+        expect(stored!.status).toBe('acknowledged');
+        expect(stored!.audit.note).toBeUndefined();
+      });
+
+      it('should leave an existing note untouched when the caller omits the field', async () => {
+        const alert = await AlertV2.create(
+          createAlertInput({ status: 'firing', audit: auditWithNote('Original note') })
+        );
+
+        await PATCH(
+          createMockPatchRequest(`/api/v2/alerts/${alert._id}`, { status: 'acknowledged' }),
+          { params: params(String(alert._id)) }
+        );
+
+        const stored = await AlertV2.findById(alert._id).lean();
+        expect(stored!.audit.note).toBe('Original note');
+      });
+
+      // One operator action must leave one timestamp. The old `.save()` fired
+      // AlertV2's pre('save') hook, which re-stamped audit.updated_at a moment
+      // after acknowledge()'s own $set had already set it — so the audit trail
+      // showed an update strictly later than the acknowledgement it WAS.
+      it('should stamp audit.updated_at once, from the transition itself', async () => {
+        const alert = await AlertV2.create(createAlertInput({ status: 'firing' }));
+
+        await PATCH(
+          createMockPatchRequest(`/api/v2/alerts/${alert._id}`, {
+            status: 'acknowledged',
+            note: 'Handled',
+          }),
+          { params: params(String(alert._id)) }
+        );
+
+        const stored = await AlertV2.findById(alert._id).lean();
+        expect(stored!.audit.updated_at).toEqual(stored!.audit.acknowledged_at);
+      });
+    });
+
+    // ========================================================================
+    // BROADCAST FAILURE AFTER A COMMITTED WRITE
+    // ========================================================================
+    //
+    // The resolve is already in the database by the time publishAlertEvents
+    // runs, so a broadcast fault must not become a 500 — but it must not
+    // vanish either. logger.error only reaches a console line
+    // (lib/monitoring/logger.ts), so the Sentry escalation is what makes a
+    // permanently broken broadcast visible while every PATCH returns 200.
+    describe('broadcast failure', () => {
+      it('should still return 200 with the resolve applied, and escalate the failure', async () => {
+        const publishSpy = jest
+          .spyOn(alerting, 'publishAlertEvents')
+          .mockRejectedValue(new Error('envelope construction exploded'));
+        const captureSpy = jest
+          .spyOn(monitoring, 'captureException')
+          .mockReturnValue(undefined);
+
+        const alert = await AlertV2.create(createAlertInput({ status: 'firing' }));
+
+        const response = await PATCH(
+          createMockPatchRequest(`/api/v2/alerts/${alert._id}`, { status: 'resolved' }),
+          { params: params(String(alert._id)) }
+        );
+        const body = await parseResponse<{ data: { status: string } }>(response);
+
+        expect(response.status).toBe(200);
+        expect(body.data.status).toBe('resolved');
+
+        const stored = await AlertV2.findById(alert._id).lean();
+        expect(stored!.status).toBe('resolved');
+        expect(stored!.is_open).toBe(false);
+
+        // Escalated, not silently swallowed.
+        expect(captureSpy).toHaveBeenCalledTimes(1);
+        expect((captureSpy.mock.calls[0][0] as Error).message).toBe(
+          'envelope construction exploded'
+        );
+        expect(captureSpy.mock.calls[0][2]).toEqual({ subsystem: 'alerting' });
+
+        publishSpy.mockRestore();
+        captureSpy.mockRestore();
+      });
     });
   });
 

--- a/__tests__/integration/api/alerts.integration.test.ts
+++ b/__tests__/integration/api/alerts.integration.test.ts
@@ -158,19 +158,16 @@ describe('Alerts API Integration Tests', () => {
       expect(body.data.map(a => a.device_id).sort()).toEqual(['device_crit', 'device_info']);
     });
 
-    // Proves sortBy is actually wired to SORT_FIELD_MAP rather than silently
-    // falling back to the default (audit.created_at desc). Chosen orderings
-    // are deliberately NOT a coincidental match: audit.created_at order
-    // (oldest -> newest) is warning, critical, info, so a collapsed
-    // SORT_FIELD_MAP (which would fall back to created_at desc, giving
-    // info/critical/warning) cannot accidentally satisfy this assertion.
-    //
-    // Also documents an oddity, not a bug to fix here: severity sorts
-    // LEXICALLY (there is no severity-rank comparator), so descending yields
-    // warning -> info -> critical — 'critical' sorts last because 'c' < 'i' <
-    // 'w'. A user asking for "most severe first" almost certainly does not
-    // mean this. See the task report for why this is surfaced, not changed.
-    it('should sort by severity, not silently fall back to created_at', async () => {
+    // Proves sortBy=severity orders by urgency RANK (critical > warning >
+    // info), not lexically and not by silently falling back to
+    // audit.created_at. Chosen orderings are deliberately NOT a coincidental
+    // match for either fallback:
+    //   - severity desc (the fix):    device_crit, device_warn, device_info
+    //   - created_at desc (fallback): device_info, device_crit, device_warn
+    //   - created_at asc (fallback):  device_warn, device_crit, device_info
+    // A collapsed SORT_FIELD_MAP falling back to created_at, in either
+    // direction, therefore cannot accidentally satisfy the assertion below.
+    async function seedThreeSeverities() {
       const t1 = new Date('2026-01-01T08:00:00.000Z');
       const t2 = new Date('2026-01-01T09:00:00.000Z');
       const t3 = new Date('2026-01-01T10:00:00.000Z');
@@ -205,13 +202,40 @@ describe('Alerts API Integration Tests', () => {
           audit: auditAt(t3),
         })
       );
+    }
+
+    it('should sort by severity rank descending, most severe first', async () => {
+      await seedThreeSeverities();
 
       const response = await listAlerts(
         createMockGetRequest('/api/v2/alerts', { sortBy: 'severity', sortDirection: 'desc' })
       );
+      const body = await parseResponse<{
+        data: Array<{ _id: string; device_id: string }>;
+      }>(response);
+
+      expect(body.data.map(a => a.device_id)).toEqual(['device_crit', 'device_warn', 'device_info']);
+
+      // The route branches to AlertV2.aggregate() for this sort only.
+      // aggregate() must serialize identically to the .lean() path used by
+      // every other sort: a bare hex-string _id, and __v projected away.
+      expect(typeof body.data[0]._id).toBe('string');
+      expect(body.data[0]._id).toMatch(/^[a-f0-9]{24}$/);
+      expect(body.data[0]).not.toHaveProperty('__v');
+    });
+
+    // Proves the rank is genuinely ORDERED (info < warning < critical), not
+    // merely "different from lexical" — reversing sortDirection must reverse
+    // the whole rank order, not just move 'critical' out of last place.
+    it('should sort by severity rank ascending, least severe first', async () => {
+      await seedThreeSeverities();
+
+      const response = await listAlerts(
+        createMockGetRequest('/api/v2/alerts', { sortBy: 'severity', sortDirection: 'asc' })
+      );
       const body = await parseResponse<{ data: Array<{ device_id: string }> }>(response);
 
-      expect(body.data.map(a => a.device_id)).toEqual(['device_warn', 'device_info', 'device_crit']);
+      expect(body.data.map(a => a.device_id)).toEqual(['device_info', 'device_warn', 'device_crit']);
     });
 
     it('should paginate', async () => {

--- a/__tests__/integration/api/alerts.integration.test.ts
+++ b/__tests__/integration/api/alerts.integration.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Alerts API Integration Tests
+ */
+
+import { NextRequest } from 'next/server';
+import { Types } from 'mongoose';
+import AlertV2 from '@/models/v2/AlertV2';
+import DeviceV2 from '@/models/v2/DeviceV2';
+import { createAlertInput, createDeviceInput, resetCounters } from '../../setup/factories';
+import { mockAuthAsAdmin, mockAuthAsMember } from '../../setup/auth-helpers';
+
+import { GET as listAlerts } from '@/app/api/v2/alerts/route';
+import { GET as getAlert, PATCH } from '@/app/api/v2/alerts/[id]/route';
+
+function createMockGetRequest(path: string, searchParams: Record<string, string> = {}): NextRequest {
+  const url = new URL(`http://localhost:3000${path}`);
+  Object.entries(searchParams).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url);
+}
+
+function createMockPatchRequest(path: string, body: unknown): NextRequest {
+  return new NextRequest(`http://localhost:3000${path}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function params(id: string): Promise<{ id: string }> {
+  return Promise.resolve({ id });
+}
+
+async function parseResponse<T>(response: Response): Promise<T> {
+  return response.json();
+}
+
+describe('Alerts API Integration Tests', () => {
+  beforeEach(() => {
+    resetCounters();
+    mockAuthAsAdmin();
+  });
+
+  describe('GET /api/v2/alerts', () => {
+    it('should default to open alerts and exclude pending and resolved', async () => {
+      await AlertV2.create(createAlertInput({ status: 'firing' }));
+      await AlertV2.create(createAlertInput({ status: 'acknowledged' }));
+      await AlertV2.create(createAlertInput({ status: 'pending' }));
+      await AlertV2.create(createAlertInput({ status: 'resolved', is_open: false }));
+
+      const response = await listAlerts(createMockGetRequest('/api/v2/alerts'));
+      const body = await parseResponse<{ data: Array<{ status: string }> }>(response);
+
+      expect(response.status).toBe(200);
+      expect(body.data).toHaveLength(2);
+      expect(body.data.map(a => a.status).sort()).toEqual(['acknowledged', 'firing']);
+    });
+
+    it('should never return pending even when explicitly requested', async () => {
+      await AlertV2.create(createAlertInput({ status: 'pending' }));
+
+      const response = await listAlerts(createMockGetRequest('/api/v2/alerts', { status: 'pending' }));
+      const body = await parseResponse<{ data: unknown[] }>(response);
+
+      expect(body.data).toHaveLength(0);
+    });
+
+    it('should return history when status=resolved', async () => {
+      await AlertV2.create(createAlertInput({ status: 'resolved', is_open: false }));
+
+      const response = await listAlerts(createMockGetRequest('/api/v2/alerts', { status: 'resolved' }));
+      const body = await parseResponse<{ data: unknown[] }>(response);
+
+      expect(body.data).toHaveLength(1);
+    });
+
+    it('should filter by severity', async () => {
+      await AlertV2.create(createAlertInput({ status: 'firing', severity: 'critical' }));
+      await AlertV2.create(createAlertInput({ status: 'firing', severity: 'info' }));
+
+      const response = await listAlerts(createMockGetRequest('/api/v2/alerts', { severity: 'critical' }));
+      const body = await parseResponse<{ data: Array<{ severity: string }> }>(response);
+
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].severity).toBe('critical');
+    });
+
+    it('should filter by device_id', async () => {
+      await AlertV2.create(createAlertInput({ status: 'firing', device_id: 'device_aaa' }));
+      await AlertV2.create(createAlertInput({ status: 'firing', device_id: 'device_bbb' }));
+
+      const response = await listAlerts(createMockGetRequest('/api/v2/alerts', { device_id: 'device_aaa' }));
+      const body = await parseResponse<{ data: Array<{ device_id: string }> }>(response);
+
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].device_id).toBe('device_aaa');
+    });
+
+    it('should paginate', async () => {
+      for (let i = 0; i < 5; i++) await AlertV2.create(createAlertInput({ status: 'firing' }));
+
+      const response = await listAlerts(
+        createMockGetRequest('/api/v2/alerts', { page: '2', limit: '2' })
+      );
+      const body = await parseResponse<{ data: unknown[]; pagination: { total: number; page: number } }>(response);
+
+      expect(body.data).toHaveLength(2);
+      expect(body.pagination.total).toBe(5);
+      expect(body.pagination.page).toBe(2);
+    });
+
+    it('should reject an invalid query parameter with 400', async () => {
+      const response = await listAlerts(createMockGetRequest('/api/v2/alerts', { severity: 'nuclear' }));
+      expect(response.status).toBe(400);
+    });
+
+    it('should allow a member to read', async () => {
+      mockAuthAsMember();
+      await AlertV2.create(createAlertInput({ status: 'firing' }));
+
+      const response = await listAlerts(createMockGetRequest('/api/v2/alerts'));
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe('GET /api/v2/alerts/[id]', () => {
+    it('should return a single alert', async () => {
+      const alert = await AlertV2.create(createAlertInput({ status: 'firing' }));
+
+      const response = await getAlert(
+        createMockGetRequest(`/api/v2/alerts/${alert._id}`),
+        { params: params(String(alert._id)) }
+      );
+      const body = await parseResponse<{ data: { _id: string } }>(response);
+
+      expect(response.status).toBe(200);
+      expect(body.data._id).toBe(String(alert._id));
+    });
+
+    it('should include device details when requested', async () => {
+      await DeviceV2.create(createDeviceInput({ _id: 'device_detail' }));
+      const alert = await AlertV2.create(
+        createAlertInput({ status: 'firing', device_id: 'device_detail' })
+      );
+
+      const response = await getAlert(
+        createMockGetRequest(`/api/v2/alerts/${alert._id}`, { include_device: 'true' }),
+        { params: params(String(alert._id)) }
+      );
+      const body = await parseResponse<{ data: { device: { _id: string } | null } }>(response);
+
+      expect(body.data.device?._id).toBe('device_detail');
+    });
+
+    it('should return null device when the device is gone', async () => {
+      const alert = await AlertV2.create(
+        createAlertInput({ status: 'firing', device_id: 'device_vanished' })
+      );
+
+      const response = await getAlert(
+        createMockGetRequest(`/api/v2/alerts/${alert._id}`, { include_device: 'true' }),
+        { params: params(String(alert._id)) }
+      );
+      const body = await parseResponse<{ data: { device: unknown } }>(response);
+
+      expect(body.data.device).toBeNull();
+    });
+
+    it('should 404 for an unknown id', async () => {
+      const id = String(new Types.ObjectId());
+
+      const response = await getAlert(
+        createMockGetRequest(`/api/v2/alerts/${id}`),
+        { params: params(id) }
+      );
+      const body = await parseResponse<{ error: { code: string } }>(response);
+
+      expect(response.status).toBe(404);
+      expect(body.error.code).toBe('ALERT_NOT_FOUND');
+    });
+
+    it('should 400 for a malformed id', async () => {
+      const response = await getAlert(
+        createMockGetRequest('/api/v2/alerts/nope'),
+        { params: params('nope') }
+      );
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe('PATCH /api/v2/alerts/[id]', () => {
+    it('should acknowledge a firing alert', async () => {
+      const alert = await AlertV2.create(createAlertInput({ status: 'firing' }));
+
+      const response = await PATCH(
+        createMockPatchRequest(`/api/v2/alerts/${alert._id}`, { status: 'acknowledged' }),
+        { params: params(String(alert._id)) }
+      );
+      const body = await parseResponse<{ data: { status: string; is_open: boolean } }>(response);
+
+      expect(response.status).toBe(200);
+      expect(body.data.status).toBe('acknowledged');
+      expect(body.data.is_open).toBe(true);
+    });
+
+    it('should resolve a firing alert and record a manual resolution', async () => {
+      const alert = await AlertV2.create(createAlertInput({ status: 'firing' }));
+
+      const response = await PATCH(
+        createMockPatchRequest(`/api/v2/alerts/${alert._id}`, { status: 'resolved', note: 'Swapped sensor' }),
+        { params: params(String(alert._id)) }
+      );
+      const body = await parseResponse<{
+        data: { status: string; is_open: boolean; audit: { resolution: string; note?: string } };
+      }>(response);
+
+      expect(body.data.status).toBe('resolved');
+      expect(body.data.is_open).toBe(false);
+      expect(body.data.audit.resolution).toBe('manual');
+      expect(body.data.audit.note).toBe('Swapped sensor');
+    });
+
+    it('should return 422 ALERT_ALREADY_ACKNOWLEDGED', async () => {
+      const alert = await AlertV2.create(createAlertInput({ status: 'acknowledged' }));
+
+      const response = await PATCH(
+        createMockPatchRequest(`/api/v2/alerts/${alert._id}`, { status: 'acknowledged' }),
+        { params: params(String(alert._id)) }
+      );
+      const body = await parseResponse<{ error: { code: string } }>(response);
+
+      expect(response.status).toBe(422);
+      expect(body.error.code).toBe('ALERT_ALREADY_ACKNOWLEDGED');
+    });
+
+    it('should return 422 ALERT_ALREADY_RESOLVED', async () => {
+      const alert = await AlertV2.create(createAlertInput({ status: 'resolved', is_open: false }));
+
+      const response = await PATCH(
+        createMockPatchRequest(`/api/v2/alerts/${alert._id}`, { status: 'resolved' }),
+        { params: params(String(alert._id)) }
+      );
+      const body = await parseResponse<{ error: { code: string } }>(response);
+
+      expect(response.status).toBe(422);
+      expect(body.error.code).toBe('ALERT_ALREADY_RESOLVED');
+    });
+
+    it('should return 422 INVALID_ALERT_STATUS_TRANSITION for a pending alert', async () => {
+      const alert = await AlertV2.create(createAlertInput({ status: 'pending' }));
+
+      const response = await PATCH(
+        createMockPatchRequest(`/api/v2/alerts/${alert._id}`, { status: 'acknowledged' }),
+        { params: params(String(alert._id)) }
+      );
+      const body = await parseResponse<{ error: { code: string } }>(response);
+
+      expect(response.status).toBe(422);
+      expect(body.error.code).toBe('INVALID_ALERT_STATUS_TRANSITION');
+    });
+
+    it('should 403 for a member', async () => {
+      mockAuthAsMember();
+      const alert = await AlertV2.create(createAlertInput({ status: 'firing' }));
+
+      const response = await PATCH(
+        createMockPatchRequest(`/api/v2/alerts/${alert._id}`, { status: 'acknowledged' }),
+        { params: params(String(alert._id)) }
+      );
+
+      expect(response.status).toBe(403);
+    });
+
+    it('should 400 for an unsupported status', async () => {
+      const alert = await AlertV2.create(createAlertInput({ status: 'firing' }));
+
+      const response = await PATCH(
+        createMockPatchRequest(`/api/v2/alerts/${alert._id}`, { status: 'firing' }),
+        { params: params(String(alert._id)) }
+      );
+
+      expect(response.status).toBe(400);
+    });
+
+    it('should 404 for an unknown id', async () => {
+      const id = String(new Types.ObjectId());
+
+      const response = await PATCH(
+        createMockPatchRequest(`/api/v2/alerts/${id}`, { status: 'acknowledged' }),
+        { params: params(id) }
+      );
+
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/__tests__/integration/api/alerts.integration.test.ts
+++ b/__tests__/integration/api/alerts.integration.test.ts
@@ -120,6 +120,113 @@ describe('Alerts API Integration Tests', () => {
       const response = await listAlerts(createMockGetRequest('/api/v2/alerts'));
       expect(response.status).toBe(200);
     });
+
+    // The date range must filter on `fired_at` (the visible domain event), not
+    // `audit.created_at` (stamped when the invisible `pending` episode is first
+    // created). With a non-zero for_duration_seconds those two timestamps
+    // diverge by the whole duration, so each alert below is built so that
+    // filtering on the wrong field returns the wrong alert entirely — these
+    // tests would fail if the route reverted to `audit.created_at`.
+    describe('date range filtering (fired_at, not audit.created_at)', () => {
+      const t1 = new Date('2026-01-01T08:00:00.000Z');
+      const t2 = new Date('2026-01-01T09:00:00.000Z');
+      const t3 = new Date('2026-01-01T09:30:00.000Z');
+      const t4 = new Date('2026-01-01T10:00:00.000Z');
+
+      function auditAt(created_at: Date) {
+        return { created_at, created_by: 'system', updated_at: created_at, updated_by: 'system' };
+      }
+
+      it('should return the alert whose fired_at falls in the window, not the one whose audit.created_at does', async () => {
+        // In range by fired_at, out of range by audit.created_at.
+        await AlertV2.create(
+          createAlertInput({
+            status: 'firing',
+            device_id: 'device_fired_in_window',
+            fired_at: t2,
+            audit: auditAt(t1),
+          })
+        );
+        // Out of range by fired_at, in range by audit.created_at.
+        await AlertV2.create(
+          createAlertInput({
+            status: 'firing',
+            device_id: 'device_created_in_window',
+            fired_at: t1,
+            audit: auditAt(t2),
+          })
+        );
+
+        const response = await listAlerts(
+          createMockGetRequest('/api/v2/alerts', {
+            startDate: t2.toISOString(),
+            endDate: t3.toISOString(),
+          })
+        );
+        const body = await parseResponse<{ data: Array<{ device_id: string }> }>(response);
+
+        expect(body.data).toHaveLength(1);
+        expect(body.data[0].device_id).toBe('device_fired_in_window');
+      });
+
+      it('should filter by fired_at with startDate only', async () => {
+        // fired_at after the cutoff, audit.created_at before it.
+        await AlertV2.create(
+          createAlertInput({
+            status: 'firing',
+            device_id: 'device_fired_after_cutoff',
+            fired_at: t4,
+            audit: auditAt(t1),
+          })
+        );
+        // fired_at before the cutoff, audit.created_at after it.
+        await AlertV2.create(
+          createAlertInput({
+            status: 'firing',
+            device_id: 'device_created_after_cutoff',
+            fired_at: t1,
+            audit: auditAt(t4),
+          })
+        );
+
+        const response = await listAlerts(
+          createMockGetRequest('/api/v2/alerts', { startDate: t3.toISOString() })
+        );
+        const body = await parseResponse<{ data: Array<{ device_id: string }> }>(response);
+
+        expect(body.data).toHaveLength(1);
+        expect(body.data[0].device_id).toBe('device_fired_after_cutoff');
+      });
+
+      it('should filter by fired_at with endDate only', async () => {
+        // fired_at before the cutoff, audit.created_at after it.
+        await AlertV2.create(
+          createAlertInput({
+            status: 'firing',
+            device_id: 'device_fired_before_cutoff',
+            fired_at: t1,
+            audit: auditAt(t4),
+          })
+        );
+        // fired_at after the cutoff, audit.created_at before it.
+        await AlertV2.create(
+          createAlertInput({
+            status: 'firing',
+            device_id: 'device_created_before_cutoff',
+            fired_at: t4,
+            audit: auditAt(t1),
+          })
+        );
+
+        const response = await listAlerts(
+          createMockGetRequest('/api/v2/alerts', { endDate: t2.toISOString() })
+        );
+        const body = await parseResponse<{ data: Array<{ device_id: string }> }>(response);
+
+        expect(body.data).toHaveLength(1);
+        expect(body.data[0].device_id).toBe('device_fired_before_cutoff');
+      });
+    });
   });
 
   describe('GET /api/v2/alerts/[id]', () => {

--- a/__tests__/integration/api/alerts.integration.test.ts
+++ b/__tests__/integration/api/alerts.integration.test.ts
@@ -7,7 +7,7 @@ import { Types } from 'mongoose';
 import AlertV2 from '@/models/v2/AlertV2';
 import DeviceV2 from '@/models/v2/DeviceV2';
 import { createAlertInput, createDeviceInput, resetCounters } from '../../setup/factories';
-import { mockAuthAsAdmin, mockAuthAsMember } from '../../setup/auth-helpers';
+import { mockAuthAsAdmin, mockAuthAsMember, mockAuthAsUnauthenticated } from '../../setup/auth-helpers';
 
 import { GET as listAlerts } from '@/app/api/v2/alerts/route';
 import { GET as getAlert, PATCH } from '@/app/api/v2/alerts/[id]/route';
@@ -315,6 +315,34 @@ describe('Alerts API Integration Tests', () => {
         { params: params('nope') }
       );
       expect(response.status).toBe(400);
+    });
+
+    // requireOrgMembership() guards this handler in code but, unlike the list
+    // endpoint above, had no test exercising either the member-allowed path or
+    // the unauthenticated-rejected path — a silent removal of the guard would
+    // break zero tests.
+    it('should allow a member to read a single alert', async () => {
+      mockAuthAsMember();
+      const alert = await AlertV2.create(createAlertInput({ status: 'firing' }));
+
+      const response = await getAlert(
+        createMockGetRequest(`/api/v2/alerts/${alert._id}`),
+        { params: params(String(alert._id)) }
+      );
+
+      expect(response.status).toBe(200);
+    });
+
+    it('should reject an unauthenticated request', async () => {
+      mockAuthAsUnauthenticated();
+      const id = String(new Types.ObjectId());
+
+      const response = await getAlert(
+        createMockGetRequest(`/api/v2/alerts/${id}`),
+        { params: params(id) }
+      );
+
+      expect(response.status).toBe(401);
     });
   });
 

--- a/__tests__/integration/api/alerts.integration.test.ts
+++ b/__tests__/integration/api/alerts.integration.test.ts
@@ -13,6 +13,18 @@ import { mockAuthAsAdmin, mockAuthAsMember, mockAuthAsUnauthenticated } from '..
 import { GET as listAlerts } from '@/app/api/v2/alerts/route';
 import { GET as getAlert, PATCH } from '@/app/api/v2/alerts/[id]/route';
 
+// Mock Pusher to avoid network errors in tests. A manual resolve now
+// broadcasts via publishAlertEvents (Task 13), which every PATCH test below
+// reaches unless it separately spies on '@/lib/alerting' — this mock only
+// replaces the underlying pusherServer.trigger, so it composes with that spy
+// rather than fighting it: when publishAlertEvents itself is mocked, this
+// mock is simply never reached.
+jest.mock('@/lib/pusher', () => ({
+  pusherServer: {
+    trigger: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
 function createMockGetRequest(path: string, searchParams: Record<string, string> = {}): NextRequest {
   const url = new URL(`http://localhost:3000${path}`);
   Object.entries(searchParams).forEach(([k, v]) => url.searchParams.set(k, v));

--- a/__tests__/integration/api/alerts.integration.test.ts
+++ b/__tests__/integration/api/alerts.integration.test.ts
@@ -465,6 +465,24 @@ describe('Alerts API Integration Tests', () => {
       expect(body.error.code).toBe('ALERT_NOT_FOUND');
     });
 
+    // `pending` is internal (see the list endpoint's own header comment and
+    // its `VISIBLE_STATUSES` filter, which excludes it from every list
+    // response) — a `pending` alert existing in the collection must not be
+    // fetchable by id either, or the two endpoints disagree about what
+    // "exists" means for the same resource.
+    it('should 404 for a pending alert, matching the list endpoint\'s contract', async () => {
+      const alert = await AlertV2.create(createAlertInput({ status: 'pending', is_open: true }));
+
+      const response = await getAlert(
+        createMockGetRequest(`/api/v2/alerts/${alert._id}`),
+        { params: params(String(alert._id)) }
+      );
+      const body = await parseResponse<{ error: { code: string } }>(response);
+
+      expect(response.status).toBe(404);
+      expect(body.error.code).toBe('ALERT_NOT_FOUND');
+    });
+
     it('should 400 for a malformed id', async () => {
       const response = await getAlert(
         createMockGetRequest('/api/v2/alerts/nope'),
@@ -633,6 +651,179 @@ describe('Alerts API Integration Tests', () => {
       );
 
       expect(response.status).toBe(404);
+    });
+  });
+
+  // ==========================================================================
+  // DEMO MODE REDACTION (Critical finding from the whole-branch review)
+  // ==========================================================================
+  //
+  // getAuditUser() (lib/auth/index.ts) resolves audit.*_by fields to the
+  // acting admin's Clerk EMAIL whenever one is on file. requireOrgMembership()
+  // grants an anonymous demo-mode visitor the same read access as a real org
+  // member, so without server-side redaction every GET here would hand a
+  // stranger a real administrator's email. Each pair below proves BOTH
+  // halves of the contract: a demo caller gets no email anywhere in the
+  // payload, and a genuinely authenticated admin still gets the real value —
+  // a redaction that fired unconditionally would pass a demo-only test suite
+  // while silently breaking the feature for every real user.
+  describe('demo mode redaction', () => {
+    const originalDemoMode = process.env.DEMO_MODE;
+
+    afterEach(() => {
+      if (originalDemoMode === undefined) delete process.env.DEMO_MODE;
+      else process.env.DEMO_MODE = originalDemoMode;
+    });
+
+    /** Simulate an anonymous visitor on a demo deployment: no session, DEMO_MODE on. */
+    function mockDemoVisitor() {
+      process.env.DEMO_MODE = 'true';
+      mockAuthAsUnauthenticated();
+    }
+
+    function auditWithRealEmail(overrides: Record<string, unknown>) {
+      const now = new Date();
+      return {
+        created_at: now,
+        created_by: 'admin@example.com',
+        updated_at: now,
+        updated_by: 'admin@example.com',
+        ...overrides,
+      };
+    }
+
+    it('should redact audit actor fields for a demo-mode list request', async () => {
+      mockDemoVisitor();
+      await AlertV2.create(
+        createAlertInput({
+          status: 'acknowledged',
+          audit: auditWithRealEmail({
+            acknowledged_at: new Date(),
+            acknowledged_by: 'admin@example.com',
+          }),
+        })
+      );
+
+      const response = await listAlerts(createMockGetRequest('/api/v2/alerts'));
+      const body = await parseResponse<unknown>(response);
+
+      expect(response.status).toBe(200);
+      // Blunt but robust: no value anywhere in the payload may contain an
+      // email address when the caller is the anonymous demo visitor — this
+      // would still catch a leak through a field nobody thought to name.
+      expect(JSON.stringify(body)).not.toContain('@');
+    });
+
+    it('should still return the real actor to a genuinely authenticated admin (list)', async () => {
+      mockAuthAsAdmin();
+      await AlertV2.create(
+        createAlertInput({
+          status: 'acknowledged',
+          audit: auditWithRealEmail({
+            acknowledged_at: new Date(),
+            acknowledged_by: 'admin@example.com',
+          }),
+        })
+      );
+
+      const response = await listAlerts(createMockGetRequest('/api/v2/alerts'));
+      const body = await parseResponse<{ data: Array<{ audit: { acknowledged_by?: string } }> }>(
+        response
+      );
+
+      expect(response.status).toBe(200);
+      expect(body.data[0].audit.acknowledged_by).toBe('admin@example.com');
+    });
+
+    it('should redact audit actor fields for a demo-mode single-alert request', async () => {
+      const alert = await AlertV2.create(
+        createAlertInput({
+          status: 'resolved',
+          is_open: false,
+          audit: auditWithRealEmail({
+            resolved_at: new Date(),
+            resolved_by: 'admin@example.com',
+            resolution: 'manual',
+          }),
+        })
+      );
+      mockDemoVisitor();
+
+      const response = await getAlert(createMockGetRequest(`/api/v2/alerts/${alert._id}`), {
+        params: params(String(alert._id)),
+      });
+      const body = await parseResponse<unknown>(response);
+
+      expect(response.status).toBe(200);
+      expect(JSON.stringify(body)).not.toContain('@');
+    });
+
+    it('should still return the real actor to a genuinely authenticated admin (single alert)', async () => {
+      const alert = await AlertV2.create(
+        createAlertInput({
+          status: 'resolved',
+          is_open: false,
+          audit: auditWithRealEmail({
+            resolved_at: new Date(),
+            resolved_by: 'admin@example.com',
+            resolution: 'manual',
+          }),
+        })
+      );
+
+      const response = await getAlert(createMockGetRequest(`/api/v2/alerts/${alert._id}`), {
+        params: params(String(alert._id)),
+      });
+      const body = await parseResponse<{ data: { audit: { resolved_by?: string } } }>(response);
+
+      expect(response.status).toBe(200);
+      expect(body.data.audit.resolved_by).toBe('admin@example.com');
+    });
+
+    it('should leave a system actor alone for a demo-mode reader, not misrepresent it as an admin', async () => {
+      // Factory default audit for a resolved alert is created_by/updated_by/
+      // resolved_by: 'system' — an auto-resolution, not a human action.
+      const alert = await AlertV2.create(createAlertInput({ status: 'resolved', is_open: false }));
+      mockDemoVisitor();
+
+      const response = await getAlert(createMockGetRequest(`/api/v2/alerts/${alert._id}`), {
+        params: params(String(alert._id)),
+      });
+      const body = await parseResponse<{ data: { audit: { resolved_by?: string } } }>(response);
+
+      expect(body.data.audit.resolved_by).toBe('system');
+    });
+
+    // PATCH is requireAdmin()-only, so a demo-mode visitor 403s before the
+    // handler can construct a response at all. This documents WHY redacting
+    // the PATCH response (added alongside GET, for the same endpoint file)
+    // is defense in depth rather than something a demo caller can presently
+    // trigger — the hard requirement is GET, which a demo visitor can reach.
+    it('should 403 a demo-mode visitor attempting to PATCH, never reaching the response body', async () => {
+      const alert = await AlertV2.create(createAlertInput({ status: 'firing' }));
+      mockDemoVisitor();
+
+      const response = await PATCH(
+        createMockPatchRequest(`/api/v2/alerts/${alert._id}`, { status: 'acknowledged' }),
+        { params: params(String(alert._id)) }
+      );
+
+      expect(response.status).toBe(403);
+    });
+
+    it('should still return the real actor to a genuinely authenticated admin (PATCH)', async () => {
+      const alert = await AlertV2.create(createAlertInput({ status: 'firing' }));
+
+      const response = await PATCH(
+        createMockPatchRequest(`/api/v2/alerts/${alert._id}`, { status: 'acknowledged' }),
+        { params: params(String(alert._id)) }
+      );
+      const body = await parseResponse<{ data: { audit: { acknowledged_by?: string } } }>(
+        response
+      );
+
+      expect(response.status).toBe(200);
+      expect(body.data.audit.acknowledged_by).toBe('admin@example.com');
     });
   });
 });

--- a/__tests__/integration/api/alerts.integration.test.ts
+++ b/__tests__/integration/api/alerts.integration.test.ts
@@ -6,6 +6,7 @@ import { NextRequest } from 'next/server';
 import { Types } from 'mongoose';
 import AlertV2 from '@/models/v2/AlertV2';
 import DeviceV2 from '@/models/v2/DeviceV2';
+import * as alerting from '@/lib/alerting';
 import { createAlertInput, createDeviceInput, resetCounters } from '../../setup/factories';
 import { mockAuthAsAdmin, mockAuthAsMember, mockAuthAsUnauthenticated } from '../../setup/auth-helpers';
 
@@ -519,6 +520,22 @@ describe('Alerts API Integration Tests', () => {
       expect(body.data.is_open).toBe(false);
       expect(body.data.audit.resolution).toBe('manual');
       expect(body.data.audit.note).toBe('Swapped sensor');
+    });
+
+    it('should broadcast a manual resolution with the user id, never an email', async () => {
+      const spy = jest.spyOn(alerting, 'publishAlertEvents').mockResolvedValue(undefined);
+      const alert = await AlertV2.create(createAlertInput({ status: 'firing' }));
+
+      await PATCH(
+        createMockPatchRequest(`/api/v2/alerts/${alert._id}`, { status: 'resolved' }),
+        { params: params(String(alert._id)) }
+      );
+
+      const [, resolvedArg] = spy.mock.calls[0];
+      expect(resolvedArg[0].actor).toBe('user_test_admin');
+      expect(resolvedArg[0].actor).not.toContain('@');
+
+      spy.mockRestore();
     });
 
     it('should not expose the internal __v field on the updated alert', async () => {

--- a/__tests__/integration/api/alerts.integration.test.ts
+++ b/__tests__/integration/api/alerts.integration.test.ts
@@ -113,6 +113,18 @@ describe('Alerts API Integration Tests', () => {
       expect(response.status).toBe(400);
     });
 
+    // __v is Mongoose's internal version key. It is not part of AlertV2Response
+    // (types/v2/alert.types.ts) and must never reach a client.
+    it('should not expose the internal __v field', async () => {
+      await AlertV2.create(createAlertInput({ status: 'firing' }));
+
+      const response = await listAlerts(createMockGetRequest('/api/v2/alerts'));
+      const body = await parseResponse<{ data: Array<Record<string, unknown>> }>(response);
+
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0]).not.toHaveProperty('__v');
+    });
+
     it('should allow a member to read', async () => {
       mockAuthAsMember();
       await AlertV2.create(createAlertInput({ status: 'firing' }));
@@ -243,6 +255,18 @@ describe('Alerts API Integration Tests', () => {
       expect(body.data._id).toBe(String(alert._id));
     });
 
+    it('should not expose the internal __v field', async () => {
+      const alert = await AlertV2.create(createAlertInput({ status: 'firing' }));
+
+      const response = await getAlert(
+        createMockGetRequest(`/api/v2/alerts/${alert._id}`),
+        { params: params(String(alert._id)) }
+      );
+      const body = await parseResponse<{ data: Record<string, unknown> }>(response);
+
+      expect(body.data).not.toHaveProperty('__v');
+    });
+
     it('should include device details when requested', async () => {
       await DeviceV2.create(createDeviceInput({ _id: 'device_detail' }));
       const alert = await AlertV2.create(
@@ -324,6 +348,18 @@ describe('Alerts API Integration Tests', () => {
       expect(body.data.is_open).toBe(false);
       expect(body.data.audit.resolution).toBe('manual');
       expect(body.data.audit.note).toBe('Swapped sensor');
+    });
+
+    it('should not expose the internal __v field on the updated alert', async () => {
+      const alert = await AlertV2.create(createAlertInput({ status: 'firing' }));
+
+      const response = await PATCH(
+        createMockPatchRequest(`/api/v2/alerts/${alert._id}`, { status: 'acknowledged' }),
+        { params: params(String(alert._id)) }
+      );
+      const body = await parseResponse<{ data: Record<string, unknown> }>(response);
+
+      expect(body.data).not.toHaveProperty('__v');
     });
 
     it('should return 422 ALERT_ALREADY_ACKNOWLEDGED', async () => {

--- a/__tests__/integration/api/ingest-rejection-observability.integration.test.ts
+++ b/__tests__/integration/api/ingest-rejection-observability.integration.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Ingest rejection observability (A4) — cron simulate AND production ingest.
+ *
+ * Both write paths compute a rejected count and both used to put it ONLY in the
+ * response body, on a 2xx. No log at a level anyone alerts on, and — on the cron
+ * path — no metric at all.
+ *
+ * Why that is worse than an ordinary missing log: a reading that never persisted
+ * is never handed to `evaluateReadings`, so `last_observed_at` stops advancing
+ * on every open alert. After `ALERT_STALE_AFTER_SECONDS` the staleness sweep
+ * auto-resolves all of them as `stale`, and the dashboard goes green — BECAUSE
+ * ingest is down. The failure actively erases its own evidence, so the signal
+ * has to be emitted at the moment of rejection or it is not recoverable later.
+ *
+ * These tests assert on the three channels this repo actually has (structured
+ * log at a level matched to severity, the `recordIngestion` counter, and Sentry
+ * escalation on total failure) and, in every case, that the response contract is
+ * unchanged — this is observability, not behaviour.
+ *
+ * Sentry is asserted against the REAL `@sentry/nextjs` client (mocked here, but
+ * the same module singleton `instrumentation.ts` initializes in production)
+ * rather than against anything private to `lib/monitoring/sentry.ts`, which
+ * gates capture on `SENTRY_DSN` alone.
+ */
+
+import { NextRequest } from 'next/server';
+import * as SentryClient from '@sentry/nextjs';
+import DeviceV2 from '@/models/v2/DeviceV2';
+import ReadingV2, { type IReadingV2 } from '@/models/v2/ReadingV2';
+import { getMetricsSnapshot, logger, resetMetrics } from '@/lib/monitoring';
+import { createDeviceInput, resetCounters } from '../../setup/factories';
+
+import { GET as GET_SIMULATE_RAW } from '@/app/api/v2/cron/simulate/route';
+import { POST as POST_INGEST } from '@/app/api/v2/readings/ingest/route';
+
+jest.mock('@/lib/pusher', () => ({
+  pusherServer: { trigger: jest.fn().mockResolvedValue(undefined) },
+}));
+
+jest.mock('@sentry/nextjs', () => ({
+  init: jest.fn(),
+  captureException: jest.fn().mockReturnValue('ingest-event-id'),
+  captureMessage: jest.fn(),
+  addBreadcrumb: jest.fn(),
+  setUser: jest.fn(),
+  setTag: jest.fn(),
+  setExtra: jest.fn(),
+  startInactiveSpan: jest.fn().mockReturnValue({ end: jest.fn() }),
+}));
+
+function callSimulate() {
+  return GET_SIMULATE_RAW(
+    new NextRequest('http://localhost:3000/api/v2/cron/simulate', {
+      headers: { Authorization: `Bearer ${process.env.SEED_SECRET}` },
+    })
+  );
+}
+
+function callIngest(readings: unknown[]) {
+  return POST_INGEST(
+    new NextRequest('http://localhost:3000/api/v2/readings/ingest', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ readings }),
+    })
+  );
+}
+
+function ingestItem(deviceId: string) {
+  return {
+    device_id: deviceId,
+    type: 'temperature',
+    unit: 'celsius',
+    value: 21.5,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function ingestionMetrics() {
+  return getMetricsSnapshot().ingestion as { total: number; errors: number };
+}
+
+describe('ingest rejection observability', () => {
+  const originalDsn = process.env.SENTRY_DSN;
+
+  beforeEach(() => {
+    resetCounters();
+    resetMetrics();
+    delete process.env.SENTRY_DSN;
+  });
+
+  afterAll(() => {
+    if (originalDsn === undefined) delete process.env.SENTRY_DSN;
+    else process.env.SENTRY_DSN = originalDsn;
+  });
+
+  // ==========================================================================
+  // GET /api/v2/cron/simulate
+  // ==========================================================================
+
+  describe('cron simulate route', () => {
+    beforeEach(async () => {
+      await DeviceV2.insertMany([
+        createDeviceInput({ _id: 'obs_sim_01', type: 'temperature' }),
+        createDeviceInput({ _id: 'obs_sim_02', type: 'temperature' }),
+        createDeviceInput({ _id: 'obs_sim_03', type: 'temperature' }),
+      ]);
+    });
+
+    /**
+     * Stand-in for bulkInsertReadings' real `{ ordered: false }` behavior: some
+     * documents are dropped and only the survivors come back, without throwing.
+     * Survivors carry a `toObject()` so the route's Pusher broadcast behaves as
+     * it would against the real Mongoose documents insertMany returns.
+     */
+    function insertOnly(count: number) {
+      return jest
+        .spyOn(ReadingV2, 'bulkInsertReadings')
+        .mockImplementation(
+          async readings =>
+            readings.slice(0, count).map(r => ({ ...r, toObject: () => ({ ...r }) })) as unknown as IReadingV2[]
+        );
+    }
+
+    it('should warn and count a partial rejection', async () => {
+      const spy = insertOnly(2);
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+
+      const response = await callSimulate();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('partially rejected'),
+        expect.objectContaining({ generated: 3, inserted: 2, rejected: 1 })
+      );
+      // A partial rejection is a warning, not an outage.
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(SentryClient.captureException).not.toHaveBeenCalled();
+
+      expect(ingestionMetrics()).toMatchObject({ total: 2, errors: 1 });
+
+      // Response contract unchanged.
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ success: true, count: 2, rejected: 1 });
+
+      spy.mockRestore();
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('should log at error and escalate to Sentry when every reading is rejected', async () => {
+      process.env.SENTRY_DSN = 'https://example@sentry.invalid/1';
+      const spy = insertOnly(0);
+      const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+
+      const response = await callSimulate();
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('rejected every reading'),
+        expect.objectContaining({ generated: 3, inserted: 0, rejected: 3 })
+      );
+      expect(SentryClient.captureException).toHaveBeenCalledTimes(1);
+      expect(ingestionMetrics()).toMatchObject({ total: 0, errors: 3 });
+
+      // The dangerous part: the handler still reports success, which is exactly
+      // why the log and the metric have to carry the signal instead.
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ success: true, count: 0, rejected: 3 });
+
+      spy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('should stay quiet and still record the batch when nothing is rejected', async () => {
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+
+      const response = await callSimulate();
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+      // The counter still moves on a healthy run — without a denominator the
+      // error count above says nothing about the ingest success rate.
+      expect(ingestionMetrics()).toMatchObject({ total: 3, errors: 0 });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({ success: true, count: 3, rejected: 0 });
+
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+  });
+
+  // ==========================================================================
+  // POST /api/v2/readings/ingest — the real production path
+  // ==========================================================================
+
+  describe('readings ingest route', () => {
+    beforeEach(async () => {
+      await DeviceV2.insertMany([
+        createDeviceInput({ _id: 'obs_ing_01' }),
+        createDeviceInput({ _id: 'obs_ing_02' }),
+      ]);
+    });
+
+    it('should log at info when nothing is rejected', async () => {
+      const infoSpy = jest.spyOn(logger, 'info').mockImplementation(() => undefined);
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+
+      const response = await callIngest([ingestItem('obs_ing_01')]);
+
+      expect(response.status).toBe(201);
+      expect(infoSpy).toHaveBeenCalledWith(
+        'Readings ingested',
+        expect.objectContaining({ inserted: 1, rejected: 0 })
+      );
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      infoSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    it('should warn on a partial rejection instead of reporting it as a plain success', async () => {
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+
+      const response = await callIngest([ingestItem('obs_ing_01'), ingestItem('obs_ing_missing')]);
+
+      expect(response.status).toBe(201);
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Readings ingested with rejections',
+        expect.objectContaining({
+          inserted: 1,
+          rejected: 1,
+          rejectedUnknownDevice: 1,
+          rejectedAtInsert: 0,
+        })
+      );
+      expect(errorSpy).not.toHaveBeenCalled();
+
+      // Response contract unchanged.
+      expect(await response.json()).toMatchObject({
+        data: { inserted: 1, rejected: 1 },
+      });
+
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('should log at error and escalate when the datastore persists none of a valid batch', async () => {
+      process.env.SENTRY_DSN = 'https://example@sentry.invalid/1';
+      // The devices exist and the payload is valid — the writes themselves fail.
+      // This is the outage shape, and the one that starts the stale cascade.
+      const insertSpy = jest
+        .spyOn(ReadingV2, 'insertMany')
+        .mockResolvedValue([] as never);
+      const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+
+      const response = await callIngest([ingestItem('obs_ing_01'), ingestItem('obs_ing_02')]);
+
+      expect(response.status).toBe(201);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Readings ingest rejected every reading',
+        expect.objectContaining({ inserted: 0, rejected: 2, rejectedAtInsert: 2 })
+      );
+      expect(SentryClient.captureException).toHaveBeenCalledTimes(1);
+      expect(ingestionMetrics()).toMatchObject({ total: 0, errors: 2 });
+
+      insertSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('should log at error but NOT page anyone when every device id is simply unknown', async () => {
+      process.env.SENTRY_DSN = 'https://example@sentry.invalid/1';
+      const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+
+      const response = await callIngest([ingestItem('nobody_01'), ingestItem('nobody_02')]);
+
+      expect(response.status).toBe(201);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Readings ingest rejected every reading',
+        expect.objectContaining({
+          inserted: 0,
+          rejected: 2,
+          rejectedUnknownDevice: 2,
+          rejectedAtInsert: 0,
+        })
+      );
+      // A caller naming devices that do not exist is a client mistake, already
+      // itemized in the response's errors[]. Escalating it would train everyone
+      // to ignore the alert that matters.
+      expect(SentryClient.captureException).not.toHaveBeenCalled();
+
+      errorSpy.mockRestore();
+    });
+  });
+});

--- a/__tests__/integration/api/pusher-auth.integration.test.ts
+++ b/__tests__/integration/api/pusher-auth.integration.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Pusher Channel Authorization Integration Tests
+ *
+ * This route is the whole reason the alert channel can be `private-`. If it is
+ * wrong, one of two things happens and neither is loud:
+ *
+ *   - too permissive: it becomes a signing oracle. Anyone who can reach it gets
+ *     an authorization for any channel they name, and the private prefix buys
+ *     nothing. The `rejects a channel other than the alert channel` rows below
+ *     are the ones that catch that.
+ *
+ *   - wrong response shape: pusher-js parses the body itself and wants Pusher's
+ *     bare `{ auth: "<key>:<sig>" }`. Wrapping it in this repo's
+ *     `jsonSuccess()` envelope breaks subscription silently — 200 OK, no error
+ *     anywhere, no alert ever arrives. Hence the explicit "not the envelope"
+ *     assertions.
+ *
+ * `pusherServer` is NOT mocked. `authorizeChannel` is a local HMAC over the
+ * socket id and channel name — no network — so using the real thing asserts the
+ * real payload shape rather than whatever a mock was told to return.
+ */
+
+import { NextRequest } from 'next/server';
+import { POST as authorizeChannel } from '@/app/api/pusher/auth/route';
+import { ALERT_CHANNEL, READINGS_CHANNEL } from '@/lib/pusher-channels';
+import { auth, currentUser } from '@clerk/nextjs/server';
+
+jest.mock('@clerk/nextjs/server', () => ({
+  auth: jest.fn(),
+  currentUser: jest.fn(),
+}));
+
+const mockAuth = auth as jest.MockedFunction<typeof auth>;
+const mockCurrentUser = currentUser as jest.MockedFunction<typeof currentUser>;
+
+const SOCKET_ID = '123456.7891011';
+
+function mockSignedIn(role = 'org:admin', orgSlug = 'users') {
+  mockAuth.mockResolvedValue({
+    userId: 'user_test123',
+    orgId: 'org_test',
+    orgSlug,
+    orgRole: role,
+  } as Awaited<ReturnType<typeof auth>>);
+  mockCurrentUser.mockResolvedValue({
+    id: 'user_test123',
+    fullName: 'Test User',
+    firstName: 'Test',
+    lastName: 'User',
+    primaryEmailAddressId: 'email_1',
+    emailAddresses: [{ id: 'email_1', emailAddress: 'test@example.com' }],
+  } as Awaited<ReturnType<typeof currentUser>>);
+}
+
+function mockSignedOut() {
+  mockAuth.mockResolvedValue({
+    userId: null,
+    orgId: null,
+    orgSlug: null,
+    orgRole: null,
+  } as Awaited<ReturnType<typeof auth>>);
+  mockCurrentUser.mockResolvedValue(null);
+}
+
+/** Builds the form-encoded POST pusher-js's `ajax` transport actually sends. */
+function authRequest(channelName: string, socketId: string = SOCKET_ID): NextRequest {
+  return new NextRequest('http://localhost:3000/api/pusher/auth', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ socket_id: socketId, channel_name: channelName }).toString(),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // DEMO_MODE would hand an anonymous caller a synthetic member context.
+  delete process.env.DEMO_MODE;
+});
+
+describe('POST /api/pusher/auth', () => {
+  describe('authorized callers', () => {
+    it('authorizes an org member for the alert channel', async () => {
+      mockSignedIn('org:member');
+
+      const response = await authorizeChannel(authRequest(ALERT_CHANNEL));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      // Pusher's own shape: "<app key>:<hex signature>".
+      expect(typeof body.auth).toBe('string');
+      expect(body.auth).toMatch(/^test-key:[a-f0-9]+$/);
+    });
+
+    it('authorizes an org admin too — reading alerts is not an admin action', async () => {
+      mockSignedIn('org:admin');
+
+      const response = await authorizeChannel(authRequest(ALERT_CHANNEL));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(typeof body.auth).toBe('string');
+    });
+
+    it('returns the RAW Pusher payload, not this repo’s success envelope', async () => {
+      mockSignedIn('org:member');
+
+      const response = await authorizeChannel(authRequest(ALERT_CHANNEL));
+      const body = await response.json();
+
+      // pusher-js reads `auth` off the top level. `{ success, data: { auth } }`
+      // is a 200 that breaks subscription with no error anywhere.
+      expect(body).not.toHaveProperty('success');
+      expect(body).not.toHaveProperty('data');
+      expect(body).not.toHaveProperty('timestamp');
+      expect(Object.keys(body)).toContain('auth');
+    });
+
+    it('accepts a JSON body as well as a form body', async () => {
+      mockSignedIn('org:member');
+
+      const request = new NextRequest('http://localhost:3000/api/pusher/auth', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ socket_id: SOCKET_ID, channel_name: ALERT_CHANNEL }),
+      });
+      const response = await authorizeChannel(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(typeof body.auth).toBe('string');
+    });
+  });
+
+  describe('rejected callers', () => {
+    it('rejects a signed-out caller with 401', async () => {
+      mockSignedOut();
+
+      const response = await authorizeChannel(authRequest(ALERT_CHANNEL));
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('UNAUTHORIZED');
+      expect(body).not.toHaveProperty('auth');
+    });
+
+    it('rejects a signed-in user outside the allowed organization with 403', async () => {
+      mockSignedIn('org:member', 'some-other-org');
+
+      const response = await authorizeChannel(authRequest(ALERT_CHANNEL));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('FORBIDDEN');
+      expect(body).not.toHaveProperty('auth');
+    });
+
+    it('rejects a signed-in user with no organization at all with 403', async () => {
+      // Double cast: Clerk's signed-in auth object type requires a dozen
+      // session fields the route never reads, and a signed-in-but-org-less
+      // session does not structurally overlap either branch of the union.
+      mockAuth.mockResolvedValue({
+        userId: 'user_test123',
+        orgId: null,
+        orgSlug: null,
+        orgRole: null,
+      } as unknown as Awaited<ReturnType<typeof auth>>);
+      mockCurrentUser.mockResolvedValue({
+        id: 'user_test123',
+        fullName: 'Test User',
+        firstName: 'Test',
+        lastName: 'User',
+        primaryEmailAddressId: 'email_1',
+        emailAddresses: [{ id: 'email_1', emailAddress: 'test@example.com' }],
+      } as Awaited<ReturnType<typeof currentUser>>);
+
+      const response = await authorizeChannel(authRequest(ALERT_CHANNEL));
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe('channel allow-list', () => {
+    // A member IS allowed on the alert channel, so every row here isolates the
+    // channel check: same caller, different channel name.
+    beforeEach(() => mockSignedIn('org:member'));
+
+    it.each([
+      ['the public readings channel', READINGS_CHANNEL],
+      ['an arbitrary private channel', 'private-somebody-elses-tenant'],
+      ['a presence channel', 'presence-alerts'],
+      ['a look-alike prefix', `${ALERT_CHANNEL}-admin`],
+      ['an empty channel name', ''],
+    ])('rejects %s', async (_label, channelName) => {
+      const response = await authorizeChannel(authRequest(channelName));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('FORBIDDEN');
+      // The signature is the thing that must never leak for an unlisted channel.
+      expect(body).not.toHaveProperty('auth');
+    });
+
+    it('rejects even an admin asking for a channel outside the list', async () => {
+      mockSignedIn('org:admin');
+
+      const response = await authorizeChannel(authRequest('private-anything-else'));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body).not.toHaveProperty('auth');
+    });
+  });
+
+  describe('malformed requests', () => {
+    beforeEach(() => mockSignedIn('org:member'));
+
+    it.each([
+      ['a missing socket id', ''],
+      ['a non-numeric socket id', 'not-a-socket'],
+      ['a partial socket id', '123456'],
+    ])('rejects %s with 400', async (_label, socketId) => {
+      const response = await authorizeChannel(authRequest(ALERT_CHANNEL, socketId));
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body).not.toHaveProperty('auth');
+    });
+  });
+});

--- a/__tests__/integration/api/pusher-auth.integration.test.ts
+++ b/__tests__/integration/api/pusher-auth.integration.test.ts
@@ -181,6 +181,68 @@ describe('POST /api/pusher/auth', () => {
     });
   });
 
+  // ==========================================================================
+  // DEMO MODE
+  // ==========================================================================
+  //
+  // Every other row in this file runs with DEMO_MODE deleted, which is exactly
+  // why this block is needed: under DEMO_MODE=true `getAuthContext()` hands an
+  // anonymous visitor a synthetic `org:member` context, so
+  // `requireOrgMembership()` SUCCEEDS for a caller with no session at all. The
+  // "rejects a signed-out caller with 401" row above passes only because the
+  // env var is unset there.
+  //
+  // Nothing inside this handler used to notice. The single thing refusing the
+  // request was `proxy.ts`, whose demo bypass is limited to GET/HEAD — and
+  // middleware behaviour is not exercised by these tests at all. A route whose
+  // entire job is to be the second line of defense had one line of defense.
+  describe('demo mode', () => {
+    beforeEach(() => {
+      process.env.DEMO_MODE = 'true';
+    });
+
+    afterEach(() => {
+      delete process.env.DEMO_MODE;
+    });
+
+    it('refuses to sign the alert channel for an anonymous demo visitor', async () => {
+      mockSignedOut();
+
+      const response = await authorizeChannel(authRequest(ALERT_CHANNEL));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.success).toBe(false);
+      expect(body.error.code).toBe('FORBIDDEN');
+      // The signature is what must never be minted here: it is what would let
+      // an anonymous visitor join `private-alerts` and receive rule names,
+      // device ids, trigger values and resolver identities.
+      expect(body).not.toHaveProperty('auth');
+    });
+
+    it('refuses on identity alone, before the socket id is even parsed', async () => {
+      mockSignedOut();
+
+      // A malformed socket id must not be what saves us — the rejection has to
+      // be the demo check, so this stays 403 rather than becoming a 400.
+      const response = await authorizeChannel(authRequest(ALERT_CHANNEL, 'not-a-socket'));
+
+      expect(response.status).toBe(403);
+    });
+
+    it('still authorizes a genuinely signed-in member while demo mode is on', async () => {
+      // The rejection is keyed on the demo sentinel, not on the env var: a
+      // demo deployment must keep working for real users who sign in.
+      mockSignedIn('org:member');
+
+      const response = await authorizeChannel(authRequest(ALERT_CHANNEL));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(typeof body.auth).toBe('string');
+    });
+  });
+
   describe('channel allow-list', () => {
     // A member IS allowed on the alert channel, so every row here isolates the
     // channel check: same caller, different channel name.

--- a/__tests__/integration/api/readings-ingest.integration.test.ts
+++ b/__tests__/integration/api/readings-ingest.integration.test.ts
@@ -14,6 +14,15 @@ import * as evaluateModule from '@/lib/alerting/evaluate';
 import * as monitoring from '@/lib/monitoring';
 import { createDeviceInput, createAlertRuleInput, resetCounters } from '../../setup/factories';
 
+// Mock Pusher to avoid network errors in tests. A breaching ingested reading
+// fires an alert, which now broadcasts via publishAlertEvents (Task 13) —
+// see the "alert evaluation on the ingest path" tests below.
+jest.mock('@/lib/pusher', () => ({
+  pusherServer: {
+    trigger: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
 // We need to import and test the handler more directly
 // The route exports POST which is wrapped with middleware
 

--- a/__tests__/integration/api/readings-ingest.integration.test.ts
+++ b/__tests__/integration/api/readings-ingest.integration.test.ts
@@ -8,7 +8,10 @@
 import { NextRequest } from 'next/server';
 import DeviceV2 from '@/models/v2/DeviceV2';
 import ReadingV2 from '@/models/v2/ReadingV2';
-import { createDeviceInput, resetCounters } from '../../setup/factories';
+import AlertRuleV2 from '@/models/v2/AlertRuleV2';
+import AlertV2 from '@/models/v2/AlertV2';
+import * as evaluateModule from '@/lib/alerting/evaluate';
+import { createDeviceInput, createAlertRuleInput, resetCounters } from '../../setup/factories';
 
 // We need to import and test the handler more directly
 // The route exports POST which is wrapped with middleware
@@ -31,6 +34,13 @@ function createMockPostRequest(path: string, body: unknown): NextRequest {
  */
 async function parseResponse<T>(response: Response): Promise<T> {
   return response.json();
+}
+
+/**
+ * Helper to seed a single device for alert-evaluation tests.
+ */
+async function seedDevice(id: string) {
+  return DeviceV2.create(createDeviceInput({ _id: id }));
 }
 
 describe('POST /api/v2/readings/ingest Integration Tests', () => {
@@ -1268,6 +1278,80 @@ describe('POST /api/v2/readings/ingest Integration Tests', () => {
         expect(data.data.errors.length).toBeLessThanOrEqual(10);
         expect(data.data.total_errors).toBe(15);
       }
+    });
+  });
+
+  // ==========================================================================
+  // ALERT EVALUATION TESTS
+  // ==========================================================================
+
+  describe('alert evaluation on the ingest path', () => {
+    it('should open a firing alert for a breaching ingested reading', async () => {
+      await seedDevice('device_alert_01');
+      await AlertRuleV2.create(
+        createAlertRuleInput({
+          name: 'Ingest high temp',
+          metric: 'value',
+          comparison: 'gt',
+          threshold: 30,
+          severity: 'critical',
+          selector: { types: ['temperature'] },
+        })
+      );
+
+      const { POST } = await import('@/app/api/v2/readings/ingest/route');
+
+      const request = createMockPostRequest('/api/v2/readings/ingest', {
+        readings: [
+          {
+            device_id: 'device_alert_01',
+            type: 'temperature',
+            unit: 'celsius',
+            value: 42,
+            timestamp: new Date().toISOString(),
+          },
+        ],
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(201);
+
+      const alert = await AlertV2.findOne({ device_id: 'device_alert_01' }).lean();
+      expect(alert).not.toBeNull();
+      expect(alert!.status).toBe('firing');
+    });
+
+    it('should still return 201 with readings persisted when evaluation throws', async () => {
+      await seedDevice('device_alert_02');
+      const spy = jest
+        .spyOn(evaluateModule, 'evaluateReadings')
+        .mockRejectedValueOnce(new Error('evaluator exploded'));
+
+      const { POST } = await import('@/app/api/v2/readings/ingest/route');
+
+      const request = createMockPostRequest('/api/v2/readings/ingest', {
+        readings: [
+          {
+            device_id: 'device_alert_02',
+            type: 'temperature',
+            unit: 'celsius',
+            value: 42,
+            timestamp: new Date().toISOString(),
+          },
+        ],
+      });
+
+      const response = await POST(request);
+      const body = await parseResponse<{ success: boolean; data: { inserted: number } }>(response);
+
+      // Prove the mocked rejection was actually reached, not merely that the
+      // route succeeds regardless of whether alerting runs at all.
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(response.status).toBe(201);
+      expect(body.data.inserted).toBe(1);
+      expect(await ReadingV2.countDocuments({ 'metadata.device_id': 'device_alert_02' })).toBe(1);
+
+      spy.mockRestore();
     });
   });
 });

--- a/__tests__/integration/api/readings-ingest.integration.test.ts
+++ b/__tests__/integration/api/readings-ingest.integration.test.ts
@@ -1375,5 +1375,99 @@ describe('POST /api/v2/readings/ingest Integration Tests', () => {
       spy.mockRestore();
       infoSpy.mockRestore();
     });
+
+    // The PR widened the device projection in the ingest route (`_id`, `type`,
+    // `location`, `metadata.tags`) specifically so selectors that key on more
+    // than `types` can match. The tests above only ever use `selector: {
+    // types: [...] }`, which needs no device fields at all, so a regression
+    // that narrowed the projection back to `{ _id: 1 }` would pass every
+    // existing test in this file. This test exercises every non-type selector
+    // dimension against a real device, with a negative twin that differs by
+    // exactly one field (floor) to prove the rule discriminates on selector
+    // fields rather than merely firing whenever device data is present.
+    it('should fire only for the device whose location and tags match the selector', async () => {
+      const matchingDevice = createDeviceInput({
+        _id: 'device_selector_match_ingest',
+        type: 'temperature',
+        location: {
+          building_id: 'building_selector_ingest',
+          floor: 7,
+          room_name: 'Selector Room',
+          zone: 'zone_selector',
+        },
+        metadata: { tags: ['hvac_critical'], department: 'Facilities' },
+      });
+      // Negative twin: identical selector-relevant fields except floor. If
+      // matching degenerated to "device data is present" rather than a real
+      // per-field comparison, this device would incorrectly fire too.
+      const wrongFloorDevice = createDeviceInput({
+        _id: 'device_selector_wrongfloor_ingest',
+        type: 'temperature',
+        location: {
+          building_id: 'building_selector_ingest',
+          floor: 9,
+          room_name: 'Other Room',
+          zone: 'zone_selector',
+        },
+        metadata: { tags: ['hvac_critical'], department: 'Facilities' },
+      });
+      await DeviceV2.insertMany([matchingDevice, wrongFloorDevice]);
+
+      const rule = await AlertRuleV2.create(
+        createAlertRuleInput({
+          name: 'Building/floor/zone/tag scoped rule',
+          metric: 'value',
+          comparison: 'gt',
+          threshold: 30,
+          severity: 'critical',
+          selector: {
+            types: ['temperature'],
+            building_id: 'building_selector_ingest',
+            floor: 7,
+            zone: 'zone_selector',
+            tags: ['hvac_critical'],
+          },
+        })
+      );
+
+      const { POST } = await import('@/app/api/v2/readings/ingest/route');
+
+      const request = createMockPostRequest('/api/v2/readings/ingest', {
+        readings: [
+          {
+            device_id: 'device_selector_match_ingest',
+            type: 'temperature',
+            unit: 'celsius',
+            value: 42, // breaches threshold of 30 for both devices equally
+            timestamp: new Date().toISOString(),
+          },
+          {
+            device_id: 'device_selector_wrongfloor_ingest',
+            type: 'temperature',
+            unit: 'celsius',
+            value: 42,
+            timestamp: new Date().toISOString(),
+          },
+        ],
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(201);
+
+      const matchedAlert = await AlertV2.findOne({
+        device_id: 'device_selector_match_ingest',
+      }).lean();
+      expect(matchedAlert).not.toBeNull();
+      expect(matchedAlert!.status).toBe('firing');
+      expect(String(matchedAlert!.rule_id)).toBe(String(rule._id));
+
+      // The negative twin breaches the same metric/threshold and shares every
+      // selector dimension except floor — if an alert exists for it, matching
+      // is not actually discriminating on the selector.
+      const unmatchedAlert = await AlertV2.findOne({
+        device_id: 'device_selector_wrongfloor_ingest',
+      }).lean();
+      expect(unmatchedAlert).toBeNull();
+    });
   });
 });

--- a/__tests__/integration/api/readings-ingest.integration.test.ts
+++ b/__tests__/integration/api/readings-ingest.integration.test.ts
@@ -11,6 +11,7 @@ import ReadingV2 from '@/models/v2/ReadingV2';
 import AlertRuleV2 from '@/models/v2/AlertRuleV2';
 import AlertV2 from '@/models/v2/AlertV2';
 import * as evaluateModule from '@/lib/alerting/evaluate';
+import * as monitoring from '@/lib/monitoring';
 import { createDeviceInput, createAlertRuleInput, resetCounters } from '../../setup/factories';
 
 // We need to import and test the handler more directly
@@ -1288,7 +1289,7 @@ describe('POST /api/v2/readings/ingest Integration Tests', () => {
   describe('alert evaluation on the ingest path', () => {
     it('should open a firing alert for a breaching ingested reading', async () => {
       await seedDevice('device_alert_01');
-      await AlertRuleV2.create(
+      const rule = await AlertRuleV2.create(
         createAlertRuleInput({
           name: 'Ingest high temp',
           metric: 'value',
@@ -1298,6 +1299,7 @@ describe('POST /api/v2/readings/ingest Integration Tests', () => {
           selector: { types: ['temperature'] },
         })
       );
+      const infoSpy = jest.spyOn(monitoring.logger, 'info');
 
       const { POST } = await import('@/app/api/v2/readings/ingest/route');
 
@@ -1319,6 +1321,17 @@ describe('POST /api/v2/readings/ingest Integration Tests', () => {
       const alert = await AlertV2.findOne({ device_id: 'device_alert_01' }).lean();
       expect(alert).not.toBeNull();
       expect(alert!.status).toBe('firing');
+
+      // A fired alert is a domain event in its own right and must be logged,
+      // with the rule and device it involves — not just counted.
+      expect(infoSpy).toHaveBeenCalledWith('Alert rules fired or resolved during ingest', {
+        fired: 1,
+        resolved: 0,
+        ruleIds: [String(rule._id)],
+        deviceIds: ['device_alert_01'],
+      });
+
+      infoSpy.mockRestore();
     });
 
     it('should still return 201 with readings persisted when evaluation throws', async () => {
@@ -1326,6 +1339,7 @@ describe('POST /api/v2/readings/ingest Integration Tests', () => {
       const spy = jest
         .spyOn(evaluateModule, 'evaluateReadings')
         .mockRejectedValueOnce(new Error('evaluator exploded'));
+      const infoSpy = jest.spyOn(monitoring.logger, 'info');
 
       const { POST } = await import('@/app/api/v2/readings/ingest/route');
 
@@ -1347,11 +1361,19 @@ describe('POST /api/v2/readings/ingest Integration Tests', () => {
       // Prove the mocked rejection was actually reached, not merely that the
       // route succeeds regardless of whether alerting runs at all.
       expect(spy).toHaveBeenCalledTimes(1);
+      // The empty fallback result must not be reported as if something fired
+      // or resolved — the new logging must not regress the existing isolation
+      // guarantee it sits next to.
+      expect(infoSpy).not.toHaveBeenCalledWith(
+        'Alert rules fired or resolved during ingest',
+        expect.anything()
+      );
       expect(response.status).toBe(201);
       expect(body.data.inserted).toBe(1);
       expect(await ReadingV2.countDocuments({ 'metadata.device_id': 'device_alert_02' })).toBe(1);
 
       spy.mockRestore();
+      infoSpy.mockRestore();
     });
   });
 });

--- a/__tests__/integration/api/readings-ingest.integration.test.ts
+++ b/__tests__/integration/api/readings-ingest.integration.test.ts
@@ -1479,4 +1479,189 @@ describe('POST /api/v2/readings/ingest Integration Tests', () => {
       expect(unmatchedAlert).toBeNull();
     });
   });
+
+  // ==========================================================================
+  // PARTIAL INSERT HANDLING (Important finding from the whole-branch review)
+  // ==========================================================================
+  //
+  // Mirrors simulate-cron.integration.test.ts's "partial insert handling"
+  // tests, which cover the same bug already fixed on the cron write path
+  // (commits 2480e01, 4cb3d26). This route builds `validReadings` (everything
+  // ATTEMPTED) before its batch-insert loop and, before this fix, evaluated
+  // alert rules against that array regardless of which documents actually
+  // landed in `readings_v2` — a reading that failed to insert could still
+  // fire an alert with a trigger_value from a row that does not exist.
+  //
+  // The rejection is driven through `ReadingV2.insertMany` itself (the exact
+  // call the route makes — it does not go through `bulkInsertReadings`),
+  // never by mocking what the evaluator receives: `evaluateSpy` below is a
+  // plain `jest.spyOn` with no `mockImplementation`, so it still calls
+  // through to the real `evaluateReadings` and the real bulk-write recovery
+  // logic in the route runs for real. A test that instead asserted on a
+  // value it invented independently of what actually persisted would pass
+  // even if the fix were reverted.
+  describe('partial insert handling', () => {
+    it('evaluates only the readings that actually persisted, never the full attempted batch', async () => {
+      await seedDevice('device_partial_ingest_01');
+      await seedDevice('device_partial_ingest_02');
+      await seedDevice('device_partial_ingest_03');
+
+      await AlertRuleV2.create(
+        createAlertRuleInput({
+          name: 'Partial insert rule',
+          metric: 'value',
+          comparison: 'gt',
+          threshold: 30,
+          severity: 'critical',
+          selector: { types: ['temperature'] },
+        })
+      );
+
+      // Real MongoBulkWriteError shape (see mongodb@7's mongodb.d.ts):
+      // `insertedIds` is an index -> _id map, keyed by position in the array
+      // passed to insertMany. Index 1 (the second reading, device_02) is the
+      // one that "failed" — 0 and 2 survived.
+      const bulkError = Object.assign(new Error('simulated partial bulk write failure'), {
+        insertedCount: 2,
+        insertedIds: { 0: 'inserted-id-0', 2: 'inserted-id-2' },
+        writeErrors: [{ index: 1, code: 121 }],
+      });
+      const insertManySpy = jest
+        .spyOn(ReadingV2, 'insertMany')
+        .mockRejectedValueOnce(bulkError as never);
+      const evaluateSpy = jest.spyOn(evaluateModule, 'evaluateReadings');
+
+      const { POST } = await import('@/app/api/v2/readings/ingest/route');
+
+      const request = createMockPostRequest('/api/v2/readings/ingest', {
+        readings: [
+          {
+            device_id: 'device_partial_ingest_01',
+            type: 'temperature',
+            unit: 'celsius',
+            value: 42, // breaches threshold of 30
+            timestamp: new Date().toISOString(),
+          },
+          {
+            device_id: 'device_partial_ingest_02',
+            type: 'temperature',
+            unit: 'celsius',
+            value: 42,
+            timestamp: new Date().toISOString(),
+          },
+          {
+            device_id: 'device_partial_ingest_03',
+            type: 'temperature',
+            unit: 'celsius',
+            value: 42,
+            timestamp: new Date().toISOString(),
+          },
+        ],
+      });
+
+      const response = await POST(request);
+      const body = await parseResponse<{
+        success: boolean;
+        data: { inserted: number; rejected: number };
+      }>(response);
+
+      expect(insertManySpy).toHaveBeenCalledTimes(1);
+      expect(response.status).toBe(201);
+      // The response must describe what was actually persisted, not what was
+      // merely attempted.
+      expect(body.data.inserted).toBe(2);
+      expect(body.data.rejected).toBe(1);
+
+      // The evaluator must receive exactly the two readings recovered via
+      // insertedIds (indices 0 and 2) — never index 1, which never
+      // persisted, and never the full 3-reading attempted batch.
+      expect(evaluateSpy).toHaveBeenCalledTimes(1);
+      const passedReadings = evaluateSpy.mock.calls[0][0];
+      expect(passedReadings).toHaveLength(2);
+      expect(passedReadings.map(r => r.metadata?.device_id).sort()).toEqual([
+        'device_partial_ingest_01',
+        'device_partial_ingest_03',
+      ]);
+
+      // Proves the exclusion is THIS specific reading, not just a count: the
+      // dropped device breaches the identical rule at the identical value as
+      // its two surviving peers, yet must have no alert at all.
+      const droppedAlert = await AlertV2.findOne({
+        device_id: 'device_partial_ingest_02',
+      }).lean();
+      expect(droppedAlert).toBeNull();
+
+      const survivorAlert = await AlertV2.findOne({
+        device_id: 'device_partial_ingest_01',
+      }).lean();
+      expect(survivorAlert).not.toBeNull();
+      expect(survivorAlert!.status).toBe('firing');
+
+      insertManySpy.mockRestore();
+      evaluateSpy.mockRestore();
+    });
+
+    it('treats a batch as contributing nothing to evaluation when insertedIds is unavailable', async () => {
+      await seedDevice('device_partial_noids_01');
+
+      await AlertRuleV2.create(
+        createAlertRuleInput({
+          name: 'No insertedIds rule',
+          metric: 'value',
+          comparison: 'gt',
+          threshold: 30,
+          severity: 'critical',
+          selector: { types: ['temperature'] },
+        })
+      );
+
+      // A bulk write error that reports a partial success (insertedCount > 0)
+      // but, unlike the driver's real MongoBulkWriteError, carries no
+      // insertedIds map — the deliberate under-approximation path.
+      const bulkError = Object.assign(new Error('partial failure without insertedIds'), {
+        insertedCount: 1,
+      });
+      const insertManySpy = jest
+        .spyOn(ReadingV2, 'insertMany')
+        .mockRejectedValueOnce(bulkError as never);
+      const evaluateSpy = jest.spyOn(evaluateModule, 'evaluateReadings');
+      const warnSpy = jest.spyOn(monitoring.logger, 'warn');
+
+      const { POST } = await import('@/app/api/v2/readings/ingest/route');
+
+      const request = createMockPostRequest('/api/v2/readings/ingest', {
+        readings: [
+          {
+            device_id: 'device_partial_noids_01',
+            type: 'temperature',
+            unit: 'celsius',
+            value: 42,
+            timestamp: new Date().toISOString(),
+          },
+        ],
+      });
+
+      const response = await POST(request);
+      const body = await parseResponse<{ data: { inserted: number } }>(response);
+
+      // Reporting still reflects the driver's insertedCount...
+      expect(response.status).toBe(201);
+      expect(body.data.inserted).toBe(1);
+      // ...but evaluation never runs: there is no way to identify which
+      // specific reading the count refers to, so the batch is excluded
+      // entirely rather than guessed at.
+      expect(evaluateSpy).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('insertedIds'),
+        expect.objectContaining({ insertedCount: 1 })
+      );
+
+      const alert = await AlertV2.findOne({ device_id: 'device_partial_noids_01' }).lean();
+      expect(alert).toBeNull();
+
+      insertManySpy.mockRestore();
+      evaluateSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+  });
 });

--- a/__tests__/integration/api/simulate-cron.integration.test.ts
+++ b/__tests__/integration/api/simulate-cron.integration.test.ts
@@ -8,8 +8,12 @@
 import { NextRequest } from 'next/server';
 import DeviceV2 from '@/models/v2/DeviceV2';
 import ReadingV2 from '@/models/v2/ReadingV2';
+import AlertRuleV2 from '@/models/v2/AlertRuleV2';
+import AlertV2 from '@/models/v2/AlertV2';
 import {
   createDeviceInput,
+  createAlertRuleInput,
+  createAlertInput,
   resetCounters,
   VALID_DEVICE_TYPES,
 } from '../../setup/factories';
@@ -638,6 +642,44 @@ describe('Simulate Cron API Integration Tests', () => {
       readings.forEach((r) => {
         expect(r.metadata.source).toBe('simulation');
       });
+    });
+  });
+
+  // ==========================================================================
+  // ALERT EVALUATION TESTS
+  // ==========================================================================
+
+  describe('alert evaluation on the cron path', () => {
+    it('should evaluate rules against simulated readings', async () => {
+      await DeviceV2.create(createDeviceInput({ _id: 'device_cron_01', type: 'temperature' }));
+      await AlertRuleV2.create(
+        createAlertRuleInput({
+          name: 'Any temperature',
+          metric: 'value',
+          comparison: 'gt',
+          threshold: -1000, // guaranteed to breach whatever the simulator emits
+          severity: 'info',
+          selector: { types: ['temperature'] },
+        })
+      );
+
+      const response = await GET_SIMULATE();
+      expect(response.status).toBe(200);
+
+      expect(await AlertV2.countDocuments({ status: 'firing' })).toBeGreaterThan(0);
+    });
+
+    it('should sweep an alert whose device no longer reports', async () => {
+      await DeviceV2.create(createDeviceInput({ _id: 'device_cron_02', type: 'temperature' }));
+      await AlertV2.create(
+        createAlertInput({ device_id: 'device_ghost', status: 'firing', is_open: true })
+      );
+
+      await GET_SIMULATE();
+
+      const swept = await AlertV2.findOne({ device_id: 'device_ghost' }).lean();
+      expect(swept!.status).toBe('resolved');
+      expect(swept!.audit.resolution).toBe('device_inactive');
     });
   });
 });

--- a/__tests__/integration/api/simulate-cron.integration.test.ts
+++ b/__tests__/integration/api/simulate-cron.integration.test.ts
@@ -11,6 +11,7 @@ import ReadingV2, { type IReadingV2 } from '@/models/v2/ReadingV2';
 import AlertRuleV2 from '@/models/v2/AlertRuleV2';
 import AlertV2 from '@/models/v2/AlertV2';
 import * as evaluateModule from '@/lib/alerting/evaluate';
+import * as sweepModule from '@/lib/alerting/sweep';
 import * as simulationModule from '@/lib/simulation/readings';
 import * as monitoring from '@/lib/monitoring';
 import {
@@ -736,6 +737,109 @@ describe('Simulate Cron API Integration Tests', () => {
 
       spy.mockRestore();
       infoSpy.mockRestore();
+    });
+
+    // safeSweepStaleAlerts is the only caller of sweepStaleAlerts, and the cron
+    // route is the only caller of safeSweepStaleAlerts — so a throwing sweep is
+    // otherwise uncovered anywhere in the suite. Mirrors the evaluateReadings
+    // throw test above: mock the RAW function the safe wrapper delegates to, so
+    // a regression that pointed the route at the raw, unwrapped sweep would
+    // surface here as a 500 instead of a 200.
+    it('should still return 200 with readings persisted when the staleness sweep throws', async () => {
+      await DeviceV2.create(
+        createDeviceInput({ _id: 'device_cron_sweep_throws', type: 'temperature' })
+      );
+      const spy = jest
+        .spyOn(sweepModule, 'sweepStaleAlerts')
+        .mockRejectedValueOnce(new Error('sweep exploded'));
+
+      const response = await GET_SIMULATE();
+      const body = await parseResponse<{ success: boolean }>(response);
+
+      // Prove the mocked rejection was actually reached, not merely that the
+      // route succeeds regardless of whether the sweep runs at all.
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(
+        await ReadingV2.countDocuments({ 'metadata.device_id': 'device_cron_sweep_throws' })
+      ).toBe(1);
+
+      spy.mockRestore();
+    });
+
+    // The PR widened the device projection in the cron route (`_id`, `type`,
+    // `location`, `metadata.tags`) specifically so selectors that key on more
+    // than `types` can match. The tests above only ever use `selector: {
+    // types: [...] }`, which needs no device fields at all, so a regression
+    // that narrowed the projection back to `{ _id: 1, type: 1, location: 1 }`
+    // (dropping only metadata.tags) would pass every existing test in this
+    // file. This test exercises every non-type selector dimension against a
+    // real device, with a negative twin that differs by exactly one field
+    // (floor) to prove the rule discriminates on selector fields rather than
+    // merely firing whenever device data is present.
+    it('should fire only for the device whose location and tags match the selector', async () => {
+      const matchingDevice = createDeviceInput({
+        _id: 'device_selector_match_cron',
+        type: 'temperature',
+        location: {
+          building_id: 'building_selector_cron',
+          floor: 4,
+          room_name: 'Selector Room',
+          zone: 'zone_selector_cron',
+        },
+        metadata: { tags: ['hvac_critical'], department: 'Facilities' },
+      });
+      // Negative twin: identical selector-relevant fields except floor. If
+      // matching degenerated to "device data is present" rather than a real
+      // per-field comparison, this device would incorrectly fire too.
+      const wrongFloorDevice = createDeviceInput({
+        _id: 'device_selector_wrongfloor_cron',
+        type: 'temperature',
+        location: {
+          building_id: 'building_selector_cron',
+          floor: 11,
+          room_name: 'Other Room',
+          zone: 'zone_selector_cron',
+        },
+        metadata: { tags: ['hvac_critical'], department: 'Facilities' },
+      });
+      await DeviceV2.insertMany([matchingDevice, wrongFloorDevice]);
+
+      const rule = await AlertRuleV2.create(
+        createAlertRuleInput({
+          name: 'Building/floor/zone/tag scoped rule',
+          metric: 'value',
+          comparison: 'gt',
+          threshold: -1000, // guaranteed to breach whatever the simulator emits
+          severity: 'critical',
+          selector: {
+            types: ['temperature'],
+            building_id: 'building_selector_cron',
+            floor: 4,
+            zone: 'zone_selector_cron',
+            tags: ['hvac_critical'],
+          },
+        })
+      );
+
+      const response = await GET_SIMULATE();
+      expect(response.status).toBe(200);
+
+      const matchedAlert = await AlertV2.findOne({
+        device_id: 'device_selector_match_cron',
+      }).lean();
+      expect(matchedAlert).not.toBeNull();
+      expect(matchedAlert!.status).toBe('firing');
+      expect(String(matchedAlert!.rule_id)).toBe(String(rule._id));
+
+      // The negative twin breaches the same metric/threshold and shares every
+      // selector dimension except floor — if an alert exists for it, matching
+      // is not actually discriminating on the selector.
+      const unmatchedAlert = await AlertV2.findOne({
+        device_id: 'device_selector_wrongfloor_cron',
+      }).lean();
+      expect(unmatchedAlert).toBeNull();
     });
   });
 

--- a/__tests__/integration/api/simulate-cron.integration.test.ts
+++ b/__tests__/integration/api/simulate-cron.integration.test.ts
@@ -10,6 +10,7 @@ import DeviceV2 from '@/models/v2/DeviceV2';
 import ReadingV2, { type IReadingV2 } from '@/models/v2/ReadingV2';
 import AlertRuleV2 from '@/models/v2/AlertRuleV2';
 import AlertV2 from '@/models/v2/AlertV2';
+import { pusherServer } from '@/lib/pusher';
 import * as evaluateModule from '@/lib/alerting/evaluate';
 import * as sweepModule from '@/lib/alerting/sweep';
 import * as simulationModule from '@/lib/simulation/readings';
@@ -899,6 +900,52 @@ describe('Simulate Cron API Integration Tests', () => {
 
       bulkInsertSpy.mockRestore();
       evaluateSpy.mockRestore();
+    });
+
+    // A rejected reading must never reach a connected client's tile as though
+    // it were stored. The rejection is driven through bulkInsertReadings
+    // itself (the same partial-insert stand-in as the test above), and the
+    // assertion reads the ACTUAL argument the route passed to the already-
+    // mocked pusherServer.trigger — not a value asserted independently of
+    // what the route computed, which would prove nothing about the wiring.
+    it('broadcasts only the readings that persisted, not every reading generated', async () => {
+      await DeviceV2.insertMany([
+        createDeviceInput({ _id: 'device_broadcast_01', type: 'temperature' }),
+        createDeviceInput({ _id: 'device_broadcast_02', type: 'temperature' }),
+        createDeviceInput({ _id: 'device_broadcast_03', type: 'temperature' }),
+      ]);
+
+      // 3 candidate readings in, only 2 "persisted". Each survivor is given a
+      // toObject() so `insertedReadings.map(r => r.toObject(...))` in the
+      // route behaves the way it would against real Mongoose documents
+      // returned by insertMany.
+      let insertedSubset: Partial<IReadingV2>[] = [];
+      const bulkInsertSpy = jest
+        .spyOn(ReadingV2, 'bulkInsertReadings')
+        .mockImplementation(async readings => {
+          insertedSubset = readings.slice(0, 2);
+          return insertedSubset.map(r => ({
+            ...r,
+            toObject: () => ({ ...r }),
+          })) as unknown as IReadingV2[];
+        });
+
+      const response = await GET_SIMULATE();
+      const data = await parseResponse<{ count: number; rejected: number }>(response);
+
+      expect(response.status).toBe(200);
+      expect(bulkInsertSpy.mock.calls[0][0]).toHaveLength(3);
+      expect(data.count).toBe(2);
+      expect(data.rejected).toBe(1);
+
+      const newReadingsCall = (pusherServer.trigger as jest.Mock).mock.calls.find(
+        call => call[1] === 'new-readings'
+      );
+      expect(newReadingsCall).toBeDefined();
+      // insertedReadings.length (2), never newReadings.length (3).
+      expect(newReadingsCall![2]).toHaveLength(2);
+
+      bulkInsertSpy.mockRestore();
     });
 
     it('must not count a reading bulkInsertReadings rejected toward the anomaly total', async () => {

--- a/__tests__/integration/api/simulate-cron.integration.test.ts
+++ b/__tests__/integration/api/simulate-cron.integration.test.ts
@@ -7,13 +7,15 @@
 
 import { NextRequest } from 'next/server';
 import DeviceV2 from '@/models/v2/DeviceV2';
-import ReadingV2 from '@/models/v2/ReadingV2';
+import ReadingV2, { type IReadingV2 } from '@/models/v2/ReadingV2';
 import AlertRuleV2 from '@/models/v2/AlertRuleV2';
 import AlertV2 from '@/models/v2/AlertV2';
 import * as evaluateModule from '@/lib/alerting/evaluate';
+import * as simulationModule from '@/lib/simulation/readings';
 import * as monitoring from '@/lib/monitoring';
 import {
   createDeviceInput,
+  createReadingV2Input,
   createAlertRuleInput,
   createAlertInput,
   resetCounters,
@@ -734,6 +736,116 @@ describe('Simulate Cron API Integration Tests', () => {
 
       spy.mockRestore();
       infoSpy.mockRestore();
+    });
+  });
+
+  // ==========================================================================
+  // PARTIAL INSERT HANDLING TESTS
+  // ==========================================================================
+
+  describe('partial insert handling', () => {
+    it('evaluates and reports only the readings bulkInsertReadings actually inserted', async () => {
+      // Three active devices so the mocked partial insert below has a real
+      // remainder to reject, not an all-or-nothing case.
+      await DeviceV2.insertMany([
+        createDeviceInput({ _id: 'device_partial_01', type: 'temperature' }),
+        createDeviceInput({ _id: 'device_partial_02', type: 'temperature' }),
+        createDeviceInput({ _id: 'device_partial_03', type: 'temperature' }),
+      ]);
+
+      // Stand-in for insertMany's real `{ ordered: false }` behavior: some
+      // documents are silently dropped and only the survivors come back,
+      // without throwing. `insertedSubset` is captured so the assertions
+      // below can prove the route forwards this EXACT array reference
+      // downstream, rather than reconstructing something that merely looks
+      // the same.
+      let insertedSubset: Partial<IReadingV2>[] = [];
+      const bulkInsertSpy = jest
+        .spyOn(ReadingV2, 'bulkInsertReadings')
+        .mockImplementation(async readings => {
+          insertedSubset = readings.slice(0, 2);
+          return insertedSubset as IReadingV2[];
+        });
+      const evaluateSpy = jest.spyOn(evaluateModule, 'evaluateReadings');
+
+      const response = await GET_SIMULATE();
+      const data = await parseResponse<{
+        success: boolean;
+        count: number;
+        rejected: number;
+        anomalies: number;
+      }>(response);
+
+      expect(response.status).toBe(200);
+      // 3 active devices generate 3 candidate readings; the mock reports
+      // only 2 of them as actually inserted.
+      expect(bulkInsertSpy.mock.calls[0][0]).toHaveLength(3);
+      expect(insertedSubset).toHaveLength(2);
+
+      // The response must describe what was actually persisted, not what
+      // was merely generated.
+      expect(data.count).toBe(2);
+      expect(data.rejected).toBe(1);
+
+      // safeEvaluateReadings (via evaluateReadings) must receive exactly the
+      // inserted subset returned by bulkInsertReadings — never the full
+      // generated batch, and never a copy that merely looks the same.
+      expect(evaluateSpy).toHaveBeenCalledTimes(1);
+      expect(evaluateSpy.mock.calls[0][0]).toBe(insertedSubset);
+
+      bulkInsertSpy.mockRestore();
+      evaluateSpy.mockRestore();
+    });
+
+    it('must not count a reading bulkInsertReadings rejected toward the anomaly total', async () => {
+      await DeviceV2.insertMany([
+        createDeviceInput({ _id: 'device_anom_keep', type: 'temperature' }),
+        createDeviceInput({ _id: 'device_anom_drop', type: 'temperature' }),
+      ]);
+
+      // Deterministic stand-in for the real (random) simulator: one normal
+      // reading and one anomalous reading. The bulkInsertReadings mock below
+      // "persists" only the normal one, simulating the anomalous one having
+      // failed to insert.
+      const keptReading = createReadingV2Input('device_anom_keep', {
+        quality: {
+          is_valid: true,
+          confidence_score: 0.95,
+          is_anomaly: false,
+          anomaly_score: 0.05,
+        },
+      });
+      const droppedAnomalousReading = createReadingV2Input('device_anom_drop', {
+        quality: {
+          is_valid: true,
+          confidence_score: 0.95,
+          is_anomaly: true,
+          anomaly_score: 0.92,
+        },
+      });
+      const generateSpy = jest
+        .spyOn(simulationModule, 'generateSimulatedReadings')
+        .mockReturnValue([keptReading, droppedAnomalousReading]);
+      const bulkInsertSpy = jest
+        .spyOn(ReadingV2, 'bulkInsertReadings')
+        .mockImplementation(async () => [keptReading] as unknown as IReadingV2[]);
+
+      const response = await GET_SIMULATE();
+      const data = await parseResponse<{ count: number; rejected: number; anomalies: number }>(
+        response
+      );
+
+      expect(response.status).toBe(200);
+      expect(data.count).toBe(1);
+      expect(data.rejected).toBe(1);
+      // The one reading that actually persisted was NOT anomalous. If this
+      // count were still derived from the full generated batch (which
+      // includes the rejected, anomalous reading) it would report 1 instead
+      // of 0.
+      expect(data.anomalies).toBe(0);
+
+      generateSpy.mockRestore();
+      bulkInsertSpy.mockRestore();
     });
   });
 });

--- a/__tests__/integration/api/simulate-cron.integration.test.ts
+++ b/__tests__/integration/api/simulate-cron.integration.test.ts
@@ -10,6 +10,8 @@ import DeviceV2 from '@/models/v2/DeviceV2';
 import ReadingV2 from '@/models/v2/ReadingV2';
 import AlertRuleV2 from '@/models/v2/AlertRuleV2';
 import AlertV2 from '@/models/v2/AlertV2';
+import * as evaluateModule from '@/lib/alerting/evaluate';
+import * as monitoring from '@/lib/monitoring';
 import {
   createDeviceInput,
   createAlertRuleInput,
@@ -652,7 +654,7 @@ describe('Simulate Cron API Integration Tests', () => {
   describe('alert evaluation on the cron path', () => {
     it('should evaluate rules against simulated readings', async () => {
       await DeviceV2.create(createDeviceInput({ _id: 'device_cron_01', type: 'temperature' }));
-      await AlertRuleV2.create(
+      const rule = await AlertRuleV2.create(
         createAlertRuleInput({
           name: 'Any temperature',
           metric: 'value',
@@ -662,11 +664,25 @@ describe('Simulate Cron API Integration Tests', () => {
           selector: { types: ['temperature'] },
         })
       );
+      const infoSpy = jest.spyOn(monitoring.logger, 'info');
 
       const response = await GET_SIMULATE();
       expect(response.status).toBe(200);
 
       expect(await AlertV2.countDocuments({ status: 'firing' })).toBeGreaterThan(0);
+
+      // An alert firing is a domain event in its own right and must be
+      // logged, with the rule and device it involves — not just counted. One
+      // device exists, so exactly one reading is generated and exactly one
+      // (rule, device) pair can fire.
+      expect(infoSpy).toHaveBeenCalledWith('Alert rules fired or resolved during simulation', {
+        fired: 1,
+        resolved: 0,
+        ruleIds: [String(rule._id)],
+        deviceIds: ['device_cron_01'],
+      });
+
+      infoSpy.mockRestore();
     });
 
     it('should sweep an alert whose device no longer reports', async () => {
@@ -674,12 +690,50 @@ describe('Simulate Cron API Integration Tests', () => {
       await AlertV2.create(
         createAlertInput({ device_id: 'device_ghost', status: 'firing', is_open: true })
       );
+      const infoSpy = jest.spyOn(monitoring.logger, 'info');
 
       await GET_SIMULATE();
 
       const swept = await AlertV2.findOne({ device_id: 'device_ghost' }).lean();
       expect(swept!.status).toBe('resolved');
       expect(swept!.audit.resolution).toBe('device_inactive');
+
+      // The SWEEP resolved this alert, not the evaluator — no alert rule
+      // exists in this test, so safeEvaluateReadings's own fired/resolved
+      // counts are both 0 and the evaluation-scoped log must not fire.
+      expect(infoSpy).not.toHaveBeenCalledWith(
+        'Alert rules fired or resolved during simulation',
+        expect.anything()
+      );
+
+      infoSpy.mockRestore();
+    });
+
+    it('should still return 200 with readings persisted when evaluation throws', async () => {
+      await DeviceV2.create(createDeviceInput({ _id: 'device_cron_03', type: 'temperature' }));
+      const spy = jest
+        .spyOn(evaluateModule, 'evaluateReadings')
+        .mockRejectedValueOnce(new Error('evaluator exploded'));
+      const infoSpy = jest.spyOn(monitoring.logger, 'info');
+
+      const response = await GET_SIMULATE();
+      const body = await parseResponse<{ success: boolean }>(response);
+
+      // Prove the mocked rejection was actually reached, not merely that the
+      // route succeeds regardless of whether alerting runs at all.
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(await ReadingV2.countDocuments({ 'metadata.device_id': 'device_cron_03' })).toBe(1);
+      // The empty fallback result must not be reported as if something fired
+      // or resolved.
+      expect(infoSpy).not.toHaveBeenCalledWith(
+        'Alert rules fired or resolved during simulation',
+        expect.anything()
+      );
+
+      spy.mockRestore();
+      infoSpy.mockRestore();
     });
   });
 });

--- a/__tests__/integration/cache-commit-script.redis.test.ts
+++ b/__tests__/integration/cache-commit-script.redis.test.ts
@@ -1,0 +1,129 @@
+/**
+ * OPT-IN: executes the cache commit script against a REAL Redis.
+ *
+ * WHY THIS EXISTS SEPARATELY. The cross-process half of the stale-write guard
+ * (see the "LAYER 2 OF 2" section of lib/cache/cache.ts) is a Lua script, and
+ * every other test in the suite fakes `eval` with the compare-and-set CONTRACT
+ * rather than executing Lua. `__tests__/unit/lib/cache.test.ts` asserts the
+ * script's semantics structurally, which catches a deleted compare — but only
+ * a real server proves the script actually behaves that way when Redis runs it.
+ *
+ * SKIPPED, NOT FAILED, when `REDIS_TEST_URL` is unset. CI has no Redis and must
+ * not grow a dependency on one; this is a check a person re-runs on demand.
+ * When the variable IS set, the suite runs for real and a connection failure is
+ * a genuine failure — you asked for it explicitly.
+ *
+ *   docker run -d --name p4-redis -p 63790:6379 redis:7-alpine
+ *   REDIS_TEST_URL=redis://127.0.0.1:63790 \
+ *     npx jest __tests__/integration/cache-commit-script.redis.test.ts
+ *   docker rm -f p4-redis
+ *
+ * The script is EXTRACTED FROM THE SOURCE by regex rather than retyped here, so
+ * this cannot drift from what ships. If the constant is ever renamed, the
+ * extraction fails loudly instead of silently testing a stale copy.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import Redis from 'ioredis';
+
+const REDIS_TEST_URL = process.env.REDIS_TEST_URL;
+
+/** Silent, visible skip: jest reports the whole block as skipped. */
+const describeWithRedis = REDIS_TEST_URL ? describe : describe.skip;
+
+function extractCommitScript(): string {
+  const source = readFileSync(join(process.cwd(), 'lib/cache/cache.ts'), 'utf8');
+  const match = source.match(/const COMMIT_IF_EPOCH_UNCHANGED = `([\s\S]*?)`;/);
+
+  if (!match)
+    throw new Error(
+      'Could not extract COMMIT_IF_EPOCH_UNCHANGED from lib/cache/cache.ts. ' +
+        'If the constant was renamed, update this extraction — do not inline a copy of the script.'
+    );
+
+  return match[1];
+}
+
+describeWithRedis('cache commit script against a real Redis (opt-in: REDIS_TEST_URL)', () => {
+  const SCRIPT = extractCommitScript();
+
+  // Namespaced so this never touches keys belonging to whoever owns the server
+  // it is pointed at. No FLUSHALL anywhere in this file, deliberately.
+  const PREFIX = `p4-commit-script:${process.pid}:${Date.now()}`;
+  const VALUE_KEY = `${PREFIX}:value`;
+  const EPOCH_KEY = `${VALUE_KEY}::epoch`;
+
+  let redis: Redis;
+
+  beforeAll(async () => {
+    redis = new Redis(REDIS_TEST_URL as string, { lazyConnect: true, maxRetriesPerRequest: 1 });
+    await redis.connect();
+  });
+
+  afterAll(async () => {
+    if (!redis) return;
+    await redis.del(VALUE_KEY, EPOCH_KEY);
+    await redis.quit();
+  });
+
+  beforeEach(async () => {
+    await redis.del(VALUE_KEY, EPOCH_KEY);
+  });
+
+  /** Mirrors commitIfEpochUnchanged's call exactly. */
+  function commit(value: string, observedEpoch: string, ttl = 60) {
+    return redis.eval(SCRIPT, 2, VALUE_KEY, EPOCH_KEY, String(ttl), value, observedEpoch);
+  }
+
+  it('should commit when the key was never invalidated', async () => {
+    await expect(commit('v1', '')).resolves.toBe(1);
+
+    expect(await redis.get(VALUE_KEY)).toBe('v1');
+    expect(await redis.ttl(VALUE_KEY)).toBeGreaterThan(0);
+  });
+
+  // THE race. A reader observed "no epoch", an invalidation bumped it, and the
+  // reader's late write must not resurrect the pre-mutation value.
+  it('should refuse a write whose observed epoch is stale', async () => {
+    await redis.incr(EPOCH_KEY);
+
+    await expect(commit('stale', '')).resolves.toBe(0);
+    expect(await redis.get(VALUE_KEY)).toBeNull();
+  });
+
+  it('should commit when the observed epoch still matches', async () => {
+    await redis.incr(EPOCH_KEY);
+    const observed = (await redis.get(EPOCH_KEY)) as string;
+
+    await expect(commit('v2', observed)).resolves.toBe(1);
+    expect(await redis.get(VALUE_KEY)).toBe('v2');
+  });
+
+  it('should leave an already-committed value alone when it refuses', async () => {
+    await redis.incr(EPOCH_KEY);
+    const observed = (await redis.get(EPOCH_KEY)) as string;
+    await commit('v2', observed);
+
+    // A second invalidation lands; the holder of the now-stale observation
+    // must not overwrite what is there.
+    await redis.incr(EPOCH_KEY);
+
+    await expect(commit('stale', observed)).resolves.toBe(0);
+    expect(await redis.get(VALUE_KEY)).toBe('v2');
+  });
+
+  // readEpoch() returns this sentinel when the epoch read itself fails. It has
+  // to fail CLOSED: an unreadable epoch must never look like "never invalidated".
+  it('should refuse the unreadable-epoch sentinel', async () => {
+    await expect(commit('stale', '\u0000unreadable')).resolves.toBe(0);
+    expect(await redis.get(VALUE_KEY)).toBeNull();
+  });
+
+  // An epoch that aged out is indistinguishable from "never invalidated", so a
+  // caller still holding a numeric observation must be refused.
+  it('should refuse when the epoch expired under a non-empty observation', async () => {
+    await expect(commit('stale', '7')).resolves.toBe(0);
+    expect(await redis.get(VALUE_KEY)).toBeNull();
+  });
+});

--- a/__tests__/integration/scripts/create-indexes-v2-cli.integration.test.ts
+++ b/__tests__/integration/scripts/create-indexes-v2-cli.integration.test.ts
@@ -25,31 +25,68 @@
  * exact scenario this bug targets.
  *
  * Reverting the try/catch around `collection.indexes()` in
- * `createCollectionIndexes()` must fail this test: the subprocess's stdout
- * would contain "Fatal error during index creation" and `alerts_v2` would
- * still have only its default `_id_` index, never having reached the six
- * AlertV2 `createIndex` calls.
+ * `createCollectionIndexes()` must fail this test: `alerts_v2` would still
+ * have only its default `_id_` index, never having reached the six AlertV2
+ * `createIndex` calls - proven below via live index state, not stdout/stderr
+ * text or the subprocess's exit code.
+ *
+ * This file also covers a second, related bug (fix round 2): every index this
+ * script wants to create is ALSO declared directly on its Mongoose schema via
+ * an unnamed `Schema.index({...})` call, so Mongoose's `autoIndex` (the
+ * default — `lib/db.ts`'s `dbConnect()` does not disable it, and neither does
+ * `pnpm seed`'s plain `mongoose.connect()`) builds each one under MongoDB's
+ * own generated name the first time that model initializes, before this
+ * script ever runs. MongoDB then refuses this script's attempt at the
+ * identical key pattern under its own custom name outright, which the
+ * no-name-match code path caught and reported as a bare `[FAIL]` — even
+ * though the auto-built index is perfectly correct, just differently named.
+ * The fix scans ALL existing indexes (not just the name-matched one) for a
+ * full shape match — key pattern, `unique`, and `partialFilterExpression`, all
+ * exact — before attempting to create, and treats that as `[SKIP]`. The
+ * danger such a fix must not introduce: a plain unique index on
+ * `{rule_id, device_id}` has the identical key pattern to the alert dedup
+ * index but lacks its `partialFilterExpression`, silently permitting only one
+ * alert document ever per (rule, device) pair — that must still be reported
+ * as loudly as a same-name mismatch, never accepted as a skip just because
+ * its name happens to differ too.
+ *
+ * A note on this file's own test isolation: importing `@/models/v2/AlertV2`
+ * below (needed to reproduce a real autoIndex build) registers that schema on
+ * the shared default mongoose connection used by every test in this Jest
+ * project, which independently races to auto-build the same six indexes in
+ * the background. That race is real and not fully controllable from a test —
+ * so the first test below deliberately verifies by SHAPE (do all six expected
+ * shapes exist, six indexes total), not by exact name, since which of "this
+ * subprocess" or "the shared connection's own background autoIndex" wins the
+ * naming race for any given index is exactly the non-determinism the fix
+ * exists to tolerate correctly rather than to eliminate.
  */
 
 import { execFile } from 'node:child_process';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import mongoose from 'mongoose';
+import AlertV2 from '@/models/v2/AlertV2';
+import { checkIndexExists, type IndexInfo } from '@/scripts/v2/index-shape';
 
 const execFileAsync = promisify(execFile);
 
 const COLLECTION = 'alerts_v2';
 const REPO_ROOT = path.resolve(__dirname, '../../..');
 
-const EXPECTED_ALERT_INDEX_NAMES = [
-  '_id_',
-  'rule_device_open_unique',
-  'rule_device_resolved_at',
-  'status_created_at',
-  'device_created_at',
-  'severity_status',
-  'is_open_last_observed_at',
-].sort();
+// Mirrors ALERT_V2_INDEXES in scripts/v2/create-indexes-v2.ts exactly.
+const EXPECTED_ALERT_SHAPES: {
+  fields: Record<string, number>;
+  unique?: boolean;
+  partialFilterExpression?: Record<string, unknown>;
+}[] = [
+  { fields: { rule_id: 1, device_id: 1 }, unique: true, partialFilterExpression: { is_open: true } },
+  { fields: { rule_id: 1, device_id: 1, 'audit.resolved_at': -1 } },
+  { fields: { status: 1, 'audit.created_at': -1 } },
+  { fields: { device_id: 1, 'audit.created_at': -1 } },
+  { fields: { severity: 1, status: 1 } },
+  { fields: { is_open: 1, last_observed_at: 1 } },
+];
 
 /** Drops alerts_v2 entirely, tolerating it already not existing. */
 async function ensureCollectionDoesNotExist(name: string): Promise<void> {
@@ -61,42 +98,154 @@ async function ensureCollectionDoesNotExist(name: string): Promise<void> {
   }
 }
 
-async function getLiveIndexNames(name: string): Promise<string[]> {
+async function getLiveIndexInfos(name: string): Promise<IndexInfo[]> {
   const indexes = await mongoose.connection.collection(name).listIndexes().toArray();
-  return indexes.map(idx => idx.name as string).sort();
+  return indexes.map(idx => ({
+    name: idx.name as string,
+    key: idx.key as Record<string, number>,
+    unique: idx.unique as boolean | undefined,
+    partialFilterExpression: idx.partialFilterExpression as Record<string, unknown> | undefined,
+  }));
+}
+
+/**
+ * Runs the real CLI as a subprocess and returns stdout and stderr COMBINED
+ * into one string, whether the process exits 0 or not.
+ *
+ * This combination matters: `[SKIP]`/`[CREATE]` go to stdout, but
+ * `[MISMATCH]`/`[FAIL]` go to stderr (`console.error`) - a test that only
+ * inspects stdout can never observe a mismatch or failure at all, which would
+ * make an assertion like `expect(stdout).not.toContain('[MISMATCH] ...')`
+ * vacuously true regardless of what the script actually did.
+ */
+async function runCreateIndexesV2(): Promise<string> {
+  try {
+    const { stdout, stderr } = await execFileAsync('npx', ['tsx', 'scripts/v2/create-indexes-v2.ts'], {
+      cwd: REPO_ROOT,
+      env: { ...process.env, MONGODB_URI: process.env.MONGODB_URI },
+      timeout: 25000,
+    });
+    return `${stdout}\n${stderr}`;
+  } catch (error) {
+    // The script can exit non-zero for reasons entirely unrelated to whatever
+    // this test set up on alerts_v2 (e.g. devices_v2/readings_v2/alert_rules_v2
+    // indexes auto-built under different names by whichever test happened to
+    // use those models earlier against this shared mongodb-memory-server).
+    // Every test below scopes its assertions to alerts_v2-specific text
+    // (index names unique to this collection's definitions) and to alerts_v2's
+    // own live index state, not the process's overall exit code.
+    const err = error as { stdout?: string; stderr?: string };
+    return `${err.stdout ?? ''}\n${err.stderr ?? ''}`;
+  }
 }
 
 describe('create-indexes-v2 CLI (subprocess): must not crash when alerts_v2 has never been created', () => {
   it('running the actual script against a database with no alerts_v2 collection creates all six AlertV2 indexes instead of aborting', async () => {
     await ensureCollectionDoesNotExist(COLLECTION);
 
-    let stdout = '';
-    try {
-      ({ stdout } = await execFileAsync('npx', ['tsx', 'scripts/v2/create-indexes-v2.ts'], {
-        cwd: REPO_ROOT,
-        env: { ...process.env, MONGODB_URI: process.env.MONGODB_URI },
-        timeout: 25000,
-      }));
-    } catch (error) {
-      // The script can still exit non-zero for reasons entirely unrelated to
-      // alerts_v2 (e.g. devices_v2/readings_v2/alert_rules_v2 indexes that are
-      // also declared directly on their Mongoose schemas, auto-built under
-      // different names by whichever test happened to use those models earlier
-      // against this shared mongodb-memory-server). What this test verifies is
-      // specifically whether alerts_v2 crashed the whole run - checked below
-      // via stdout content and, definitively, live index state - not the
-      // subprocess's overall exit code.
-      stdout = (error as { stdout?: string }).stdout ?? '';
-    }
+    const output = await runCreateIndexesV2();
 
     // The specific crash this test targets: an unhandled NamespaceNotFound
     // aborts the run before it ever reaches alerts_v2's own createIndex calls.
-    expect(stdout).not.toContain('Fatal error during index creation');
-    expect(stdout).not.toContain('ns does not exist');
+    expect(output).not.toContain('Fatal error during index creation');
+    expect(output).not.toContain('ns does not exist');
 
-    // The real proof: the collection now exists with all six named indexes it
-    // never had a chance to get while the script was crashing.
-    const indexNames = await getLiveIndexNames(COLLECTION);
-    expect(indexNames).toEqual(EXPECTED_ALERT_INDEX_NAMES);
+    // The real proof: every one of the six AlertV2 index shapes is now
+    // satisfied by some live index, and there are exactly six (not by exact
+    // name - see the file header on why that would be flaky here).
+    const indexInfos = await getLiveIndexInfos(COLLECTION);
+    for (const shape of EXPECTED_ALERT_SHAPES) expect(checkIndexExists(indexInfos, shape)).toBe(true);
+    expect(indexInfos.filter(idx => idx.name !== '_id_')).toHaveLength(6);
+  }, 30000);
+});
+
+describe('create-indexes-v2 CLI (subprocess): a same-shape index under a different name is satisfied, a same-key different-shape index is not', () => {
+  it('an index autoIndex already built under a different name, with the identical shape, is skipped rather than reported as a failure', async () => {
+    await ensureCollectionDoesNotExist(COLLECTION);
+
+    // Reproduces exactly what happens the first time anything touches the
+    // AlertV2 model with Mongoose's default autoIndex (true) - a scoped
+    // connection that registers the real schema, mirroring the technique in
+    // verify-indexes-autoindex.integration.test.ts. AlertV2Schema declares all
+    // six indexes with no explicit name, so this builds all six under
+    // MongoDB's own generated names, dedup index included - straight from the
+    // schema, so it is correctly shaped (unique + partialFilterExpression).
+    const conn = mongoose.createConnection(process.env.MONGODB_URI!);
+    try {
+      await conn.asPromise();
+      const ScopedAlertV2 = conn.model('AlertV2', AlertV2.schema);
+      await ScopedAlertV2.init(); // waits for the auto-built indexes to finish
+    } finally {
+      await conn.close();
+    }
+
+    // Confirm the setup actually produced auto-generated names, not this
+    // script's own - otherwise this test would exercise the unchanged
+    // name-matched branch instead of the new shape-scan branch.
+    const beforeInfos = await getLiveIndexInfos(COLLECTION);
+    expect(beforeInfos.map(idx => idx.name)).not.toContain('rule_device_open_unique');
+    expect(beforeInfos.filter(idx => idx.name !== '_id_')).toHaveLength(6);
+    for (const shape of EXPECTED_ALERT_SHAPES) expect(checkIndexExists(beforeInfos, shape)).toBe(true);
+
+    const output = await runCreateIndexesV2();
+
+    // The autoIndex-built dedup index (unique + partialFilterExpression,
+    // straight from the schema) must be recognized as already satisfied...
+    expect(output).toMatch(/\[SKIP\] rule_device_open_unique - already exists as/);
+    // ...and never reported as a failure or mismatch just because its name differs.
+    expect(output).not.toContain('[FAIL] rule_device_open_unique');
+    expect(output).not.toContain('[MISMATCH] rule_device_open_unique');
+
+    // No duplicate custom-named index was created alongside the shadow - the
+    // auto-named one is still the only one satisfying that shape, six total.
+    const afterInfos = await getLiveIndexInfos(COLLECTION);
+    expect(afterInfos.map(idx => idx.name)).not.toContain('rule_device_open_unique');
+    expect(afterInfos.filter(idx => idx.name !== '_id_')).toHaveLength(6);
+  }, 30000);
+
+  it('an index with the same key pattern but a different unique/partialFilterExpression shape is still reported as a loud mismatch, never silently skipped', async () => {
+    await ensureCollectionDoesNotExist(COLLECTION);
+
+    // The exact danger this guards: a PLAIN unique index on the dedup index's
+    // key pattern, missing partialFilterExpression, under a name that matches
+    // neither this script's custom name nor a real autoIndex-generated one.
+    // This would silently permit only one alert document ever per
+    // (rule, device) pair if it were ever accepted as "already satisfied".
+    await mongoose.connection
+      .collection(COLLECTION)
+      .createIndex({ rule_id: 1, device_id: 1 }, { name: 'dangerous_plain_unique', unique: true });
+
+    const output = await runCreateIndexesV2();
+
+    // This is the Critical this test guards: a plain unique index must never
+    // be silently accepted as satisfying the partial-unique dedup index.
+    expect(output).toContain('[MISMATCH] rule_device_open_unique');
+    expect(output).toContain('dangerous_plain_unique');
+    expect(output).not.toContain('[SKIP] rule_device_open_unique');
+
+    // The dangerous index must be left exactly as it was: not dropped, not
+    // "fixed" in place, and no new index created to sit alongside it under the
+    // dedup index's own name - specifically no rule_device_open_unique. The
+    // OTHER five alert index definitions have nothing blocking them (this test
+    // seeded only the one dangerous index), so they are created normally; the
+    // mismatch is scoped to the one index it actually concerns.
+    const indexInfos = await getLiveIndexInfos(COLLECTION);
+    const indexNames = indexInfos.map(idx => idx.name);
+    expect(indexNames).not.toContain('rule_device_open_unique');
+    expect(indexNames.sort()).toEqual(
+      [
+        '_id_',
+        'dangerous_plain_unique',
+        'rule_device_resolved_at',
+        'status_created_at',
+        'device_created_at',
+        'severity_status',
+        'is_open_last_observed_at',
+      ].sort()
+    );
+
+    const dangerous = indexInfos.find(idx => idx.name === 'dangerous_plain_unique');
+    expect(dangerous?.unique).toBe(true);
+    expect(dangerous?.partialFilterExpression).toBeUndefined(); // still missing, untouched
   }, 30000);
 });

--- a/__tests__/integration/scripts/create-indexes-v2-cli.integration.test.ts
+++ b/__tests__/integration/scripts/create-indexes-v2-cli.integration.test.ts
@@ -1,0 +1,102 @@
+/**
+ * create-indexes-v2.ts (the actual CLI, run as a subprocess) must not crash
+ * when a target collection has never been created.
+ *
+ * `alerts_v2` only comes into existence once an alert episode has actually
+ * fired — the normal state of a fresh database, since the seed deliberately
+ * never touches `alerts_v2` (see `scripts/v2/seed-v2.ts`). Before this fix,
+ * `createCollectionIndexes()`'s first operation was an unguarded
+ * `collection.indexes()`, which MongoDB answers with `NamespaceNotFound` for a
+ * collection that has never been created. That aborted the whole script
+ * (exit 1) before it ever reached `alerts_v2`'s own `createIndex` calls —
+ * which is exactly what would have created the collection and its indexes.
+ * Since `create-indexes-v2.ts` imports no model files, nothing in its own
+ * process can auto-vivify `alerts_v2` ahead of that call, so the crash was
+ * fully deterministic on a fresh database, not a race.
+ *
+ * `create-indexes-v2.ts` cannot be `import`ed to close that gap in-process:
+ * like `verify-indexes.ts`, it calls its main function unconditionally at
+ * module scope, and that function calls `process.exit()` on several paths, so
+ * importing it would kill the Jest worker. Instead this test runs it exactly
+ * as `pnpm create-indexes-v2` does — a real child process, `npx tsx
+ * scripts/v2/create-indexes-v2.ts`, pointed at the shared
+ * mongodb-memory-server via the inherited `MONGODB_URI` — against a database
+ * where `alerts_v2` has been dropped so it genuinely does not exist, the
+ * exact scenario this bug targets.
+ *
+ * Reverting the try/catch around `collection.indexes()` in
+ * `createCollectionIndexes()` must fail this test: the subprocess's stdout
+ * would contain "Fatal error during index creation" and `alerts_v2` would
+ * still have only its default `_id_` index, never having reached the six
+ * AlertV2 `createIndex` calls.
+ */
+
+import { execFile } from 'node:child_process';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import mongoose from 'mongoose';
+
+const execFileAsync = promisify(execFile);
+
+const COLLECTION = 'alerts_v2';
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+
+const EXPECTED_ALERT_INDEX_NAMES = [
+  '_id_',
+  'rule_device_open_unique',
+  'rule_device_resolved_at',
+  'status_created_at',
+  'device_created_at',
+  'severity_status',
+  'is_open_last_observed_at',
+].sort();
+
+/** Drops alerts_v2 entirely, tolerating it already not existing. */
+async function ensureCollectionDoesNotExist(name: string): Promise<void> {
+  try {
+    await mongoose.connection.collection(name).drop();
+  } catch (error) {
+    // NamespaceNotFound (26): already gone, which is the state this test wants.
+    if ((error as { code?: number }).code !== 26) throw error;
+  }
+}
+
+async function getLiveIndexNames(name: string): Promise<string[]> {
+  const indexes = await mongoose.connection.collection(name).listIndexes().toArray();
+  return indexes.map(idx => idx.name as string).sort();
+}
+
+describe('create-indexes-v2 CLI (subprocess): must not crash when alerts_v2 has never been created', () => {
+  it('running the actual script against a database with no alerts_v2 collection creates all six AlertV2 indexes instead of aborting', async () => {
+    await ensureCollectionDoesNotExist(COLLECTION);
+
+    let stdout = '';
+    try {
+      ({ stdout } = await execFileAsync('npx', ['tsx', 'scripts/v2/create-indexes-v2.ts'], {
+        cwd: REPO_ROOT,
+        env: { ...process.env, MONGODB_URI: process.env.MONGODB_URI },
+        timeout: 25000,
+      }));
+    } catch (error) {
+      // The script can still exit non-zero for reasons entirely unrelated to
+      // alerts_v2 (e.g. devices_v2/readings_v2/alert_rules_v2 indexes that are
+      // also declared directly on their Mongoose schemas, auto-built under
+      // different names by whichever test happened to use those models earlier
+      // against this shared mongodb-memory-server). What this test verifies is
+      // specifically whether alerts_v2 crashed the whole run - checked below
+      // via stdout content and, definitively, live index state - not the
+      // subprocess's overall exit code.
+      stdout = (error as { stdout?: string }).stdout ?? '';
+    }
+
+    // The specific crash this test targets: an unhandled NamespaceNotFound
+    // aborts the run before it ever reaches alerts_v2's own createIndex calls.
+    expect(stdout).not.toContain('Fatal error during index creation');
+    expect(stdout).not.toContain('ns does not exist');
+
+    // The real proof: the collection now exists with all six named indexes it
+    // never had a chance to get while the script was crashing.
+    const indexNames = await getLiveIndexNames(COLLECTION);
+    expect(indexNames).toEqual(EXPECTED_ALERT_INDEX_NAMES);
+  }, 30000);
+});

--- a/__tests__/integration/scripts/verify-indexes-autoindex.integration.test.ts
+++ b/__tests__/integration/scripts/verify-indexes-autoindex.integration.test.ts
@@ -1,0 +1,149 @@
+/**
+ * verify-indexes.ts must not create the index it is checking for.
+ *
+ * `verify-indexes.ts` imports every v2 model to register their schemas
+ * (`import '../../models/v2/AlertV2'`, etc.), then connects with Mongoose.
+ * AlertV2's dedup index is declared on the schema with no explicit name
+ * (`AlertV2Schema.index({ rule_id: 1, device_id: 1 }, { unique: true,
+ * partialFilterExpression: { is_open: true } })`), so if Mongoose's `autoIndex`
+ * is left at its default (`true`), connecting builds that index under an
+ * auto-generated name (`rule_id_1_device_id_1`) alongside whatever is already on
+ * disk. `checkIndexExists` is name-agnostic — it asks "does *some* index satisfy
+ * this shape" — so in exactly the catastrophic scenario Task 7 targets (a plain,
+ * non-partial unique index already sitting under the name
+ * `rule_device_open_unique`), connecting would cause the script to build the
+ * correctly-shaped index it was about to look for, then report success having
+ * verified its own handiwork. The broken, differently-named index — the one
+ * MongoDB is actually enforcing on every write — is left exactly as broken as it
+ * was, silently.
+ *
+ * The fix is to connect with `autoIndex: false`, so the script observes the
+ * database as it actually is instead of as connecting to it would leave it.
+ *
+ * This test proves the mechanism directly against a real MongoDB (the shared
+ * mongodb-memory-server instance; see __tests__/setup/globalSetup.ts) rather than
+ * asserting on connection options: it seeds the exact broken index, opens a
+ * connection exactly as verify-indexes.ts's pre-fix code did (schema registered,
+ * autoIndex left at its default), and shows both that a shadow index gets built
+ * AND that checkIndexExists is fooled by it — then repeats with autoIndex: false
+ * and shows neither happens.
+ *
+ * Note on timing: manually driving the real `verify-indexes.ts` CLI against a
+ * live database (see the task report) showed this bug is actually RACY — the
+ * script's own `mongoose.connect(uri)` call resolves as soon as the socket is up,
+ * not once Mongoose's background autoIndex build finishes, so a single run can
+ * get lucky and read the collection before the shadow index lands. This test does
+ * not rely on that race: it explicitly awaits `Model.init()`, Mongoose's own
+ * documented way to wait for a model's index build to finish, which is what makes
+ * the "before" case below deterministic instead of intermittent — the shadow
+ * index is real either way, whether or not any particular run happens to observe
+ * it before it lands.
+ */
+
+import mongoose from 'mongoose';
+import AlertV2 from '@/models/v2/AlertV2';
+import { checkIndexExists, type IndexInfo } from '@/scripts/v2/index-shape';
+
+const COLLECTION = 'alerts_v2';
+
+// The exact expectation verify-indexes.ts declares for the AlertV2 dedup index
+// (EXPECTED_ALERT_INDEXES's rule_device_open_unique entry).
+const RULE_DEVICE_OPEN_UNIQUE_EXPECTATION = {
+  fields: { rule_id: 1, device_id: 1 },
+  unique: true,
+  partialFilterExpression: { is_open: true },
+};
+
+/**
+ * Resets alerts_v2 to hold exactly one non-_id_ index: the catastrophic
+ * misconfiguration this whole task targets — a PLAIN unique index on
+ * {rule_id, device_id}, no partialFilterExpression, under the real index's name.
+ */
+async function seedOnlyTheBrokenDedupIndex(): Promise<void> {
+  const collection = mongoose.connection.collection(COLLECTION);
+  const existing = await collection.indexes().catch(() => []);
+  for (const idx of existing) if (idx.name !== '_id_') await collection.dropIndex(idx.name!);
+
+  await collection.createIndex(
+    { rule_id: 1, device_id: 1 },
+    { name: 'rule_device_open_unique', unique: true }
+  );
+}
+
+async function getLiveAlertIndexes(): Promise<IndexInfo[]> {
+  const collection = mongoose.connection.collection(COLLECTION);
+  const indexes = await collection.listIndexes().toArray();
+  return indexes.map(idx => ({
+    name: idx.name,
+    key: idx.key as Record<string, number>,
+    unique: idx.unique,
+    partialFilterExpression: idx.partialFilterExpression as Record<string, unknown> | undefined,
+  }));
+}
+
+describe('verify-indexes: connecting must not create the index it is checking for', () => {
+  const openConnections: mongoose.Connection[] = [];
+
+  afterEach(async () => {
+    await Promise.all(openConnections.splice(0).map(conn => conn.close()));
+  });
+
+  it('[the hole, reproduced] without autoIndex: false, connecting builds a shadow index and checkIndexExists reports a false success', async () => {
+    await seedOnlyTheBrokenDedupIndex();
+
+    // Mirrors exactly what verify-indexes.ts did before this fix: a connection
+    // that registers the AlertV2 schema with Mongoose's default autoIndex (true).
+    const conn = mongoose.createConnection(process.env.MONGODB_URI!);
+    openConnections.push(conn);
+    await conn.asPromise();
+    const ScopedAlertV2 = conn.model('AlertV2', AlertV2.schema);
+    await ScopedAlertV2.init(); // waits for the (mis-)auto-built indexes to finish
+
+    const liveIndexes = await getLiveAlertIndexes();
+
+    // AlertV2Schema declares six indexes, none with an explicit name, so
+    // connecting with autoIndex enabled builds all six under auto-generated
+    // names. Find the specific shadow that matches the dedup index's shape —
+    // that's the one that fools checkIndexExists below — not just any extra
+    // index.
+    const shadow = liveIndexes.find(
+      idx =>
+        idx.name !== 'rule_device_open_unique' &&
+        idx.unique === true &&
+        idx.partialFilterExpression !== undefined
+    );
+    expect(shadow).toBeDefined();
+    expect(shadow?.name).not.toBe('rule_device_open_unique'); // a different name...
+    expect(shadow?.key).toEqual({ rule_id: 1, device_id: 1 }); // ...same key...
+    expect(shadow?.partialFilterExpression).toEqual({ is_open: true }); // ...correct filter.
+
+    // The actual danger: checkIndexExists (name-agnostic — "does *some* index
+    // satisfy this shape") now reports success...
+    expect(checkIndexExists(liveIndexes, RULE_DEVICE_OPEN_UNIQUE_EXPECTATION)).toBe(true);
+
+    // ...while the index MongoDB is actually enforcing under the real name is
+    // still exactly as broken as it was. This is the false green.
+    const broken = liveIndexes.find(idx => idx.name === 'rule_device_open_unique');
+    expect(broken?.partialFilterExpression).toBeUndefined();
+  });
+
+  it('[the fix, verified] with autoIndex: false, connecting creates no shadow index and checkIndexExists correctly reports failure', async () => {
+    await seedOnlyTheBrokenDedupIndex();
+
+    const conn = mongoose.createConnection(process.env.MONGODB_URI!, { autoIndex: false });
+    openConnections.push(conn);
+    await conn.asPromise();
+    const ScopedAlertV2 = conn.model('AlertV2', AlertV2.schema);
+    await ScopedAlertV2.init(); // no index build to wait for; autoIndex is off
+
+    const liveIndexes = await getLiveAlertIndexes();
+
+    // The database was only observed, not mutated: still just _id_ and the
+    // deliberately broken index, nothing else.
+    expect(liveIndexes.map(idx => idx.name).sort()).toEqual(['_id_', 'rule_device_open_unique']);
+
+    // checkIndexExists now correctly reports failure, because there is genuinely
+    // nothing in the database that satisfies the expected shape.
+    expect(checkIndexExists(liveIndexes, RULE_DEVICE_OPEN_UNIQUE_EXPECTATION)).toBe(false);
+  });
+});

--- a/__tests__/integration/scripts/verify-indexes-cli.integration.test.ts
+++ b/__tests__/integration/scripts/verify-indexes-cli.integration.test.ts
@@ -1,0 +1,92 @@
+/**
+ * verify-indexes.ts (the actual CLI, run as a subprocess) must not create the
+ * index it is checking for.
+ *
+ * `verify-indexes-autoindex.integration.test.ts` proves the underlying
+ * mechanism — that connecting with autoIndex left at its default builds a
+ * shadow index and fools `checkIndexExists`, and that `autoIndex: false`
+ * prevents both. That file is deliberately kept as-is; this file exists because
+ * proving the mechanism is not the same as proving the shipped script uses it.
+ * Those two tests construct their own Mongoose connections with hand-chosen
+ * `autoIndex` values — they never import, execute, or otherwise touch
+ * `verify-indexes.ts`, so a regression that reverted the fix in that file would
+ * not fail either of them.
+ *
+ * `verify-indexes.ts` cannot be `import`ed to close that gap: it calls
+ * `main()` unconditionally at module scope and `main()` calls `process.exit()`,
+ * so importing it in-process would kill the Jest worker. Instead this test runs
+ * it exactly as `pnpm verify-indexes` does — as a real child process, `npx tsx
+ * scripts/v2/verify-indexes.ts`, pointed at the shared mongodb-memory-server via
+ * the inherited `MONGODB_URI` — against a database seeded with the catastrophic
+ * misconfiguration this whole task targets: a plain unique index on
+ * `{rule_id, device_id}` under the real name `rule_device_open_unique`, no
+ * `partialFilterExpression`. This is the actual file, actually executed, with
+ * no exported seam to route around.
+ *
+ * Reverting `scripts/v2/verify-indexes.ts`'s `mongoose.connect(uri, { autoIndex:
+ * false })` back to `mongoose.connect(uri)` must fail this test: the script
+ * would build a correctly-shaped shadow index under an auto-generated name,
+ * report success for `rule_device_open_unique`, and leave that index exactly as
+ * broken as it was.
+ */
+
+import { execFile } from 'node:child_process';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import mongoose from 'mongoose';
+
+const execFileAsync = promisify(execFile);
+
+const COLLECTION = 'alerts_v2';
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+
+/**
+ * Resets alerts_v2 to hold exactly one non-_id_ index: the catastrophic
+ * misconfiguration this whole task targets.
+ */
+async function seedOnlyTheBrokenDedupIndex(): Promise<void> {
+  const collection = mongoose.connection.collection(COLLECTION);
+  const existing = await collection.indexes().catch(() => []);
+  for (const idx of existing) if (idx.name !== '_id_') await collection.dropIndex(idx.name!);
+
+  await collection.createIndex(
+    { rule_id: 1, device_id: 1 },
+    { name: 'rule_device_open_unique', unique: true }
+  );
+}
+
+async function getLiveAlertIndexNames(): Promise<string[]> {
+  const collection = mongoose.connection.collection(COLLECTION);
+  const indexes = await collection.listIndexes().toArray();
+  return indexes.map(idx => idx.name as string).sort();
+}
+
+/** Strips ANSI color codes so the CLI's colorized ✓/✗ output can be matched with plain text. */
+function stripAnsi(text: string): string {
+  return text.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+describe('verify-indexes CLI (subprocess): must not create the index it checks for', () => {
+  it('running the actual script against a broken dedup index reports failure and creates no shadow index', async () => {
+    await seedOnlyTheBrokenDedupIndex();
+
+    const { stdout } = await execFileAsync('npx', ['tsx', 'scripts/v2/verify-indexes.ts'], {
+      cwd: REPO_ROOT,
+      env: { ...process.env, MONGODB_URI: process.env.MONGODB_URI },
+      timeout: 25000,
+    });
+
+    const plainOutput = stripAnsi(stdout);
+    const alertSection = plainOutput.slice(plainOutput.indexOf('AlertV2 Collection Indexes'));
+
+    // The script must report the broken index as missing/failing...
+    expect(alertSection).toContain('✗ rule_device_open_unique');
+    expect(alertSection).not.toContain('✓ rule_device_open_unique');
+
+    // ...and must not have silently built the index it was checking for as a
+    // side effect of connecting. If this fails, the database has a
+    // rule_id_1_device_id_1 (or similarly auto-named) shadow index in it.
+    const indexNames = await getLiveAlertIndexNames();
+    expect(indexNames).toEqual(['_id_', 'rule_device_open_unique']);
+  }, 30000);
+});

--- a/__tests__/setup/factories.ts
+++ b/__tests__/setup/factories.ts
@@ -39,6 +39,7 @@ export function resetCounters(): void {
   _readingCounter = 0;
   readingV2Counter = 0;
   scheduleCounter = 0;
+  alertRuleCounter = 0;
 }
 
 /**
@@ -777,4 +778,44 @@ export function createScheduleOfType(
  */
 export function futureDateISO(daysAhead: number = 7): string {
   return new Date(Date.now() + daysAhead * 24 * 60 * 60 * 1000).toISOString();
+}
+
+// ============================================================================
+// ALERT RULE FACTORIES
+// ============================================================================
+
+export interface AlertRuleInput {
+  name: string;
+  description?: string;
+  enabled?: boolean;
+  selector: Record<string, unknown>;
+  metric: 'value' | 'anomaly_score' | 'battery_level';
+  comparison: 'gt' | 'gte' | 'lt' | 'lte';
+  threshold: number;
+  for_duration_seconds?: number;
+  severity: 'info' | 'warning' | 'critical';
+  cooldown_seconds?: number;
+  audit?: Record<string, unknown>;
+}
+
+let alertRuleCounter = 0;
+
+export function createAlertRuleInput(overrides: Partial<AlertRuleInput> = {}): AlertRuleInput {
+  alertRuleCounter += 1;
+  return {
+    name: `Test Rule ${alertRuleCounter}`,
+    enabled: true,
+    selector: { types: ['temperature'] },
+    metric: 'value',
+    comparison: 'gt',
+    threshold: 30,
+    severity: 'warning',
+    audit: {
+      created_at: new Date(),
+      created_by: 'test@example.com',
+      updated_at: new Date(),
+      updated_by: 'test@example.com',
+    },
+    ...overrides,
+  };
 }

--- a/__tests__/setup/factories.ts
+++ b/__tests__/setup/factories.ts
@@ -4,6 +4,7 @@
  * Provides functions for creating valid test data for models and API tests.
  */
 
+import { Types } from 'mongoose';
 import type { IDeviceV2, DeviceType, DeviceStatus } from '@/models/v2/DeviceV2';
 
 // ============================================================================
@@ -40,6 +41,7 @@ export function resetCounters(): void {
   readingV2Counter = 0;
   scheduleCounter = 0;
   alertRuleCounter = 0;
+  alertCounter = 0;
 }
 
 /**
@@ -815,6 +817,62 @@ export function createAlertRuleInput(overrides: Partial<AlertRuleInput> = {}): A
       created_by: 'test@example.com',
       updated_at: new Date(),
       updated_by: 'test@example.com',
+    },
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// ALERT FACTORIES
+// ============================================================================
+
+export interface AlertInput {
+  rule_id: Types.ObjectId;
+  rule_name: string;
+  device_id: string;
+  status: 'pending' | 'firing' | 'acknowledged' | 'resolved';
+  is_open: boolean;
+  severity: 'info' | 'warning' | 'critical';
+  metric: string;
+  comparison: string;
+  threshold: number;
+  trigger_value: number;
+  last_value: number;
+  breached_since: Date;
+  last_observed_at: Date;
+  fired_at?: Date;
+  audit?: Record<string, unknown>;
+}
+
+let alertCounter = 0;
+
+export function createAlertInput(overrides: Partial<AlertInput> = {}): AlertInput {
+  alertCounter += 1;
+  const now = new Date();
+  const status = overrides.status ?? 'firing';
+  return {
+    rule_id: new Types.ObjectId(),
+    rule_name: `Test Rule ${alertCounter}`,
+    device_id: `device_${String(alertCounter).padStart(3, '0')}`,
+    status,
+    is_open: status !== 'resolved',
+    severity: 'warning',
+    metric: 'value',
+    comparison: 'gt',
+    threshold: 30,
+    trigger_value: 35,
+    last_value: 35,
+    breached_since: now,
+    last_observed_at: now,
+    fired_at: status === 'pending' ? undefined : now,
+    audit: {
+      created_at: now,
+      created_by: 'system',
+      updated_at: now,
+      updated_by: 'system',
+      ...(status === 'resolved'
+        ? { resolved_at: now, resolved_by: 'system', resolution: 'auto' }
+        : {}),
     },
     ...overrides,
   };

--- a/__tests__/setup/jest.setup.jsdom.ts
+++ b/__tests__/setup/jest.setup.jsdom.ts
@@ -10,6 +10,19 @@ import '@testing-library/jest-dom';
 // Set test timeout
 jest.setTimeout(15000);
 
+// jsdom does not implement ResizeObserver. @radix-ui/react-use-size (used by
+// Checkbox, Switch, and other Radix primitives to measure themselves) calls
+// it unconditionally in a layout effect, so any test that renders one of
+// those primitives crashes with "ResizeObserver is not defined" without this
+// stub. No test exercised a Radix Checkbox before CreateAlertRuleModal.test.tsx,
+// which is why this gap wasn't hit earlier.
+if (typeof global.ResizeObserver === 'undefined') 
+  global.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+
 // Mock Clerk auth for component tests
 jest.mock('@clerk/nextjs/server', () => ({
   auth: jest.fn().mockResolvedValue({

--- a/__tests__/unit/app/RootLayout.test.tsx
+++ b/__tests__/unit/app/RootLayout.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * Root Layout — alert-surface gating
+ *
+ * WHY THIS FILE EXISTS. Critical 2 was fixed with BOTH mechanisms the human
+ * partner asked for: the `private-alerts` channel denies alert data at source,
+ * and `<SignedIn>` in `app/layout.tsx` keeps the alert surfaces from mounting
+ * for a signed-out visitor. Only the first was covered. Deleting the
+ * `<SignedIn>` wrappers left the entire 2218-test suite green, because nothing
+ * anywhere rendered `app/layout.tsx` — so one of the two requested mechanisms
+ * could be removed by any future refactor without a single red test.
+ *
+ * That gate is load-bearing on its own terms: `/sign-in` renders INSIDE this
+ * layout, so an ungated `AlertToaster` puts the fleet's live alert traffic —
+ * rule name, device id, trigger value — on the login page of anyone who can
+ * reach it. The private channel is what stops the data arriving; this is what
+ * stops it being rendered if it ever does.
+ *
+ * WHAT IS ASSERTED. Behaviour, not markup: signed out, the alert surfaces do
+ * not render; signed in, they do. A test that looked for a `SignedIn` element
+ * would pass against a wrapper that renders its children unconditionally,
+ * which is the same defect class as the gate it is checking.
+ *
+ * The `@clerk/nextjs` mock below is therefore the one piece that has to be
+ * faithful: `SignedIn` renders children only when there is a session, exactly
+ * as Clerk's does (Clerk's also renders nothing while loading; `mockIsSignedIn
+ * = false` covers that case identically, which is why the provider itself is
+ * deliberately NOT wrapped in the layout).
+ *
+ * Everything else is stubbed down to a marker so this stays a test of the
+ * layout's gating and nothing else. `PusherProvider` in particular must be
+ * mocked: the real one opens a socket and its module requires the
+ * NEXT_PUBLIC_PUSHER_* env vars at import time.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import RootLayout from '@/app/layout';
+
+/** Flipped per test; read by the `SignedIn` stub below. */
+let mockIsSignedIn = true;
+
+jest.mock('@clerk/nextjs', () => ({
+  __esModule: true,
+  // Clerk's SignedIn renders its children only when a session exists.
+  SignedIn: ({ children }: { children: React.ReactNode }) =>
+    mockIsSignedIn ? <>{children}</> : null,
+}));
+
+// Stylesheets: no transform is configured for .css, so these must not be
+// loaded for real.
+jest.mock('../../../app/globals.css', () => ({}));
+jest.mock('react-toastify/dist/ReactToastify.css', () => ({}));
+
+jest.mock('next/font/google', () => ({
+  Geist: () => ({ variable: '--font-geist-sans' }),
+  Geist_Mono: () => ({ variable: '--font-geist-mono' }),
+}));
+
+jest.mock('@/lib/pusher-context', () => ({
+  PusherProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/components/theme-provider', () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/components/clerk-theme-provider', () => ({
+  ClerkThemeProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/components/TopNav', () => ({
+  __esModule: true,
+  default: () => <nav data-testid="top-nav" />,
+}));
+
+jest.mock('@/components/DemoBanner', () => ({
+  __esModule: true,
+  default: () => <div data-testid="demo-banner" />,
+}));
+
+// The two gated surfaces. Markers, so presence/absence is unambiguous.
+jest.mock('@/components/alerts/AlertToaster', () => ({
+  AlertToaster: () => <div data-testid="alert-toaster" />,
+}));
+
+jest.mock('@/components/alerts/RealtimeStatusBanner', () => ({
+  RealtimeStatusBanner: () => <div data-testid="realtime-status-banner" />,
+}));
+
+jest.mock('react-toastify', () => ({
+  ToastContainer: () => <div data-testid="toast-container" />,
+}));
+
+jest.mock('@tanstack/react-query-devtools', () => ({
+  ReactQueryDevtools: () => null,
+}));
+
+/**
+ * React 19 treats `<html>`, `<head>` and `<body>` as document singletons: it
+ * resolves them to the real document's elements rather than creating copies
+ * inside the container testing-library hands it. That is what makes rendering
+ * a root layout in jsdom work at all, and why `screen` — rooted at
+ * `document.body` — finds this layout's output.
+ */
+function renderLayout() {
+  return render(
+    <RootLayout>
+      <div data-testid="page-content" />
+    </RootLayout>
+  );
+}
+
+describe('RootLayout alert gating', () => {
+  // The singleton resolution above still logs one "in HTML, <html> cannot be a
+  // child of <div>" per render. Silenced by exact message so everything else
+  // React has to say still surfaces.
+  const originalConsoleError = console.error;
+
+  beforeAll(() => {
+    console.error = (...args: unknown[]) => {
+      if (typeof args[0] === 'string' && args[0].includes('cannot be a child of')) return;
+      originalConsoleError(...(args as Parameters<typeof console.error>));
+    };
+  });
+
+  afterAll(() => {
+    console.error = originalConsoleError;
+  });
+
+  afterEach(() => {
+    mockIsSignedIn = true;
+  });
+
+  describe('signed out', () => {
+    beforeEach(() => {
+      mockIsSignedIn = false;
+    });
+
+    it('does not render the alert toaster', () => {
+      renderLayout();
+
+      // `/sign-in` renders inside this layout. Without the gate, a visitor who
+      // has not signed in is shown live alert popups carrying rule_name,
+      // device_id and trigger_value.
+      expect(screen.queryByTestId('alert-toaster')).not.toBeInTheDocument();
+    });
+
+    it('does not render the realtime status banner', () => {
+      renderLayout();
+
+      expect(screen.queryByTestId('realtime-status-banner')).not.toBeInTheDocument();
+    });
+
+    it('still renders the ungated chrome and the page itself', () => {
+      renderLayout();
+
+      // Proves the layout rendered at all, so the two absences above are the
+      // gate doing its job rather than a render that silently failed.
+      expect(screen.getByTestId('top-nav')).toBeInTheDocument();
+      expect(screen.getByTestId('page-content')).toBeInTheDocument();
+    });
+  });
+
+  describe('signed in', () => {
+    beforeEach(() => {
+      mockIsSignedIn = true;
+    });
+
+    it('renders the alert toaster', () => {
+      renderLayout();
+
+      expect(screen.getByTestId('alert-toaster')).toBeInTheDocument();
+    });
+
+    it('renders the realtime status banner', () => {
+      renderLayout();
+
+      expect(screen.getByTestId('realtime-status-banner')).toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/unit/components/ActiveAlertsWidget.test.tsx
+++ b/__tests__/unit/components/ActiveAlertsWidget.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * ActiveAlertsWidget Tests
+ *
+ * `@/lib/query/hooks` is mocked at the exact module specifier
+ * ActiveAlertsWidget.tsx imports from (matching the working pattern in
+ * AlertList.test.tsx / DashboardStatCards.test.tsx), so the mock actually
+ * intercepts the import the widget uses rather than a barrel re-export that
+ * never gets hit.
+ *
+ * Loading / empty / error are asserted as mutually exclusive: each state's
+ * test also asserts the OTHER states' text is absent. This guards against the
+ * failure mode called out in the task brief — a component whose empty and
+ * error branches both fall through to the same "nothing to show" output,
+ * which would let a naive test (asserting only the positive case) pass while
+ * the error state is invisible to an operator. Deletion-check evidence
+ * proving these actually catch that regression is recorded in the task
+ * report.
+ */
+
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ActiveAlertsWidget } from '@/components/dashboard/ActiveAlertsWidget';
+import { useAlertsList } from '@/lib/query/hooks';
+import type { AlertV2Response } from '@/types/v2';
+
+jest.mock('@/lib/query/hooks', () => ({
+  useAlertsList: jest.fn(),
+}));
+
+const mockUseAlertsList = useAlertsList as jest.Mock;
+
+function makeAlert(overrides: Partial<AlertV2Response> = {}): AlertV2Response {
+  return {
+    _id: 'a1',
+    rule_id: 'rule_1',
+    rule_name: 'High temp',
+    device_id: 'device_001',
+    status: 'firing',
+    is_open: true,
+    severity: 'critical',
+    metric: 'value',
+    comparison: 'gt',
+    threshold: 30,
+    trigger_value: 42,
+    last_value: 42,
+    breached_since: '2026-08-01T11:55:00.000Z',
+    last_observed_at: '2026-08-01T12:00:00.000Z',
+    fired_at: '2026-08-01T12:00:00.000Z',
+    audit: {
+      created_at: '2026-08-01T11:55:00.000Z',
+      created_by: 'system',
+      updated_at: '2026-08-01T12:00:00.000Z',
+      updated_by: 'system',
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  // Fixed 5 minutes after the default fixture's fired_at, so relative-time
+  // assertions are deterministic.
+  jest.setSystemTime(new Date('2026-08-01T12:05:00.000Z'));
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('ActiveAlertsWidget', () => {
+  it('should show a loading state', () => {
+    mockUseAlertsList.mockReturnValue({ data: undefined, isLoading: true, error: null });
+
+    const { container } = render(<ActiveAlertsWidget />);
+
+    expect(container.querySelector('.animate-pulse, .animate-spin')).not.toBeNull();
+    // Loading must not also present as empty or errored.
+    expect(screen.queryByText(/no active alerts/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/failed to load/i)).not.toBeInTheDocument();
+  });
+
+  it('should request the 5 highest-severity open alerts', () => {
+    mockUseAlertsList.mockReturnValue({ data: [], isLoading: false, error: null });
+
+    render(<ActiveAlertsWidget />);
+
+    // Task 12 made severity sort rank-based (critical first) rather than
+    // lexical. The widget must actually ask for that sort to benefit from it.
+    expect(mockUseAlertsList).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 5, sortBy: 'severity', sortDirection: 'desc' })
+    );
+  });
+
+  it('should show an all-clear state when nothing is open', () => {
+    mockUseAlertsList.mockReturnValue({ data: [], isLoading: false, error: null });
+
+    render(<ActiveAlertsWidget />);
+
+    expect(screen.getByText(/no active alerts/i)).toBeInTheDocument();
+    // Distinct from the error branch — not a shared fallback.
+    expect(screen.queryByText(/failed to load/i)).not.toBeInTheDocument();
+  });
+
+  it('should render alert rows with status, severity, device id, and time since fired', () => {
+    mockUseAlertsList.mockReturnValue({
+      data: [makeAlert()],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ActiveAlertsWidget />);
+
+    expect(screen.getByText('High temp')).toBeInTheDocument();
+    expect(screen.getByText(/critical/i)).toBeInTheDocument();
+    expect(screen.getByText(/firing/i)).toBeInTheDocument();
+    expect(screen.getByText('device_001')).toBeInTheDocument();
+    // fired_at is 12:00:00.000Z, fixed "now" is 12:05:00.000Z.
+    expect(screen.getByText('5 minutes ago')).toBeInTheDocument();
+  });
+
+  it('should preserve server-provided order (critical first) rather than re-sorting client-side', () => {
+    mockUseAlertsList.mockReturnValue({
+      data: [
+        makeAlert({ _id: 'a1', rule_name: 'Critical rule', severity: 'critical' }),
+        makeAlert({ _id: 'a2', rule_name: 'Info rule', severity: 'info' }),
+      ],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ActiveAlertsWidget />);
+
+    const rows = screen
+      .getAllByRole('link')
+      .filter(el => /^\/alerts\//.test(el.getAttribute('href') ?? ''));
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveTextContent('Critical rule');
+    expect(rows[1]).toHaveTextContent('Info rule');
+  });
+
+  it('should link each row to its alert page', () => {
+    mockUseAlertsList.mockReturnValue({
+      data: [makeAlert()],
+      isLoading: false,
+      error: null,
+    });
+
+    render(<ActiveAlertsWidget />);
+
+    expect(screen.getByRole('link', { name: /high temp/i })).toHaveAttribute('href', '/alerts/a1');
+  });
+
+  it('should link "View all alerts" to /alerts', () => {
+    mockUseAlertsList.mockReturnValue({ data: [], isLoading: false, error: null });
+
+    render(<ActiveAlertsWidget />);
+
+    expect(screen.getByRole('link', { name: /view all alerts/i })).toHaveAttribute(
+      'href',
+      '/alerts'
+    );
+  });
+
+  it('should show an error state', () => {
+    mockUseAlertsList.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('boom'),
+    });
+
+    render(<ActiveAlertsWidget />);
+
+    expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
+    // Distinct from the empty branch — not a shared fallback.
+    expect(screen.queryByText(/no active alerts/i)).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/unit/components/AlertBadges.test.tsx
+++ b/__tests__/unit/components/AlertBadges.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import { AlertSeverityBadge } from '@/components/alerts/AlertSeverityBadge';
+import { AlertStatusBadge } from '@/components/alerts/AlertStatusBadge';
+
+describe('AlertSeverityBadge', () => {
+  it.each(['info', 'warning', 'critical'] as const)('should render %s', severity => {
+    render(<AlertSeverityBadge severity={severity} />);
+    expect(screen.getByText(new RegExp(severity, 'i'))).toBeInTheDocument();
+  });
+
+  it('should hide the icon when showIcon is false', () => {
+    const { container } = render(<AlertSeverityBadge severity="critical" showIcon={false} />);
+    expect(container.querySelector('svg')).toBeNull();
+  });
+});
+
+describe('AlertStatusBadge', () => {
+  it.each([
+    ['firing', /firing/i],
+    ['acknowledged', /acknowledged/i],
+    ['resolved', /resolved/i],
+    ['pending', /pending/i],
+  ] as const)('should render %s', (status, pattern) => {
+    render(<AlertStatusBadge status={status} />);
+    expect(screen.getByText(pattern)).toBeInTheDocument();
+  });
+});

--- a/__tests__/unit/components/AlertDetailPage.test.tsx
+++ b/__tests__/unit/components/AlertDetailPage.test.tsx
@@ -121,9 +121,17 @@ const mockAlertDetailViewMode: { useReal: boolean } = { useReal: false };
 jest.mock('@/components/alerts/AlertDetailView', () => ({
   AlertDetailView: (props: ComponentProps<typeof AlertDetailViewType>) => {
     if (mockAlertDetailViewMode.useReal) {
+      // Typed off the `AlertDetailViewType` import already at the top of this
+      // file rather than a `typeof import(...)` annotation (banned by
+      // consistent-type-imports) or a second namespace import from the same
+      // module (banned by import/no-duplicates). Only the one binding this
+      // destructure actually takes needs describing. `AlertDetailViewType` is
+      // an `import type`, so it is erased at transpile — no runtime import of
+      // a module that `jest.mock` is intercepting, and no out-of-scope
+      // variable reference inside the factory.
       const { AlertDetailView: Real } = jest.requireActual(
         '@/components/alerts/AlertDetailView'
-      ) as typeof import('@/components/alerts/AlertDetailView');
+      ) as { AlertDetailView: typeof AlertDetailViewType };
       return <Real {...props} />;
     }
     return <div data-testid="alert-detail-view">{props.alert.rule_name}</div>;

--- a/__tests__/unit/components/AlertDetailPage.test.tsx
+++ b/__tests__/unit/components/AlertDetailPage.test.tsx
@@ -39,8 +39,17 @@ import type { AlertV2Response } from '@/types/v2';
 import type { AlertDetailView as AlertDetailViewType } from '@/components/alerts/AlertDetailView';
 
 const mockUseAlertDetail = jest.fn();
+const mockAcknowledgeMutate = jest.fn();
+const mockResolveMutate = jest.fn();
 jest.mock('@/lib/query/hooks', () => ({
   useAlertDetail: (...args: unknown[]) => mockUseAlertDetail(...args),
+  // Needed once the "readings error must reach the screen" tests below (A3,
+  // fix round 2) render the REAL AlertDetailView instead of the stub —
+  // AlertDetailView calls these two directly (mirrors the mock in
+  // AlertDetailView.test.tsx). Unused by every other test in this file,
+  // which keeps AlertDetailView stubbed.
+  useAcknowledgeAlert: () => ({ mutate: mockAcknowledgeMutate, isPending: false }),
+  useResolveAlert: () => ({ mutate: mockResolveMutate, isPending: false }),
 }));
 
 const mockUseParams = jest.fn();
@@ -77,10 +86,48 @@ jest.mock('next/link', () => {
   return Link;
 });
 
+// AlertDetailView.tsx (rendered for REAL by the "readings error must reach
+// the screen" tests below) calls useAdminAction() -> useRbac() -> Clerk's
+// useAuth(). The global jsdom setup mock (jest.setup.jsdom.ts) provides
+// useUser/useOrganization but not useAuth, so it must be supplied locally —
+// the same override AlertDetailView.test.tsx / AlertList.test.tsx already
+// apply for the same reason.
+const mockUseAuth = jest.fn(() => ({
+  isLoaded: true,
+  isSignedIn: true,
+  orgRole: 'org:admin' as const,
+  orgSlug: 'users',
+}));
+jest.mock('@clerk/nextjs', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock('react-toastify', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+// The page's own loading/404/retry-banner orchestration (covered by the
+// tests below that don't touch this flag) only needs to know AlertDetailView
+// RECEIVED the right alert, so it stays a lightweight stub by default.
+//
+// Fix round 2 (A3): the "readings error must reach the screen" describe
+// block flips `useReal` to render the ACTUAL AlertDetailView instead. This
+// is deliberate, not incidental — a stub that only echoes props back would
+// keep passing even if the page stopped threading `readingsError` through in
+// a way that actually reaches the DOM, which is exactly the regression that
+// happened in round 1 (the prop existed but nothing rendered it). Reset to
+// false in the top-level beforeEach so it never leaks into other tests.
+const mockAlertDetailViewMode: { useReal: boolean } = { useReal: false };
 jest.mock('@/components/alerts/AlertDetailView', () => ({
-  AlertDetailView: (props: ComponentProps<typeof AlertDetailViewType>) => (
-    <div data-testid="alert-detail-view">{props.alert.rule_name}</div>
-  ),
+  AlertDetailView: (props: ComponentProps<typeof AlertDetailViewType>) => {
+    if (mockAlertDetailViewMode.useReal) {
+      const { AlertDetailView: Real } = jest.requireActual(
+        '@/components/alerts/AlertDetailView'
+      ) as typeof import('@/components/alerts/AlertDetailView');
+      return <Real {...props} />;
+    }
+    return <div data-testid="alert-detail-view">{props.alert.rule_name}</div>;
+  },
 }));
 
 function makeAlert(overrides: Partial<AlertV2Response> = {}): AlertV2Response {
@@ -125,6 +172,7 @@ function renderPage() {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockAlertDetailViewMode.useReal = false;
   mockUseParams.mockReturnValue({ id: 'alert_1' });
   mockReadingsList.mockResolvedValue({ success: true, data: [] });
 });
@@ -259,6 +307,55 @@ describe('AlertDetailPage', () => {
       renderPage();
 
       expect(mockReadingsList).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- A3, fix round 2: the readings error must reach the SCREEN, not just
+  // AlertDetailView's props. Round 1 added readingsError/onRetryReadings to
+  // AlertDetailView and proved (in AlertDetailView.test.tsx) that the prop
+  // renders a visually distinct state — but this page never threaded the
+  // query's `error`/`refetch` into that prop, so the fix was inert in
+  // production. A component-only test can't catch that: it would keep
+  // passing even if this page stopped passing the prop entirely. These
+  // tests render the REAL AlertDetailView (via mockAlertDetailViewMode)
+  // specifically so a regression in the page's own wiring shows up as
+  // missing/wrong text on screen, the same way a user would see it.
+  describe('readings error must reach the screen (A3, page-level)', () => {
+    beforeEach(() => {
+      mockAlertDetailViewMode.useReal = true;
+      mockUseAlertDetail.mockReturnValue({
+        data: makeAlert({ fired_at: '2026-08-01T12:05:00.000Z' }),
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+    });
+
+    it('should render a distinct error state (with a retry affordance), not the empty-state copy, when the readings query fails', async () => {
+      mockReadingsList.mockRejectedValue(new Error('network down'));
+
+      renderPage();
+
+      await waitFor(() =>
+        expect(screen.getByText(/failed to load readings/i)).toBeInTheDocument()
+      );
+      // Must not collide with the genuinely-empty-response copy.
+      expect(screen.queryByText(/no readings in this window/i)).not.toBeInTheDocument();
+      // onRetryReadings (the query's own refetch) must have arrived too —
+      // proven by the retry affordance actually being on screen.
+      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    });
+
+    it('should render "No readings in this window." (and NOT the error affordance) when the readings query succeeds but is genuinely empty', async () => {
+      mockReadingsList.mockResolvedValue({ success: true, data: [] });
+
+      renderPage();
+
+      await waitFor(() =>
+        expect(screen.getByText(/no readings in this window/i)).toBeInTheDocument()
+      );
+      expect(screen.queryByText(/failed to load readings/i)).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
     });
   });
 });

--- a/__tests__/unit/components/AlertDetailPage.test.tsx
+++ b/__tests__/unit/components/AlertDetailPage.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * AlertDetailPage Tests
+ *
+ * Not in task-16-brief.md's literal file list (which only names
+ * AlertDetailView.test.tsx), but added per the orchestrator's explicit
+ * instruction to report deletion-check evidence for the loading, error/404,
+ * and admin-gating states. The page (not AlertDetailView) is where the
+ * loading spinner and the notFound()/retry-banner branching actually live —
+ * `app/devices/[id]/page.tsx` has no direct test either, precisely because
+ * that logic sits in the separately-tested `useDeviceDetail` hook; this page
+ * has no such hook (it inlines useAlertDetail + a raw useQuery), so the page
+ * itself is what needs a direct test here.
+ *
+ * `@/lib/query/hooks` (useAlertDetail), `next/navigation`
+ * (useParams/notFound), and `@tanstack/react-query` (useQuery, for the
+ * bracketing-readings query) are all mocked so the page's own
+ * loading/error/notFound orchestration can be exercised without a real
+ * QueryClientProvider or network. `AlertDetailView` is mocked to a stub so
+ * this file stays scoped to the page's own logic — AlertDetailView.test.tsx
+ * already covers the presentational component in depth.
+ */
+
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { ComponentProps } from 'react';
+import AlertDetailPage from '@/app/alerts/[id]/page';
+import { ApiClientError } from '@/lib/api/v2-client';
+import type { AlertV2Response } from '@/types/v2';
+import type { AlertDetailView as AlertDetailViewType } from '@/components/alerts/AlertDetailView';
+
+const mockUseAlertDetail = jest.fn();
+jest.mock('@/lib/query/hooks', () => ({
+  useAlertDetail: (...args: unknown[]) => mockUseAlertDetail(...args),
+}));
+
+const mockUseParams = jest.fn();
+const mockNotFound = jest.fn();
+jest.mock('next/navigation', () => ({
+  useParams: () => mockUseParams(),
+  notFound: () => mockNotFound(),
+}));
+
+// The page's own inline useQuery (for bracketing readings) needs no
+// QueryClientProvider once mocked — its wiring isn't this file's concern.
+// requireActual keeps the real QueryClient class intact: lib/query/queryClient.ts
+// (imported transitively for queryKeys) instantiates one at module load time.
+jest.mock('@tanstack/react-query', () => ({
+  ...jest.requireActual('@tanstack/react-query'),
+  useQuery: () => ({ data: [], isLoading: false }),
+}));
+
+jest.mock('next/link', () => {
+  const Link = ({ href, children, ...rest }: ComponentProps<'a'>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  );
+  Link.displayName = 'Link';
+  return Link;
+});
+
+jest.mock('@/components/alerts/AlertDetailView', () => ({
+  AlertDetailView: (props: ComponentProps<typeof AlertDetailViewType>) => (
+    <div data-testid="alert-detail-view">{props.alert.rule_name}</div>
+  ),
+}));
+
+function makeAlert(overrides: Partial<AlertV2Response> = {}): AlertV2Response {
+  return {
+    _id: 'alert_1',
+    rule_id: 'rule_1',
+    rule_name: 'High temperature',
+    device_id: 'device_001',
+    status: 'firing',
+    is_open: true,
+    severity: 'critical',
+    metric: 'value',
+    comparison: 'gt',
+    threshold: 30,
+    trigger_value: 42,
+    last_value: 41,
+    breached_since: '2026-08-01T12:00:00.000Z',
+    last_observed_at: '2026-08-01T12:10:00.000Z',
+    fired_at: '2026-08-01T12:05:00.000Z',
+    audit: {
+      created_at: '2026-08-01T12:00:00.000Z',
+      created_by: 'system',
+      updated_at: '2026-08-01T12:10:00.000Z',
+      updated_by: 'system',
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseParams.mockReturnValue({ id: 'alert_1' });
+});
+
+describe('AlertDetailPage', () => {
+  it('should show a loading spinner while the alert is loading, and not render the view or 404', () => {
+    mockUseAlertDetail.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    const { container } = render(<AlertDetailPage />);
+
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+    expect(screen.queryByTestId('alert-detail-view')).not.toBeInTheDocument();
+    expect(mockNotFound).not.toHaveBeenCalled();
+  });
+
+  it('should render the styled not-found state for an alert id that does not resolve (404)', () => {
+    mockUseAlertDetail.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new ApiClientError(404, 'ALERT_NOT_FOUND', 'Alert not found'),
+      refetch: jest.fn(),
+    });
+
+    render(<AlertDetailPage />);
+
+    expect(mockNotFound).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show a retry banner (not the 404 page) for a non-404 error', () => {
+    mockUseAlertDetail.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new ApiClientError(500, 'NETWORK_ERROR', 'Network error occurred'),
+      refetch: jest.fn(),
+    });
+
+    render(<AlertDetailPage />);
+
+    expect(mockNotFound).not.toHaveBeenCalled();
+    expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('alert-detail-view')).not.toBeInTheDocument();
+  });
+
+  it('should render AlertDetailView once the alert loads, and not call notFound', () => {
+    mockUseAlertDetail.mockReturnValue({
+      data: makeAlert(),
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    render(<AlertDetailPage />);
+
+    expect(screen.getByTestId('alert-detail-view')).toHaveTextContent('High temperature');
+    expect(mockNotFound).not.toHaveBeenCalled();
+  });
+
+  it('should pass retry: false to useAlertDetail so a 404 does not spin through retries first', () => {
+    mockUseAlertDetail.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    render(<AlertDetailPage />);
+
+    const [, , config] = mockUseAlertDetail.mock.calls[0];
+    expect(config).toMatchObject({ retry: false });
+  });
+});

--- a/__tests__/unit/components/AlertDetailPage.test.tsx
+++ b/__tests__/unit/components/AlertDetailPage.test.tsx
@@ -11,18 +11,28 @@
  * has no such hook (it inlines useAlertDetail + a raw useQuery), so the page
  * itself is what needs a direct test here.
  *
- * `@/lib/query/hooks` (useAlertDetail), `next/navigation`
- * (useParams/notFound), and `@tanstack/react-query` (useQuery, for the
- * bracketing-readings query) are all mocked so the page's own
- * loading/error/notFound orchestration can be exercised without a real
- * QueryClientProvider or network. `AlertDetailView` is mocked to a stub so
- * this file stays scoped to the page's own logic — AlertDetailView.test.tsx
- * already covers the presentational component in depth.
+ * Fix round 1 (task-16 review): the bracketing-readings `useQuery` used to be
+ * mocked wholesale (`useQuery: () => ({ data: [], isLoading: false })`),
+ * which is exactly what let a real bug ship invisibly — the query never
+ * specified `limit`/`sortBy`/`sortDirection`, so the endpoint's defaults
+ * (limit 20, newest-first) silently truncated the early part of the
+ * bracketing window on any device reporting faster than ~90s. That mock is
+ * gone. `@tanstack/react-query` now runs for real against a real
+ * QueryClient, and `v2Api.readings.list` is mocked at the network boundary
+ * instead, so the query's actual params are observable and assertable.
+ *
+ * `@/lib/query/hooks` (useAlertDetail) and `next/navigation`
+ * (useParams/notFound) stay mocked so the page's own loading/error/notFound
+ * orchestration can still be driven directly. `AlertDetailView` is mocked to
+ * a stub so this file stays scoped to the page's own logic —
+ * AlertDetailView.test.tsx already covers the presentational component in
+ * depth.
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import type { ComponentProps } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import AlertDetailPage from '@/app/alerts/[id]/page';
 import { ApiClientError } from '@/lib/api/v2-client';
 import type { AlertV2Response } from '@/types/v2';
@@ -40,14 +50,22 @@ jest.mock('next/navigation', () => ({
   notFound: () => mockNotFound(),
 }));
 
-// The page's own inline useQuery (for bracketing readings) needs no
-// QueryClientProvider once mocked — its wiring isn't this file's concern.
-// requireActual keeps the real QueryClient class intact: lib/query/queryClient.ts
-// (imported transitively for queryKeys) instantiates one at module load time.
-jest.mock('@tanstack/react-query', () => ({
-  ...jest.requireActual('@tanstack/react-query'),
-  useQuery: () => ({ data: [], isLoading: false }),
-}));
+// Only readings.list is overridden — everything else (including the real
+// ApiClientError class used below to build 404/500 fixtures) stays real.
+const mockReadingsList = jest.fn();
+jest.mock('@/lib/api/v2-client', () => {
+  const actual = jest.requireActual('@/lib/api/v2-client');
+  return {
+    ...actual,
+    v2Api: {
+      ...actual.v2Api,
+      readings: {
+        ...actual.v2Api.readings,
+        list: (...args: unknown[]) => mockReadingsList(...args),
+      },
+    },
+  };
+});
 
 jest.mock('next/link', () => {
   const Link = ({ href, children, ...rest }: ComponentProps<'a'>) => (
@@ -92,9 +110,23 @@ function makeAlert(overrides: Partial<AlertV2Response> = {}): AlertV2Response {
   };
 }
 
+/** Fresh QueryClient per render — real useQuery, no retries, so a mocked
+ * rejection settles immediately instead of retrying into a timeout. */
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AlertDetailPage />
+    </QueryClientProvider>
+  );
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   mockUseParams.mockReturnValue({ id: 'alert_1' });
+  mockReadingsList.mockResolvedValue({ success: true, data: [] });
 });
 
 describe('AlertDetailPage', () => {
@@ -106,11 +138,13 @@ describe('AlertDetailPage', () => {
       refetch: jest.fn(),
     });
 
-    const { container } = render(<AlertDetailPage />);
+    const { container } = renderPage();
 
     expect(container.querySelector('.animate-spin')).toBeInTheDocument();
     expect(screen.queryByTestId('alert-detail-view')).not.toBeInTheDocument();
     expect(mockNotFound).not.toHaveBeenCalled();
+    // No device_id yet, so the bracketing-readings query must stay disabled.
+    expect(mockReadingsList).not.toHaveBeenCalled();
   });
 
   it('should render the styled not-found state for an alert id that does not resolve (404)', () => {
@@ -121,7 +155,7 @@ describe('AlertDetailPage', () => {
       refetch: jest.fn(),
     });
 
-    render(<AlertDetailPage />);
+    renderPage();
 
     expect(mockNotFound).toHaveBeenCalledTimes(1);
   });
@@ -134,7 +168,7 @@ describe('AlertDetailPage', () => {
       refetch: jest.fn(),
     });
 
-    render(<AlertDetailPage />);
+    renderPage();
 
     expect(mockNotFound).not.toHaveBeenCalled();
     expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
@@ -149,7 +183,7 @@ describe('AlertDetailPage', () => {
       refetch: jest.fn(),
     });
 
-    render(<AlertDetailPage />);
+    renderPage();
 
     expect(screen.getByTestId('alert-detail-view')).toHaveTextContent('High temperature');
     expect(mockNotFound).not.toHaveBeenCalled();
@@ -163,9 +197,68 @@ describe('AlertDetailPage', () => {
       refetch: jest.fn(),
     });
 
-    render(<AlertDetailPage />);
+    renderPage();
 
     const [, , config] = mockUseAlertDetail.mock.calls[0];
     expect(config).toMatchObject({ retry: false });
+  });
+
+  // --- Bracketing-readings query wiring (fix round 1) ----------------------
+
+  describe('bracketing readings query', () => {
+    it('should request an explicit limit and ascending sort, windowed +/-15m on fired_at', async () => {
+      mockUseAlertDetail.mockReturnValue({
+        data: makeAlert({ fired_at: '2026-08-01T12:05:00.000Z' }),
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderPage();
+
+      await waitFor(() => expect(mockReadingsList).toHaveBeenCalledTimes(1));
+
+      expect(mockReadingsList).toHaveBeenCalledWith({
+        device_id: 'device_001',
+        startDate: '2026-08-01T11:50:00.000Z',
+        endDate: '2026-08-01T12:20:00.000Z',
+        limit: 100,
+        sortBy: 'timestamp',
+        sortDirection: 'asc',
+      });
+    });
+
+    it('should fall back to breached_since when fired_at is absent (pending episodes are never visible, but defend anyway)', async () => {
+      mockUseAlertDetail.mockReturnValue({
+        data: makeAlert({ fired_at: undefined, breached_since: '2026-08-01T09:00:00.000Z' }),
+        isLoading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderPage();
+
+      await waitFor(() => expect(mockReadingsList).toHaveBeenCalledTimes(1));
+
+      expect(mockReadingsList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          startDate: '2026-08-01T08:45:00.000Z',
+          endDate: '2026-08-01T09:15:00.000Z',
+        })
+      );
+    });
+
+    it('should not request readings before the alert (and its device_id) has loaded', () => {
+      mockUseAlertDetail.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderPage();
+
+      expect(mockReadingsList).not.toHaveBeenCalled();
+    });
   });
 });

--- a/__tests__/unit/components/AlertDetailView.test.tsx
+++ b/__tests__/unit/components/AlertDetailView.test.tsx
@@ -147,10 +147,15 @@ describe('AlertDetailView', () => {
     );
 
     expect(screen.getByText(/acknowledged/i)).toBeInTheDocument();
-    // The status badge is the sole "Resolved" text; the timeline's own closing
-    // step deliberately avoids repeating the word (see "resolution wording"
-    // tests below) so this stays a single, unambiguous match.
-    expect(screen.getByText(/resolved/i)).toBeInTheDocument();
+    // D4 fix: this used to assert /resolved/i, which is satisfied by the
+    // status badge alone (AlertStatusBadge renders the literal text
+    // "Resolved") and says nothing about the timeline's own closing step —
+    // RESOLUTION_LABELS deliberately avoids the word "resolved" so the two
+    // don't collide. Asserting the real label text ("closed manually", from
+    // RESOLUTION_LABELS.manual) is the only way this test can actually fail
+    // if the resolved timeline block is deleted; see the task report for the
+    // deletion-check evidence.
+    expect(screen.getByText(/closed manually/i)).toBeInTheDocument();
   });
 
   it('should link to the device', () => {
@@ -312,6 +317,75 @@ describe('AlertDetailView', () => {
 
       expect(container.querySelector('.animate-spin')).not.toBeInTheDocument();
       expect(screen.getByText(/no readings in this window/i)).toBeInTheDocument();
+      // Distinct from the error branch (A3) — not a shared fallback.
+      expect(screen.queryByText(/failed to load readings/i)).not.toBeInTheDocument();
+    });
+  });
+
+  // --- A3: a failed readings fetch must render a state visually distinct
+  // from "No readings in this window." (the signature of a genuinely empty,
+  // successful response) — the two must never collapse into the same output.
+  describe('bracketing readings error state (A3)', () => {
+    it('should render a distinct error state instead of the empty-state copy when the readings query fails', () => {
+      render(
+        <AlertDetailView
+          alert={alert()}
+          bracketingReadings={[]}
+          loading={false}
+          readingsError={new Error('network down')}
+        />
+      );
+
+      expect(screen.getByText(/failed to load readings/i)).toBeInTheDocument();
+      // The empty-state copy reads as "stale/device_inactive" (see the
+      // component's own RESOLUTION_LABELS doc comment) — the wrong
+      // diagnosis for a fetch that never actually completed.
+      expect(screen.queryByText(/no readings in this window/i)).not.toBeInTheDocument();
+    });
+
+    it('should offer a retry affordance in the error state, and call it when clicked', () => {
+      const onRetryReadings = jest.fn();
+
+      render(
+        <AlertDetailView
+          alert={alert()}
+          bracketingReadings={[]}
+          loading={false}
+          readingsError={new Error('network down')}
+          onRetryReadings={onRetryReadings}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+      expect(onRetryReadings).toHaveBeenCalledTimes(1);
+    });
+
+    it('should prioritize the loading spinner over the error state while still loading', () => {
+      const { container } = render(
+        <AlertDetailView
+          alert={alert()}
+          bracketingReadings={[]}
+          loading
+          readingsError={new Error('network down')}
+        />
+      );
+
+      expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+      expect(screen.queryByText(/failed to load readings/i)).not.toBeInTheDocument();
+    });
+
+    it('should not render a retry button when no retry callback is provided', () => {
+      render(
+        <AlertDetailView
+          alert={alert()}
+          bracketingReadings={[]}
+          loading={false}
+          readingsError={new Error('network down')}
+        />
+      );
+
+      expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
     });
   });
 

--- a/__tests__/unit/components/AlertDetailView.test.tsx
+++ b/__tests__/unit/components/AlertDetailView.test.tsx
@@ -1,0 +1,425 @@
+/**
+ * AlertDetailView Tests
+ *
+ * `@/lib/query/hooks` is mocked at the exact module specifier AlertDetailView.tsx
+ * imports from (useAcknowledgeAlert/useResolveAlert), because the component calls
+ * those mutation hooks directly (mirroring AlertList.tsx's self-contained
+ * pattern) and rendering a real useMutation() with no QueryClientProvider in
+ * scope throws.
+ *
+ * `useAdminAction`/`useRbac` (lib/auth/rbac-client.tsx) are deliberately NOT
+ * mocked — only their dependency on Clerk's `useAuth` is stubbed, exactly like
+ * __tests__/unit/components/AlertList.test.tsx does. That exercises the real
+ * useAdminAction() gating contract end to end instead of only proving the
+ * component reads a mocked return value correctly (the class of bug Task 15's
+ * review flagged: hand-rolled gating that bypassed useAdminAction entirely).
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { AlertDetailView } from '@/components/alerts/AlertDetailView';
+import type { AlertV2Response } from '@/types/v2';
+
+const mockAcknowledgeMutate = jest.fn();
+const mockResolveMutate = jest.fn();
+let acknowledgeIsPending = false;
+let resolveIsPending = false;
+
+jest.mock('@/lib/query/hooks', () => ({
+  useAcknowledgeAlert: () => ({ mutate: mockAcknowledgeMutate, isPending: acknowledgeIsPending }),
+  useResolveAlert: () => ({ mutate: mockResolveMutate, isPending: resolveIsPending }),
+}));
+
+const mockUseAuth = jest.fn();
+jest.mock('@clerk/nextjs', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+jest.mock('react-toastify', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+function signedInAs(orgRole: 'org:admin' | 'org:member', orgSlug = 'users') {
+  mockUseAuth.mockReturnValue({ isLoaded: true, isSignedIn: true, orgRole, orgSlug });
+}
+
+function setDemoMode(value: 'true' | undefined) {
+  if (value === undefined) delete process.env.NEXT_PUBLIC_DEMO_MODE;
+  else process.env.NEXT_PUBLIC_DEMO_MODE = value;
+}
+
+const ORIGINAL_DEMO_MODE = process.env.NEXT_PUBLIC_DEMO_MODE;
+
+function alert(overrides: Partial<AlertV2Response> = {}): AlertV2Response {
+  return {
+    _id: '507f1f77bcf86cd799439011',
+    rule_id: '507f1f77bcf86cd799439012',
+    rule_name: 'High temperature',
+    device_id: 'device_001',
+    status: 'firing',
+    is_open: true,
+    severity: 'critical',
+    metric: 'value',
+    comparison: 'gt',
+    threshold: 30,
+    trigger_value: 42,
+    last_value: 41,
+    breached_since: '2026-08-01T12:00:00.000Z',
+    last_observed_at: '2026-08-01T12:10:00.000Z',
+    fired_at: '2026-08-01T12:05:00.000Z',
+    audit: {
+      created_at: '2026-08-01T12:00:00.000Z',
+      created_by: 'system',
+      updated_at: '2026-08-01T12:10:00.000Z',
+      updated_by: 'system',
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  acknowledgeIsPending = false;
+  resolveIsPending = false;
+  setDemoMode(undefined);
+  // Most tests below don't care about role; default to admin so
+  // Acknowledge/Resolve are visible+enabled unless a test says otherwise.
+  signedInAs('org:admin');
+});
+
+afterEach(() => {
+  setDemoMode(ORIGINAL_DEMO_MODE as 'true' | undefined);
+});
+
+describe('AlertDetailView', () => {
+  it('should state the condition in plain language', () => {
+    render(<AlertDetailView alert={alert()} bracketingReadings={[]} loading={false} />);
+
+    expect(screen.getByText(/above 30/i)).toBeInTheDocument();
+  });
+
+  it('should mention the duration when the rule has one', () => {
+    render(
+      <AlertDetailView
+        alert={alert()}
+        bracketingReadings={[]}
+        loading={false}
+        forDurationSeconds={300}
+      />
+    );
+
+    expect(screen.getByText(/for 5 minutes/i)).toBeInTheDocument();
+  });
+
+  it('should render the lifecycle timeline', () => {
+    render(<AlertDetailView alert={alert()} bracketingReadings={[]} loading={false} />);
+
+    expect(screen.getByText(/breached since/i)).toBeInTheDocument();
+    expect(screen.getByText(/fired/i)).toBeInTheDocument();
+  });
+
+  it('should show acknowledged and resolved steps once they exist', () => {
+    render(
+      <AlertDetailView
+        alert={alert({
+          status: 'resolved',
+          is_open: false,
+          audit: {
+            created_at: '2026-08-01T12:00:00.000Z',
+            created_by: 'system',
+            updated_at: '2026-08-01T12:40:00.000Z',
+            updated_by: 'user_1',
+            acknowledged_at: '2026-08-01T12:20:00.000Z',
+            acknowledged_by: 'user_1',
+            resolved_at: '2026-08-01T12:40:00.000Z',
+            resolved_by: 'user_1',
+            resolution: 'manual',
+          },
+        })}
+        bracketingReadings={[]}
+        loading={false}
+      />
+    );
+
+    expect(screen.getByText(/acknowledged/i)).toBeInTheDocument();
+    // The status badge is the sole "Resolved" text; the timeline's own closing
+    // step deliberately avoids repeating the word (see "resolution wording"
+    // tests below) so this stays a single, unambiguous match.
+    expect(screen.getByText(/resolved/i)).toBeInTheDocument();
+  });
+
+  it('should link to the device', () => {
+    render(<AlertDetailView alert={alert()} bracketingReadings={[]} loading={false} />);
+
+    expect(screen.getByRole('link', { name: /device_001/i })).toHaveAttribute(
+      'href',
+      '/devices/device_001'
+    );
+  });
+
+  it('should render the bracketing readings', () => {
+    render(
+      <AlertDetailView
+        alert={alert()}
+        bracketingReadings={[
+          { timestamp: '2026-08-01T12:04:00.000Z', value: 29 },
+          { timestamp: '2026-08-01T12:05:00.000Z', value: 42 },
+        ]}
+        loading={false}
+      />
+    );
+
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  // --- Additional coverage beyond the brief's literal 6 tests -------------
+
+  describe('resolution wording (auto vs stale/device_inactive)', () => {
+    it('should describe an automatic resolution distinctly from a stale/inactive closure', () => {
+      const resolvedAudit = {
+        created_at: '2026-08-01T12:00:00.000Z',
+        created_by: 'system',
+        updated_at: '2026-08-01T12:40:00.000Z',
+        updated_by: 'system',
+        resolved_at: '2026-08-01T12:40:00.000Z',
+        resolved_by: 'system',
+      };
+
+      const { rerender } = render(
+        <AlertDetailView
+          alert={alert({
+            status: 'resolved',
+            is_open: false,
+            audit: { ...resolvedAudit, resolution: 'auto' },
+          })}
+          bracketingReadings={[]}
+          loading={false}
+        />
+      );
+      expect(screen.getByText(/back within threshold/i)).toBeInTheDocument();
+
+      rerender(
+        <AlertDetailView
+          alert={alert({
+            status: 'resolved',
+            is_open: false,
+            audit: { ...resolvedAudit, resolution: 'stale' },
+          })}
+          bracketingReadings={[]}
+          loading={false}
+        />
+      );
+      expect(screen.getByText(/stale/i)).toBeInTheDocument();
+      expect(screen.queryByText(/back within threshold/i)).not.toBeInTheDocument();
+
+      rerender(
+        <AlertDetailView
+          alert={alert({
+            status: 'resolved',
+            is_open: false,
+            audit: { ...resolvedAudit, resolution: 'device_inactive' },
+          })}
+          bracketingReadings={[]}
+          loading={false}
+        />
+      );
+      expect(screen.getByText(/device went inactive/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('actors on the timeline', () => {
+    it('should show the actor beside both the acknowledged and closed steps', () => {
+      render(
+        <AlertDetailView
+          alert={alert({
+            status: 'resolved',
+            is_open: false,
+            audit: {
+              created_at: '2026-08-01T12:00:00.000Z',
+              created_by: 'system',
+              updated_at: '2026-08-01T12:40:00.000Z',
+              updated_by: 'alice',
+              acknowledged_at: '2026-08-01T12:20:00.000Z',
+              acknowledged_by: 'alice',
+              resolved_at: '2026-08-01T12:40:00.000Z',
+              resolved_by: 'bob',
+              resolution: 'manual',
+            },
+          })}
+          bracketingReadings={[]}
+          loading={false}
+        />
+      );
+
+      expect(screen.getByText(/acknowledged.*alice/i)).toBeInTheDocument();
+      expect(screen.getByText(/bob/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('resolved_value is conditional', () => {
+    it('should not render a closing value when resolved_value is absent (manual/swept resolution)', () => {
+      render(
+        <AlertDetailView
+          alert={alert({
+            status: 'resolved',
+            is_open: false,
+            resolved_value: undefined,
+          })}
+          bracketingReadings={[]}
+          loading={false}
+        />
+      );
+
+      expect(screen.queryByText(/closing value/i)).not.toBeInTheDocument();
+    });
+
+    it('should render the closing value when auto-resolution attributes one', () => {
+      render(
+        <AlertDetailView
+          alert={alert({
+            status: 'resolved',
+            is_open: false,
+            resolved_value: 24,
+          })}
+          bracketingReadings={[]}
+          loading={false}
+        />
+      );
+
+      expect(screen.getByText(/closing value: 24/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('bracketing readings loading state', () => {
+    it('should show a loading indicator for the readings table while it loads', () => {
+      const { container } = render(
+        <AlertDetailView alert={alert()} bracketingReadings={[]} loading />
+      );
+
+      expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+      expect(screen.queryByText(/no readings in this window/i)).not.toBeInTheDocument();
+    });
+
+    it('should show an empty state once loaded with no bracketing readings', () => {
+      const { container } = render(
+        <AlertDetailView alert={alert()} bracketingReadings={[]} loading={false} />
+      );
+
+      expect(container.querySelector('.animate-spin')).not.toBeInTheDocument();
+      expect(screen.getByText(/no readings in this window/i)).toBeInTheDocument();
+    });
+  });
+
+  // --- The three useAdminAction() branches, and the button visibility rules -
+
+  describe('admin gating on Acknowledge/Resolve (via useAdminAction)', () => {
+    it('should render Acknowledge and Resolve ENABLED for an admin, with no tooltip', () => {
+      signedInAs('org:admin');
+
+      render(<AlertDetailView alert={alert()} bracketingReadings={[]} loading={false} />);
+
+      const acknowledgeBtn = screen.getByRole('button', { name: /acknowledge/i });
+      const resolveBtn = screen.getByRole('button', { name: /resolve/i });
+
+      expect(acknowledgeBtn).not.toBeDisabled();
+      expect(acknowledgeBtn).not.toHaveAttribute('title');
+      expect(resolveBtn).not.toBeDisabled();
+      expect(resolveBtn).not.toHaveAttribute('title');
+    });
+
+    it('should render Acknowledge and Resolve PRESENT but DISABLED with a tooltip for a non-admin in demo mode', () => {
+      signedInAs('org:member');
+      setDemoMode('true');
+
+      render(<AlertDetailView alert={alert()} bracketingReadings={[]} loading={false} />);
+
+      const acknowledgeBtn = screen.getByRole('button', { name: /acknowledge/i });
+      const resolveBtn = screen.getByRole('button', { name: /resolve/i });
+
+      expect(acknowledgeBtn).toBeInTheDocument();
+      expect(acknowledgeBtn).toBeDisabled();
+      expect(acknowledgeBtn).toHaveAttribute('title', expect.stringMatching(/admin/i));
+
+      expect(resolveBtn).toBeInTheDocument();
+      expect(resolveBtn).toBeDisabled();
+      expect(resolveBtn).toHaveAttribute('title', expect.stringMatching(/admin/i));
+    });
+
+    it('should HIDE Acknowledge and Resolve entirely for a non-admin outside demo mode', () => {
+      signedInAs('org:member');
+      setDemoMode(undefined);
+
+      render(<AlertDetailView alert={alert()} bracketingReadings={[]} loading={false} />);
+
+      expect(screen.queryByRole('button', { name: /acknowledge/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /resolve/i })).not.toBeInTheDocument();
+    });
+
+    it('should not render Acknowledge for an alert that is not firing, regardless of role', () => {
+      signedInAs('org:admin');
+
+      render(
+        <AlertDetailView
+          alert={alert({ status: 'acknowledged', is_open: true })}
+          bracketingReadings={[]}
+          loading={false}
+        />
+      );
+
+      expect(screen.queryByRole('button', { name: /acknowledge/i })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /resolve/i })).toBeInTheDocument();
+    });
+
+    it('should not render Resolve for an alert that is already resolved (not open)', () => {
+      signedInAs('org:admin');
+
+      render(
+        <AlertDetailView
+          alert={alert({ status: 'resolved', is_open: false })}
+          bracketingReadings={[]}
+          loading={false}
+        />
+      );
+
+      expect(screen.queryByRole('button', { name: /resolve/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('admin actions', () => {
+    it('should acknowledge with the alert id and toast success on completion', () => {
+      signedInAs('org:admin');
+
+      render(<AlertDetailView alert={alert()} bracketingReadings={[]} loading={false} />);
+      fireEvent.click(screen.getByRole('button', { name: /acknowledge/i }));
+
+      expect(mockAcknowledgeMutate).toHaveBeenCalledTimes(1);
+      const [variables, options] = mockAcknowledgeMutate.mock.calls[0];
+      expect(variables).toEqual({ id: '507f1f77bcf86cd799439011' });
+
+      options.onSuccess();
+      expect(mockToastSuccess).toHaveBeenCalledWith('Alert acknowledged');
+
+      options.onError(new Error('boom'));
+      expect(mockToastError).toHaveBeenCalledWith('boom');
+    });
+
+    it('should resolve with the alert id and toast success on completion', () => {
+      signedInAs('org:admin');
+
+      render(<AlertDetailView alert={alert()} bracketingReadings={[]} loading={false} />);
+      fireEvent.click(screen.getByRole('button', { name: /resolve/i }));
+
+      expect(mockResolveMutate).toHaveBeenCalledTimes(1);
+      const [variables, options] = mockResolveMutate.mock.calls[0];
+      expect(variables).toEqual({ id: '507f1f77bcf86cd799439011' });
+
+      options.onSuccess();
+      expect(mockToastSuccess).toHaveBeenCalledWith('Alert resolved');
+    });
+  });
+});

--- a/__tests__/unit/components/AlertList.test.tsx
+++ b/__tests__/unit/components/AlertList.test.tsx
@@ -32,6 +32,13 @@ import '@testing-library/jest-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AlertList, formatRelativeTime } from '@/components/alerts/AlertList';
 import type { AlertV2Response } from '@/types/v2';
+// Namespace TYPE imports, used only to annotate the `jest.requireActual`
+// calls further down. `import type` is erased entirely at transpile, so
+// neither of these emits a runtime import — which matters here rather than
+// being a stylistic nicety: a VALUE import of '@/lib/query/hooks' would pull
+// the real module in and defeat the `jest.mock` these tests depend on.
+import type * as AlertQueryHooks from '@/lib/query/hooks';
+import type * as UseAlertFilterParamsModule from '@/components/alerts/useAlertFilterParams';
 
 const mockUseAlertsList = jest.fn();
 const mockAcknowledgeMutate = jest.fn();
@@ -77,11 +84,11 @@ jest.mock('react-toastify', () => ({
 // `v2Api.alerts.list` are mocked instead — the network boundary, not the
 // hooks under test — mirroring AlertDetailPage.test.tsx's established
 // `jest.requireActual(...)` partial-mock idiom.
-const actualAlertHooks = jest.requireActual(
-  '@/lib/query/hooks'
-) as typeof import('@/lib/query/hooks');
+const actualAlertHooks = jest.requireActual('@/lib/query/hooks') as typeof AlertQueryHooks;
 const actualUseAlertFilterParams = (
-  jest.requireActual('@/components/alerts/useAlertFilterParams') as typeof import('@/components/alerts/useAlertFilterParams')
+  jest.requireActual(
+    '@/components/alerts/useAlertFilterParams'
+  ) as typeof UseAlertFilterParamsModule
 ).useAlertFilterParams;
 
 const mockV2ApiAlertsList = jest.fn();
@@ -110,7 +117,14 @@ const mockNavState: { search: string; listeners: Set<() => void> } = {
   search: '',
   listeners: new Set(),
 };
-const mockRouterPush = jest.fn((url: string) => {
+// The second parameter mirrors next/navigation's real `push(href, options?)`
+// signature. It is declared but unused: the mock only needs `href` to drive
+// `useSearchParams`, while `jest.fn`'s recorded calls keep whatever the second
+// argument was for the assertions below. Typing it is not cosmetic — without
+// it the `push` wrapper at the useRouter mock spreads two arguments into a
+// one-argument function, which is a `tsc` error that ts-jest's transpile-only
+// mode does not surface.
+const mockRouterPush = jest.fn((url: string, _options?: unknown) => {
   const query = url.includes('?') ? url.slice(url.indexOf('?') + 1) : '';
   mockNavState.search = query;
   mockNavState.listeners.forEach(listener => listener());

--- a/__tests__/unit/components/AlertList.test.tsx
+++ b/__tests__/unit/components/AlertList.test.tsx
@@ -1,25 +1,35 @@
 /**
  * AlertList Tests
  *
- * `@/lib/query/hooks`, `@/lib/auth/rbac-client`, and
- * `@/components/alerts/useAlertFilterParams` are mocked at the exact module
- * specifiers AlertList.tsx imports from (matching the working pattern in
- * DashboardStatCards.test.tsx) so the mock actually intercepts the import
- * AlertList uses, rather than a barrel re-export that never gets hit.
+ * `@/lib/query/hooks` and `@/components/alerts/useAlertFilterParams` are
+ * mocked at the exact module specifiers AlertList.tsx imports from (matching
+ * the working pattern in DashboardStatCards.test.tsx) so the mock actually
+ * intercepts the import AlertList uses, rather than a barrel re-export that
+ * never gets hit.
  *
- * The admin-gated Acknowledge/Resolve buttons are the focus: per the Phase 4
- * demo-mode rule, they must render DISABLED for a non-admin, never hidden, so
- * a visitor can see the workflow exists. A test that only checks the button
- * is disabled would pass vacuously if the button were hidden entirely (the
- * query would throw first); a test that only checks the button is present
- * would pass against a permanently-enabled button. Both are asserted below,
- * for both roles, and the deletion-check evidence proving each half actually
- * catches a regression is recorded in the task report.
+ * `useAdminAction`/`useRbac` (lib/auth/rbac-client.tsx) are deliberately NOT
+ * mocked — only their dependency on Clerk's `useAuth` is stubbed, exactly like
+ * __tests__/unit/lib/rbac-client.test.ts does for useRbac directly. That way
+ * these tests exercise the real gating contract end to end (mocking
+ * useAdminAction itself would only prove AlertList reads a mock correctly,
+ * not that the wiring to the real hook is correct — which is the class of bug
+ * fixed in this round: AlertList previously hand-rolled its own isAdmin
+ * gating instead of using useAdminAction()).
+ *
+ * The admin-gated Acknowledge/Resolve buttons are the focus. Per
+ * useAdminAction's three-branch contract: an admin sees them enabled; a
+ * non-admin in demo mode sees them present-and-disabled with a tooltip (so a
+ * visitor can see the workflow exists); a non-admin outside demo mode sees
+ * them absent entirely (matching every other admin-gated control in the
+ * app — app/devices/page.tsx, app/analytics/page.tsx, app/maintenance/page.tsx,
+ * app/page.tsx). All three branches are asserted below, and the
+ * deletion-check evidence proving each one actually catches a regression is
+ * recorded in the task report.
  */
 
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { AlertList } from '@/components/alerts/AlertList';
+import { AlertList, formatRelativeTime } from '@/components/alerts/AlertList';
 import type { AlertV2Response } from '@/types/v2';
 
 const mockUseAlertsList = jest.fn();
@@ -35,9 +45,9 @@ jest.mock('@/lib/query/hooks', () => ({
   useResolveAlert: () => ({ mutate: mockResolveMutate, isPending: resolveIsPending }),
 }));
 
-const mockUseRbac = jest.fn();
-jest.mock('@/lib/auth/rbac-client', () => ({
-  useRbac: () => mockUseRbac(),
+const mockUseAuth = jest.fn();
+jest.mock('@clerk/nextjs', () => ({
+  useAuth: () => mockUseAuth(),
 }));
 
 const mockUseAlertFilterParams = jest.fn();
@@ -53,6 +63,17 @@ jest.mock('react-toastify', () => ({
     error: (...args: unknown[]) => mockToastError(...args),
   },
 }));
+
+function signedInAs(orgRole: 'org:admin' | 'org:member', orgSlug = 'users') {
+  mockUseAuth.mockReturnValue({ isLoaded: true, isSignedIn: true, orgRole, orgSlug });
+}
+
+function setDemoMode(value: 'true' | undefined) {
+  if (value === undefined) delete process.env.NEXT_PUBLIC_DEMO_MODE;
+  else process.env.NEXT_PUBLIC_DEMO_MODE = value;
+}
+
+const ORIGINAL_DEMO_MODE = process.env.NEXT_PUBLIC_DEMO_MODE;
 
 function makeAlert(overrides: Partial<AlertV2Response> = {}): AlertV2Response {
   return {
@@ -94,8 +115,16 @@ function defaultFilterParams() {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  jest.useFakeTimers();
+  // Fixed 5 minutes after the default fixture's fired_at, so relative-time
+  // assertions are deterministic (also matches the fixture's last_observed_at).
+  jest.setSystemTime(new Date('2026-08-01T12:05:00.000Z'));
   acknowledgeIsPending = false;
   resolveIsPending = false;
+  setDemoMode(undefined);
+  // Most tests below don't care about role; default to admin so
+  // Acknowledge/Resolve are visible+enabled unless a test says otherwise.
+  signedInAs('org:admin');
   mockUseAlertFilterParams.mockReturnValue(defaultFilterParams());
   mockUseAlertsList.mockReturnValue({
     data: [makeAlert()],
@@ -105,11 +134,14 @@ beforeEach(() => {
   });
 });
 
+afterEach(() => {
+  jest.useRealTimers();
+  setDemoMode(ORIGINAL_DEMO_MODE as 'true' | undefined);
+});
+
 describe('AlertList', () => {
   describe('rendering rows', () => {
-    it('should render severity, status, rule name, device id, and a plain-language condition', () => {
-      mockUseRbac.mockReturnValue({ isAdmin: false });
-
+    it('should render severity, status, rule name, device id, a plain-language condition, and a relative timestamp', () => {
       render(<AlertList />);
 
       expect(screen.getByText('Critical')).toBeInTheDocument();
@@ -118,10 +150,11 @@ describe('AlertList', () => {
       expect(screen.getByText('device_001')).toBeInTheDocument();
       expect(screen.getByText(/value above 30/)).toBeInTheDocument();
       expect(screen.getByText(/last 35/)).toBeInTheDocument();
+      // fired_at is 12:00:00.000Z, fixed "now" is 12:05:00.000Z.
+      expect(screen.getByText('5 minutes ago')).toBeInTheDocument();
     });
 
     it('should call onDeviceClick with the device id when the device button is clicked', () => {
-      mockUseRbac.mockReturnValue({ isAdmin: false });
       const onDeviceClick = jest.fn();
 
       render(<AlertList onDeviceClick={onDeviceClick} />);
@@ -129,11 +162,48 @@ describe('AlertList', () => {
 
       expect(onDeviceClick).toHaveBeenCalledWith('device_001');
     });
+
+    it('should fall back to breached_since for the relative timestamp when fired_at is absent', () => {
+      mockUseAlertsList.mockReturnValue({
+        data: [makeAlert({ fired_at: undefined, breached_since: '2026-08-01T10:00:00.000Z' })],
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+
+      render(<AlertList />);
+
+      // fixed "now" is 12:05:00.000Z; breached_since is 2h05m earlier, which
+      // rounds to "2 hours ago" — proves the row used breached_since, not a
+      // crash or blank on the missing fired_at.
+      expect(screen.getByText('2 hours ago')).toBeInTheDocument();
+    });
+  });
+
+  describe('formatRelativeTime', () => {
+    it('should describe a handful of seconds as "X seconds ago"', () => {
+      jest.setSystemTime(new Date('2026-08-01T12:00:30.000Z'));
+      expect(formatRelativeTime('2026-08-01T12:00:00.000Z')).toBe('30 seconds ago');
+    });
+
+    it('should describe minutes ago', () => {
+      jest.setSystemTime(new Date('2026-08-01T12:05:00.000Z'));
+      expect(formatRelativeTime('2026-08-01T12:00:00.000Z')).toBe('5 minutes ago');
+    });
+
+    it('should describe hours ago', () => {
+      jest.setSystemTime(new Date('2026-08-01T14:00:00.000Z'));
+      expect(formatRelativeTime('2026-08-01T12:00:00.000Z')).toBe('2 hours ago');
+    });
+
+    it('should describe days ago', () => {
+      jest.setSystemTime(new Date('2026-08-04T12:00:00.000Z'));
+      expect(formatRelativeTime('2026-08-01T12:00:00.000Z')).toBe('3 days ago');
+    });
   });
 
   describe('loading, error, and empty states', () => {
     it('should show a spinner while loading', () => {
-      mockUseRbac.mockReturnValue({ isAdmin: false });
       mockUseAlertsList.mockReturnValue({
         data: undefined,
         isLoading: true,
@@ -147,7 +217,6 @@ describe('AlertList', () => {
     });
 
     it('should show an error message when the query fails', () => {
-      mockUseRbac.mockReturnValue({ isAdmin: false });
       mockUseAlertsList.mockReturnValue({
         data: undefined,
         isLoading: false,
@@ -161,7 +230,6 @@ describe('AlertList', () => {
     });
 
     it('should show "No open alerts." when the list is empty', () => {
-      mockUseRbac.mockReturnValue({ isAdmin: false });
       mockUseAlertsList.mockReturnValue({
         data: [],
         isLoading: false,
@@ -175,11 +243,26 @@ describe('AlertList', () => {
     });
   });
 
-  // --- The demo-mode requirement: disabled, never hidden ----------------
+  // --- The three useAdminAction() branches --------------------------------
 
-  describe('admin gating on Acknowledge/Resolve (disabled, never hidden)', () => {
-    it('should render Acknowledge and Resolve PRESENT but DISABLED for a non-admin, with an explanatory tooltip', () => {
-      mockUseRbac.mockReturnValue({ isAdmin: false });
+  describe('admin gating on Acknowledge/Resolve (via useAdminAction)', () => {
+    it('should render Acknowledge and Resolve ENABLED for an admin, with no tooltip', () => {
+      signedInAs('org:admin');
+
+      render(<AlertList />);
+
+      const acknowledgeBtn = screen.getByRole('button', { name: /acknowledge/i });
+      const resolveBtn = screen.getByRole('button', { name: /resolve/i });
+
+      expect(acknowledgeBtn).not.toBeDisabled();
+      expect(acknowledgeBtn).not.toHaveAttribute('title');
+      expect(resolveBtn).not.toBeDisabled();
+      expect(resolveBtn).not.toHaveAttribute('title');
+    });
+
+    it('should render Acknowledge and Resolve PRESENT but DISABLED with a tooltip for a non-admin in demo mode', () => {
+      signedInAs('org:member');
+      setDemoMode('true');
 
       render(<AlertList />);
 
@@ -195,23 +278,18 @@ describe('AlertList', () => {
       expect(resolveBtn).toHaveAttribute('title', expect.stringMatching(/admin/i));
     });
 
-    it('should render Acknowledge and Resolve ENABLED for an admin, with no tooltip', () => {
-      mockUseRbac.mockReturnValue({ isAdmin: true });
+    it('should HIDE Acknowledge and Resolve entirely for a non-admin outside demo mode', () => {
+      signedInAs('org:member');
+      setDemoMode(undefined);
 
       render(<AlertList />);
 
-      const acknowledgeBtn = screen.getByRole('button', { name: /acknowledge/i });
-      const resolveBtn = screen.getByRole('button', { name: /resolve/i });
-
-      expect(acknowledgeBtn).not.toBeDisabled();
-      expect(acknowledgeBtn).not.toHaveAttribute('title');
-
-      expect(resolveBtn).not.toBeDisabled();
-      expect(resolveBtn).not.toHaveAttribute('title');
+      expect(screen.queryByRole('button', { name: /acknowledge/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /resolve/i })).not.toBeInTheDocument();
     });
 
     it('should not render Acknowledge for an alert that is not firing, regardless of role', () => {
-      mockUseRbac.mockReturnValue({ isAdmin: true });
+      signedInAs('org:admin');
       mockUseAlertsList.mockReturnValue({
         data: [makeAlert({ status: 'acknowledged', is_open: true })],
         isLoading: false,
@@ -226,7 +304,7 @@ describe('AlertList', () => {
     });
 
     it('should not render Resolve for an alert that is already resolved (not open)', () => {
-      mockUseRbac.mockReturnValue({ isAdmin: true });
+      signedInAs('org:admin');
       mockUseAlertsList.mockReturnValue({
         data: [makeAlert({ status: 'resolved', is_open: false })],
         isLoading: false,
@@ -242,7 +320,7 @@ describe('AlertList', () => {
 
   describe('admin actions', () => {
     it('should acknowledge with the alert id and toast success on completion', () => {
-      mockUseRbac.mockReturnValue({ isAdmin: true });
+      signedInAs('org:admin');
 
       render(<AlertList />);
       fireEvent.click(screen.getByRole('button', { name: /acknowledge/i }));
@@ -259,7 +337,7 @@ describe('AlertList', () => {
     });
 
     it('should resolve with the alert id and toast success on completion', () => {
-      mockUseRbac.mockReturnValue({ isAdmin: true });
+      signedInAs('org:admin');
 
       render(<AlertList />);
       fireEvent.click(screen.getByRole('button', { name: /resolve/i }));
@@ -274,19 +352,15 @@ describe('AlertList', () => {
   });
 
   describe('pagination', () => {
-    it('should disable the previous-page control on page 1', () => {
-      mockUseRbac.mockReturnValue({ isAdmin: false });
+    it('should disable the previous-page control on page 1, discoverable by its accessible name', () => {
       mockUseAlertFilterParams.mockReturnValue({ ...defaultFilterParams(), page: 1 });
 
-      const { container } = render(<AlertList />);
-      const pager = container.querySelector('.mt-4');
-      const [prevBtn] = pager?.querySelectorAll('button') ?? [];
+      render(<AlertList />);
 
-      expect(prevBtn).toBeDisabled();
+      expect(screen.getByRole('button', { name: /previous/i })).toBeDisabled();
     });
 
-    it('should disable the next-page control when a page comes back short of PAGE_SIZE', () => {
-      mockUseRbac.mockReturnValue({ isAdmin: false });
+    it('should disable the next-page control when a page comes back short of PAGE_SIZE, discoverable by its accessible name', () => {
       mockUseAlertFilterParams.mockReturnValue({ ...defaultFilterParams(), page: 2 });
       mockUseAlertsList.mockReturnValue({
         data: [makeAlert()], // 1 alert, well under PAGE_SIZE (10)
@@ -295,12 +369,9 @@ describe('AlertList', () => {
         refetch: mockRefetch,
       });
 
-      const { container } = render(<AlertList />);
-      const pager = container.querySelector('.mt-4');
-      const buttons = pager?.querySelectorAll('button') ?? [];
-      const nextBtn = buttons[buttons.length - 1];
+      render(<AlertList />);
 
-      expect(nextBtn).toBeDisabled();
+      expect(screen.getByRole('button', { name: /next/i })).toBeDisabled();
     });
   });
 });

--- a/__tests__/unit/components/AlertList.test.tsx
+++ b/__tests__/unit/components/AlertList.test.tsx
@@ -27,8 +27,9 @@
  * recorded in the task report.
  */
 
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AlertList, formatRelativeTime } from '@/components/alerts/AlertList';
 import type { AlertV2Response } from '@/types/v2';
 
@@ -63,6 +64,75 @@ jest.mock('react-toastify', () => ({
     error: (...args: unknown[]) => mockToastError(...args),
   },
 }));
+
+// --- D3: real-hook wiring for the "URL -> query integration" block below --
+//
+// `useAlertsList` and `useAlertFilterParams` stay mocked (as above) for
+// every OTHER describe block in this file — those `actual*` references
+// below let ONE block opt back into the real implementations via
+// `mockUseAlertsList.mockImplementation(actualAlertHooks.useAlertsList)`,
+// so that block exercises the real URL -> filters -> query wiring end to
+// end, instead of two mocks that describe each other's shape but never
+// actually meet (the review's exact D3 complaint). `next/navigation` and
+// `v2Api.alerts.list` are mocked instead — the network boundary, not the
+// hooks under test — mirroring AlertDetailPage.test.tsx's established
+// `jest.requireActual(...)` partial-mock idiom.
+const actualAlertHooks = jest.requireActual(
+  '@/lib/query/hooks'
+) as typeof import('@/lib/query/hooks');
+const actualUseAlertFilterParams = (
+  jest.requireActual('@/components/alerts/useAlertFilterParams') as typeof import('@/components/alerts/useAlertFilterParams')
+).useAlertFilterParams;
+
+const mockV2ApiAlertsList = jest.fn();
+jest.mock('@/lib/api/v2-client', () => {
+  const actual = jest.requireActual('@/lib/api/v2-client');
+  return {
+    ...actual,
+    v2Api: {
+      ...actual.v2Api,
+      alerts: {
+        ...actual.v2Api.alerts,
+        list: (...args: unknown[]) => mockV2ApiAlertsList(...args),
+      },
+    },
+  };
+});
+
+// Minimal but faithful next/navigation mock: `push` both records the call
+// AND updates what `useSearchParams` returns (via useSyncExternalStore), so
+// clicking a real pagination control drives a real re-render off the new
+// URL — exactly what AlertList.tsx experiences in the browser. Declared
+// once at file scope; inert for every other describe block below, since
+// nothing there calls a real next/navigation hook (useAlertFilterParams is
+// mocked away in those blocks).
+const mockNavState: { search: string; listeners: Set<() => void> } = {
+  search: '',
+  listeners: new Set(),
+};
+const mockRouterPush = jest.fn((url: string) => {
+  const query = url.includes('?') ? url.slice(url.indexOf('?') + 1) : '';
+  mockNavState.search = query;
+  mockNavState.listeners.forEach(listener => listener());
+});
+
+jest.mock('next/navigation', () => {
+  const { useSyncExternalStore } = jest.requireActual('react');
+  return {
+    useRouter: () => ({ push: (...args: [string, unknown?]) => mockRouterPush(...args) }),
+    usePathname: () => '/alerts',
+    useSearchParams: () =>
+      new URLSearchParams(
+        useSyncExternalStore(
+          (onStoreChange: () => void) => {
+            mockNavState.listeners.add(onStoreChange);
+            return () => mockNavState.listeners.delete(onStoreChange);
+          },
+          () => mockNavState.search
+        )
+      ),
+  };
+});
 
 function signedInAs(orgRole: 'org:admin' | 'org:member', orgSlug = 'users') {
   mockUseAuth.mockReturnValue({ isLoaded: true, isSignedIn: true, orgRole, orgSlug });
@@ -131,6 +201,7 @@ beforeEach(() => {
     isLoading: false,
     error: null,
     refetch: mockRefetch,
+    isFetching: false,
   });
 });
 
@@ -372,6 +443,195 @@ describe('AlertList', () => {
       render(<AlertList />);
 
       expect(screen.getByRole('button', { name: /next/i })).toBeDisabled();
+    });
+
+    // --- B1: a page transition in flight must disable BOTH controls, so a
+    // second click cannot skip a page (keepPreviousData keeps isLoading
+    // false and the previous page's rows visible during the transition —
+    // isFetching is the only signal a transition is in progress at all).
+    it('should disable BOTH Previous and Next while a page transition is in flight (isFetching), even though page/count alone would leave them enabled', () => {
+      mockUseAlertFilterParams.mockReturnValue({ ...defaultFilterParams(), page: 2 });
+      mockUseAlertsList.mockReturnValue({
+        // A full page (== PAGE_SIZE) on page 2: neither the page===1 guard
+        // nor the short-page guard would disable anything on their own —
+        // isFetching must be the thing doing the work here.
+        data: Array.from({ length: 10 }, (_, i) => makeAlert({ _id: `alert_${i}` })),
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+        isFetching: true,
+      });
+
+      render(<AlertList />);
+
+      expect(screen.getByRole('button', { name: /previous/i })).toBeDisabled();
+      expect(screen.getByRole('button', { name: /next/i })).toBeDisabled();
+    });
+
+    it('should also disable the refresh control (and spin its icon) while isFetching', () => {
+      mockUseAlertsList.mockReturnValue({
+        data: [makeAlert()],
+        isLoading: false, // isolates the spin to the refresh icon, not the isLoading spinner
+        error: null,
+        refetch: mockRefetch,
+        isFetching: true,
+      });
+
+      const { container } = render(<AlertList />);
+
+      const spinningIcon = container.querySelector('.animate-spin');
+      expect(spinningIcon).toBeInTheDocument();
+      expect(spinningIcon?.closest('button')).toBeDisabled();
+    });
+  });
+
+  // --- D3: mockUseAlertsList must actually be asserted against, and a
+  // filter change must be observable as a changed call argument — both
+  // still using the mocked hooks (this is about AlertList's OWN glue code
+  // that builds `filters`, not about the hooks it calls).
+  describe('query argument wiring (D3)', () => {
+    it('should call useAlertsList with the filter/pagination arguments the current URL state implies', () => {
+      mockUseAlertFilterParams.mockReturnValue({
+        ...defaultFilterParams(),
+        status: 'firing',
+        severity: 'critical',
+        page: 4,
+      });
+
+      render(<AlertList />);
+
+      expect(mockUseAlertsList).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'firing', severity: 'critical', page: 4, limit: 10 })
+      );
+    });
+
+    it('should produce a different useAlertsList argument when only the filter state changes', () => {
+      mockUseAlertFilterParams.mockReturnValue({ ...defaultFilterParams(), status: 'open', page: 1 });
+      render(<AlertList />);
+      const firstArgs = mockUseAlertsList.mock.calls.at(-1)?.[0];
+
+      mockUseAlertFilterParams.mockReturnValue({
+        ...defaultFilterParams(),
+        status: 'acknowledged',
+        page: 1,
+      });
+      render(<AlertList />);
+      const secondArgs = mockUseAlertsList.mock.calls.at(-1)?.[0];
+
+      expect(secondArgs).not.toEqual(firstArgs);
+      expect(secondArgs).toMatchObject({ status: 'acknowledged' });
+      // 'open' is the server default, sent absent — not the literal string.
+      expect(firstArgs).not.toHaveProperty('status');
+    });
+
+    it('should omit status/severity from the useAlertsList call when both filters are at their defaults', () => {
+      mockUseAlertFilterParams.mockReturnValue(defaultFilterParams());
+
+      render(<AlertList />);
+
+      const args = mockUseAlertsList.mock.calls.at(-1)?.[0];
+      expect(args).not.toHaveProperty('status');
+      expect(args).not.toHaveProperty('severity');
+      expect(args).toMatchObject({ page: 1, limit: 10 });
+    });
+  });
+
+  // --- D3: the URL -> useAlertFilterParams -> filters -> useAlertsList ->
+  // v2Api.alerts.list chain, exercised with the real hooks (only the
+  // network boundary mocked) so a break anywhere in that chain — not just
+  // in AlertList's own glue code — would show up here.
+  describe('URL -> query integration (D3)', () => {
+    function renderWithRealHooks() {
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      return render(
+        <QueryClientProvider client={queryClient}>
+          <AlertList />
+        </QueryClientProvider>
+      );
+    }
+
+    beforeEach(() => {
+      mockNavState.search = '';
+      mockNavState.listeners.clear();
+      mockRouterPush.mockClear();
+      mockV2ApiAlertsList.mockReset();
+      mockV2ApiAlertsList.mockResolvedValue({
+        success: true,
+        data: [],
+        pagination: { page: 1, limit: 10, total: 0, totalPages: 0 },
+      });
+      mockUseAlertFilterParams.mockImplementation(
+        (...args: Parameters<typeof actualUseAlertFilterParams>) =>
+          actualUseAlertFilterParams(...args)
+      );
+      mockUseAlertsList.mockImplementation(
+        (...args: Parameters<typeof actualAlertHooks.useAlertsList>) =>
+          actualAlertHooks.useAlertsList(...args)
+      );
+    });
+
+    it('should request the default open/all/page-1 filters (status and severity both omitted) when the URL is bare', async () => {
+      renderWithRealHooks();
+
+      await waitFor(() => expect(mockV2ApiAlertsList).toHaveBeenCalled());
+
+      const args = mockV2ApiAlertsList.mock.calls[0][0];
+      expect(args).toMatchObject({ page: 1, limit: 10 });
+      expect(args).not.toHaveProperty('status');
+      expect(args).not.toHaveProperty('severity');
+    });
+
+    it('should request the status/severity the URL specifies', async () => {
+      mockNavState.search = 'status=firing&severity=critical';
+
+      renderWithRealHooks();
+
+      await waitFor(() => expect(mockV2ApiAlertsList).toHaveBeenCalled());
+
+      expect(mockV2ApiAlertsList).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'firing', severity: 'critical', page: 1, limit: 10 })
+      );
+    });
+
+    it('should request the page the URL specifies', async () => {
+      mockNavState.search = 'page=3';
+
+      renderWithRealHooks();
+
+      await waitFor(() => expect(mockV2ApiAlertsList).toHaveBeenCalled());
+
+      expect(mockV2ApiAlertsList).toHaveBeenCalledWith(expect.objectContaining({ page: 3 }));
+    });
+
+    it('should advance the query argument to page 2 (not skip to 3) after a single click on Next', async () => {
+      // A full page (== PAGE_SIZE) so Next starts enabled.
+      mockV2ApiAlertsList.mockResolvedValue({
+        success: true,
+        data: Array.from({ length: 10 }, (_, i) => makeAlert({ _id: `alert_${i}` })),
+        pagination: { page: 1, limit: 10, total: 25, totalPages: 3 },
+      });
+
+      renderWithRealHooks();
+
+      // Wait for the fetch to actually SETTLE (not just be called) — data
+      // must be in state and isFetching back to false, or the Next button is
+      // still disabled (no rows yet means alerts.length < PAGE_SIZE) and the
+      // click below would be a no-op that this test could pass vacuously.
+      await waitFor(() => expect(screen.getByRole('button', { name: /next/i })).not.toBeDisabled());
+      expect(mockV2ApiAlertsList).toHaveBeenCalledTimes(1);
+      expect(mockV2ApiAlertsList.mock.calls[0][0]).toMatchObject({ page: 1 });
+
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+      // Reaches the real hook's setPage -> router.push with an ADVANCED (not
+      // skipped) page — a real click on a real page-1 view pushes to page 2.
+      expect(mockRouterPush).toHaveBeenCalledWith('/alerts?page=2', { scroll: false });
+
+      // ...and that URL change flows all the way through to a second,
+      // real network call carrying the advanced page — the full loop D3
+      // asks for, not just the outgoing push.
+      await waitFor(() => expect(mockV2ApiAlertsList).toHaveBeenCalledTimes(2));
+      expect(mockV2ApiAlertsList.mock.calls[1][0]).toMatchObject({ page: 2 });
     });
   });
 });

--- a/__tests__/unit/components/AlertList.test.tsx
+++ b/__tests__/unit/components/AlertList.test.tsx
@@ -1,0 +1,306 @@
+/**
+ * AlertList Tests
+ *
+ * `@/lib/query/hooks`, `@/lib/auth/rbac-client`, and
+ * `@/components/alerts/useAlertFilterParams` are mocked at the exact module
+ * specifiers AlertList.tsx imports from (matching the working pattern in
+ * DashboardStatCards.test.tsx) so the mock actually intercepts the import
+ * AlertList uses, rather than a barrel re-export that never gets hit.
+ *
+ * The admin-gated Acknowledge/Resolve buttons are the focus: per the Phase 4
+ * demo-mode rule, they must render DISABLED for a non-admin, never hidden, so
+ * a visitor can see the workflow exists. A test that only checks the button
+ * is disabled would pass vacuously if the button were hidden entirely (the
+ * query would throw first); a test that only checks the button is present
+ * would pass against a permanently-enabled button. Both are asserted below,
+ * for both roles, and the deletion-check evidence proving each half actually
+ * catches a regression is recorded in the task report.
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { AlertList } from '@/components/alerts/AlertList';
+import type { AlertV2Response } from '@/types/v2';
+
+const mockUseAlertsList = jest.fn();
+const mockAcknowledgeMutate = jest.fn();
+const mockResolveMutate = jest.fn();
+const mockRefetch = jest.fn();
+let acknowledgeIsPending = false;
+let resolveIsPending = false;
+
+jest.mock('@/lib/query/hooks', () => ({
+  useAlertsList: (...args: unknown[]) => mockUseAlertsList(...args),
+  useAcknowledgeAlert: () => ({ mutate: mockAcknowledgeMutate, isPending: acknowledgeIsPending }),
+  useResolveAlert: () => ({ mutate: mockResolveMutate, isPending: resolveIsPending }),
+}));
+
+const mockUseRbac = jest.fn();
+jest.mock('@/lib/auth/rbac-client', () => ({
+  useRbac: () => mockUseRbac(),
+}));
+
+const mockUseAlertFilterParams = jest.fn();
+jest.mock('@/components/alerts/useAlertFilterParams', () => ({
+  useAlertFilterParams: (...args: unknown[]) => mockUseAlertFilterParams(...args),
+}));
+
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+jest.mock('react-toastify', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+function makeAlert(overrides: Partial<AlertV2Response> = {}): AlertV2Response {
+  return {
+    _id: 'alert_1',
+    rule_id: 'rule_1',
+    rule_name: 'High temperature',
+    device_id: 'device_001',
+    status: 'firing',
+    is_open: true,
+    severity: 'critical',
+    metric: 'value',
+    comparison: 'gt',
+    threshold: 30,
+    trigger_value: 35,
+    last_value: 35,
+    breached_since: '2026-08-01T12:00:00.000Z',
+    last_observed_at: '2026-08-01T12:05:00.000Z',
+    fired_at: '2026-08-01T12:00:00.000Z',
+    audit: {
+      created_at: '2026-08-01T12:00:00.000Z',
+      created_by: 'system',
+      updated_at: '2026-08-01T12:00:00.000Z',
+      updated_by: 'system',
+    },
+    ...overrides,
+  };
+}
+
+function defaultFilterParams() {
+  return {
+    status: 'open',
+    severity: 'all',
+    page: 1,
+    setStatus: jest.fn(),
+    setSeverity: jest.fn(),
+    setPage: jest.fn(),
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  acknowledgeIsPending = false;
+  resolveIsPending = false;
+  mockUseAlertFilterParams.mockReturnValue(defaultFilterParams());
+  mockUseAlertsList.mockReturnValue({
+    data: [makeAlert()],
+    isLoading: false,
+    error: null,
+    refetch: mockRefetch,
+  });
+});
+
+describe('AlertList', () => {
+  describe('rendering rows', () => {
+    it('should render severity, status, rule name, device id, and a plain-language condition', () => {
+      mockUseRbac.mockReturnValue({ isAdmin: false });
+
+      render(<AlertList />);
+
+      expect(screen.getByText('Critical')).toBeInTheDocument();
+      expect(screen.getByText('Firing')).toBeInTheDocument();
+      expect(screen.getByText('High temperature')).toBeInTheDocument();
+      expect(screen.getByText('device_001')).toBeInTheDocument();
+      expect(screen.getByText(/value above 30/)).toBeInTheDocument();
+      expect(screen.getByText(/last 35/)).toBeInTheDocument();
+    });
+
+    it('should call onDeviceClick with the device id when the device button is clicked', () => {
+      mockUseRbac.mockReturnValue({ isAdmin: false });
+      const onDeviceClick = jest.fn();
+
+      render(<AlertList onDeviceClick={onDeviceClick} />);
+      fireEvent.click(screen.getByText('device_001'));
+
+      expect(onDeviceClick).toHaveBeenCalledWith('device_001');
+    });
+  });
+
+  describe('loading, error, and empty states', () => {
+    it('should show a spinner while loading', () => {
+      mockUseRbac.mockReturnValue({ isAdmin: false });
+      mockUseAlertsList.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        error: null,
+        refetch: mockRefetch,
+      });
+
+      const { container } = render(<AlertList />);
+
+      expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+    });
+
+    it('should show an error message when the query fails', () => {
+      mockUseRbac.mockReturnValue({ isAdmin: false });
+      mockUseAlertsList.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error('network down'),
+        refetch: mockRefetch,
+      });
+
+      render(<AlertList />);
+
+      expect(screen.getByText('Failed to load alerts')).toBeInTheDocument();
+    });
+
+    it('should show "No open alerts." when the list is empty', () => {
+      mockUseRbac.mockReturnValue({ isAdmin: false });
+      mockUseAlertsList.mockReturnValue({
+        data: [],
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+
+      render(<AlertList />);
+
+      expect(screen.getByText('No open alerts.')).toBeInTheDocument();
+    });
+  });
+
+  // --- The demo-mode requirement: disabled, never hidden ----------------
+
+  describe('admin gating on Acknowledge/Resolve (disabled, never hidden)', () => {
+    it('should render Acknowledge and Resolve PRESENT but DISABLED for a non-admin, with an explanatory tooltip', () => {
+      mockUseRbac.mockReturnValue({ isAdmin: false });
+
+      render(<AlertList />);
+
+      const acknowledgeBtn = screen.getByRole('button', { name: /acknowledge/i });
+      const resolveBtn = screen.getByRole('button', { name: /resolve/i });
+
+      expect(acknowledgeBtn).toBeInTheDocument();
+      expect(acknowledgeBtn).toBeDisabled();
+      expect(acknowledgeBtn).toHaveAttribute('title', expect.stringMatching(/admin/i));
+
+      expect(resolveBtn).toBeInTheDocument();
+      expect(resolveBtn).toBeDisabled();
+      expect(resolveBtn).toHaveAttribute('title', expect.stringMatching(/admin/i));
+    });
+
+    it('should render Acknowledge and Resolve ENABLED for an admin, with no tooltip', () => {
+      mockUseRbac.mockReturnValue({ isAdmin: true });
+
+      render(<AlertList />);
+
+      const acknowledgeBtn = screen.getByRole('button', { name: /acknowledge/i });
+      const resolveBtn = screen.getByRole('button', { name: /resolve/i });
+
+      expect(acknowledgeBtn).not.toBeDisabled();
+      expect(acknowledgeBtn).not.toHaveAttribute('title');
+
+      expect(resolveBtn).not.toBeDisabled();
+      expect(resolveBtn).not.toHaveAttribute('title');
+    });
+
+    it('should not render Acknowledge for an alert that is not firing, regardless of role', () => {
+      mockUseRbac.mockReturnValue({ isAdmin: true });
+      mockUseAlertsList.mockReturnValue({
+        data: [makeAlert({ status: 'acknowledged', is_open: true })],
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+
+      render(<AlertList />);
+
+      expect(screen.queryByRole('button', { name: /acknowledge/i })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /resolve/i })).toBeInTheDocument();
+    });
+
+    it('should not render Resolve for an alert that is already resolved (not open)', () => {
+      mockUseRbac.mockReturnValue({ isAdmin: true });
+      mockUseAlertsList.mockReturnValue({
+        data: [makeAlert({ status: 'resolved', is_open: false })],
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+
+      render(<AlertList />);
+
+      expect(screen.queryByRole('button', { name: /resolve/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('admin actions', () => {
+    it('should acknowledge with the alert id and toast success on completion', () => {
+      mockUseRbac.mockReturnValue({ isAdmin: true });
+
+      render(<AlertList />);
+      fireEvent.click(screen.getByRole('button', { name: /acknowledge/i }));
+
+      expect(mockAcknowledgeMutate).toHaveBeenCalledTimes(1);
+      const [variables, options] = mockAcknowledgeMutate.mock.calls[0];
+      expect(variables).toEqual({ id: 'alert_1' });
+
+      options.onSuccess();
+      expect(mockToastSuccess).toHaveBeenCalledWith('Alert acknowledged');
+
+      options.onError(new Error('boom'));
+      expect(mockToastError).toHaveBeenCalledWith('boom');
+    });
+
+    it('should resolve with the alert id and toast success on completion', () => {
+      mockUseRbac.mockReturnValue({ isAdmin: true });
+
+      render(<AlertList />);
+      fireEvent.click(screen.getByRole('button', { name: /resolve/i }));
+
+      expect(mockResolveMutate).toHaveBeenCalledTimes(1);
+      const [variables, options] = mockResolveMutate.mock.calls[0];
+      expect(variables).toEqual({ id: 'alert_1' });
+
+      options.onSuccess();
+      expect(mockToastSuccess).toHaveBeenCalledWith('Alert resolved');
+    });
+  });
+
+  describe('pagination', () => {
+    it('should disable the previous-page control on page 1', () => {
+      mockUseRbac.mockReturnValue({ isAdmin: false });
+      mockUseAlertFilterParams.mockReturnValue({ ...defaultFilterParams(), page: 1 });
+
+      const { container } = render(<AlertList />);
+      const pager = container.querySelector('.mt-4');
+      const [prevBtn] = pager?.querySelectorAll('button') ?? [];
+
+      expect(prevBtn).toBeDisabled();
+    });
+
+    it('should disable the next-page control when a page comes back short of PAGE_SIZE', () => {
+      mockUseRbac.mockReturnValue({ isAdmin: false });
+      mockUseAlertFilterParams.mockReturnValue({ ...defaultFilterParams(), page: 2 });
+      mockUseAlertsList.mockReturnValue({
+        data: [makeAlert()], // 1 alert, well under PAGE_SIZE (10)
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+
+      const { container } = render(<AlertList />);
+      const pager = container.querySelector('.mt-4');
+      const buttons = pager?.querySelectorAll('button') ?? [];
+      const nextBtn = buttons[buttons.length - 1];
+
+      expect(nextBtn).toBeDisabled();
+    });
+  });
+});

--- a/__tests__/unit/components/AlertRuleList.test.tsx
+++ b/__tests__/unit/components/AlertRuleList.test.tsx
@@ -1,0 +1,263 @@
+/**
+ * AlertRuleList Tests
+ *
+ * `@/lib/query/hooks` is mocked at the exact module specifier AlertRuleList.tsx
+ * imports from (matching the working pattern in AlertList.test.tsx) so the
+ * mock actually intercepts the import AlertRuleList uses.
+ *
+ * `useAdminAction`/`useRbac` (lib/auth/rbac-client.tsx) are deliberately NOT
+ * mocked — only their dependency on Clerk's `useAuth` is stubbed, exactly like
+ * AlertList.test.tsx does. That exercises the real gating contract end to end
+ * rather than a mock that would pass even if AlertRuleList stopped calling
+ * useAdminAction() altogether.
+ *
+ * The admin-gated enabled-toggle and delete button are the focus. Per
+ * useAdminAction's three-branch contract: an admin sees them enabled; a
+ * non-admin in demo mode sees them present-and-disabled with a tooltip; a
+ * non-admin outside demo mode sees them absent entirely. Deletion-check
+ * evidence proving these tests actually catch a regression (rather than
+ * passing vacuously) is recorded in the task report.
+ *
+ * Delete confirmation never uses window.confirm (it blocks the page) — it
+ * uses components/ui/alert-dialog.tsx, matching app/devices/page.tsx's
+ * established pattern. The tests assert the confirm/cancel flow directly
+ * rather than assuming any particular dialog implementation.
+ */
+
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { AlertRuleList } from '@/components/alerts/AlertRuleList';
+import type { AlertRuleV2Response } from '@/types/v2';
+
+const mockUseAlertRulesList = jest.fn();
+const mockUpdateMutate = jest.fn();
+const mockDeleteMutate = jest.fn();
+const mockRefetch = jest.fn();
+let updateIsPending = false;
+let deleteIsPending = false;
+
+jest.mock('@/lib/query/hooks', () => ({
+  useAlertRulesList: (...args: unknown[]) => mockUseAlertRulesList(...args),
+  useUpdateAlertRule: () => ({ mutate: mockUpdateMutate, isPending: updateIsPending }),
+  useDeleteAlertRule: () => ({ mutate: mockDeleteMutate, isPending: deleteIsPending }),
+}));
+
+const mockUseAuth = jest.fn();
+jest.mock('@clerk/nextjs', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+const mockToastSuccess = jest.fn();
+const mockToastError = jest.fn();
+jest.mock('react-toastify', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+function signedInAs(orgRole: 'org:admin' | 'org:member', orgSlug = 'users') {
+  mockUseAuth.mockReturnValue({ isLoaded: true, isSignedIn: true, orgRole, orgSlug });
+}
+
+function setDemoMode(value: 'true' | undefined) {
+  if (value === undefined) delete process.env.NEXT_PUBLIC_DEMO_MODE;
+  else process.env.NEXT_PUBLIC_DEMO_MODE = value;
+}
+
+const ORIGINAL_DEMO_MODE = process.env.NEXT_PUBLIC_DEMO_MODE;
+
+function makeRule(overrides: Partial<AlertRuleV2Response> = {}): AlertRuleV2Response {
+  return {
+    _id: 'rule_1',
+    name: 'High temperature',
+    description: 'Alerts when temperature exceeds threshold',
+    enabled: true,
+    selector: { types: ['temperature'] },
+    metric: 'value',
+    comparison: 'gt',
+    threshold: 30,
+    for_duration_seconds: 300,
+    severity: 'critical',
+    cooldown_seconds: 300,
+    audit: {
+      created_at: '2026-08-01T12:00:00.000Z',
+      created_by: 'admin@example.com',
+      updated_at: '2026-08-01T12:00:00.000Z',
+      updated_by: 'admin@example.com',
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  updateIsPending = false;
+  deleteIsPending = false;
+  setDemoMode(undefined);
+  // Most tests below don't care about role; default to admin so the toggle
+  // and delete controls are visible+enabled unless a test says otherwise.
+  signedInAs('org:admin');
+  mockUseAlertRulesList.mockReturnValue({
+    data: [makeRule()],
+    isLoading: false,
+    error: null,
+    refetch: mockRefetch,
+  });
+});
+
+afterEach(() => {
+  setDemoMode(ORIGINAL_DEMO_MODE as 'true' | undefined);
+});
+
+describe('AlertRuleList', () => {
+  describe('rendering rows', () => {
+    it('should render name, severity, a plain-language condition, and selector chips', () => {
+      render(<AlertRuleList />);
+
+      expect(screen.getByText('High temperature')).toBeInTheDocument();
+      expect(screen.getByText('Critical')).toBeInTheDocument();
+      expect(screen.getByText(/value above 30/i)).toBeInTheDocument();
+      expect(screen.getByText('temperature')).toBeInTheDocument();
+    });
+
+    it('should show a loading spinner while loading', () => {
+      mockUseAlertRulesList.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        error: null,
+        refetch: mockRefetch,
+      });
+
+      const { container } = render(<AlertRuleList />);
+
+      expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+    });
+
+    it('should show an error message when the query fails', () => {
+      mockUseAlertRulesList.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error('network down'),
+        refetch: mockRefetch,
+      });
+
+      render(<AlertRuleList />);
+
+      expect(screen.getByText(/failed to load alert rules/i)).toBeInTheDocument();
+    });
+
+    it('should show "No alert rules." when the list is empty', () => {
+      mockUseAlertRulesList.mockReturnValue({
+        data: [],
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+
+      render(<AlertRuleList />);
+
+      expect(screen.getByText(/no alert rules/i)).toBeInTheDocument();
+    });
+  });
+
+  // --- The three useAdminAction() branches --------------------------------
+
+  describe('admin gating on the enabled toggle and delete button (via useAdminAction)', () => {
+    it('should render the toggle and delete control ENABLED for an admin, with no tooltip', () => {
+      signedInAs('org:admin');
+
+      render(<AlertRuleList />);
+
+      const toggle = screen.getByRole('checkbox', { name: /disable high temperature/i });
+      const del = screen.getByRole('button', { name: /delete high temperature/i });
+
+      expect(toggle).not.toBeDisabled();
+      expect(toggle).not.toHaveAttribute('title');
+      expect(del).not.toBeDisabled();
+      expect(del).not.toHaveAttribute('title');
+    });
+
+    it('should render the toggle and delete control PRESENT but DISABLED with a tooltip for a non-admin in demo mode', () => {
+      signedInAs('org:member');
+      setDemoMode('true');
+
+      render(<AlertRuleList />);
+
+      const toggle = screen.getByRole('checkbox', { name: /disable high temperature/i });
+      const del = screen.getByRole('button', { name: /delete high temperature/i });
+
+      expect(toggle).toBeInTheDocument();
+      expect(toggle).toBeDisabled();
+      expect(toggle).toHaveAttribute('title', expect.stringMatching(/admin/i));
+
+      expect(del).toBeInTheDocument();
+      expect(del).toBeDisabled();
+      expect(del).toHaveAttribute('title', expect.stringMatching(/admin/i));
+    });
+
+    it('should HIDE the toggle and delete control entirely for a non-admin outside demo mode', () => {
+      signedInAs('org:member');
+      setDemoMode(undefined);
+
+      render(<AlertRuleList />);
+
+      expect(
+        screen.queryByRole('checkbox', { name: /disable high temperature|enable high temperature/i })
+      ).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /delete high temperature/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('toggling enabled', () => {
+    it('should flip enabled and toast success on completion', () => {
+      signedInAs('org:admin');
+
+      render(<AlertRuleList />);
+      fireEvent.click(screen.getByRole('checkbox', { name: /disable high temperature/i }));
+
+      expect(mockUpdateMutate).toHaveBeenCalledTimes(1);
+      const [variables, options] = mockUpdateMutate.mock.calls[0];
+      expect(variables).toEqual({ id: 'rule_1', data: { enabled: false } });
+
+      options.onSuccess();
+      expect(mockToastSuccess).toHaveBeenCalledWith('Rule disabled');
+    });
+  });
+
+  describe('delete confirmation', () => {
+    it('should never call window.confirm, and should not call delete until the dialog is confirmed', () => {
+      signedInAs('org:admin');
+      const confirmSpy = jest.spyOn(window, 'confirm');
+
+      render(<AlertRuleList />);
+      fireEvent.click(screen.getByRole('button', { name: /delete high temperature/i }));
+
+      expect(confirmSpy).not.toHaveBeenCalled();
+      expect(mockDeleteMutate).not.toHaveBeenCalled();
+
+      // The dialog's own confirm action has the exact accessible name "Delete"
+      // (the per-row trigger's name is "Delete High temperature", so this is unambiguous).
+      fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+
+      expect(mockDeleteMutate).toHaveBeenCalledTimes(1);
+      const [id, options] = mockDeleteMutate.mock.calls[0];
+      expect(id).toBe('rule_1');
+
+      act(() => options.onSuccess());
+      expect(mockToastSuccess).toHaveBeenCalledWith('Alert rule deleted');
+
+      confirmSpy.mockRestore();
+    });
+
+    it('should not call delete when the confirmation is cancelled', () => {
+      signedInAs('org:admin');
+
+      render(<AlertRuleList />);
+      fireEvent.click(screen.getByRole('button', { name: /delete high temperature/i }));
+      fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+      expect(mockDeleteMutate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/unit/components/AlertRuleList.test.tsx
+++ b/__tests__/unit/components/AlertRuleList.test.tsx
@@ -103,6 +103,7 @@ beforeEach(() => {
     isLoading: false,
     error: null,
     refetch: mockRefetch,
+    isFetching: false,
   });
 });
 
@@ -281,6 +282,66 @@ describe('AlertRuleList', () => {
       fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
 
       expect(mockDeleteMutate).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- B1: a page transition in flight must disable BOTH controls, so a
+  // second click cannot skip a page — matches the fix applied to
+  // AlertList.tsx (same underlying cause: the global
+  // `placeholderData: keepPreviousData` keeps isLoading false and the
+  // previous page's rows visible during a page transition).
+  describe('pagination in-flight guard (B1)', () => {
+    function tenRules() {
+      return Array.from({ length: 10 }, (_, i) => makeRule({ _id: `rule_${i}` }));
+    }
+
+    it('should disable BOTH Previous and Next while a page transition is in flight (isFetching), even though page/count alone would leave them enabled', () => {
+      mockUseAlertRulesList.mockReturnValue({
+        data: tenRules(),
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+        isFetching: false,
+      });
+
+      const { rerender } = render(<AlertRuleList />);
+
+      // Reach page 2 via a real Next click, so page state is genuinely > 1
+      // (at page 1, Previous would be disabled regardless of isFetching,
+      // which would make that half of the assertion below vacuous).
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
+      expect(screen.getByText(/page 2/i)).toBeInTheDocument();
+
+      // Simulate the in-flight refetch a real page-2 request triggers —
+      // still a full page, so neither the page===1 guard nor the
+      // short-page guard would disable anything on their own.
+      mockUseAlertRulesList.mockReturnValue({
+        data: tenRules(),
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+        isFetching: true,
+      });
+      rerender(<AlertRuleList />);
+
+      expect(screen.getByRole('button', { name: /previous/i })).toBeDisabled();
+      expect(screen.getByRole('button', { name: /next/i })).toBeDisabled();
+    });
+
+    it('should also disable the refresh control (and spin its icon) while isFetching', () => {
+      mockUseAlertRulesList.mockReturnValue({
+        data: [makeRule()],
+        isLoading: false, // isolates the spin to the refresh icon, not the isLoading spinner
+        error: null,
+        refetch: mockRefetch,
+        isFetching: true,
+      });
+
+      const { container } = render(<AlertRuleList />);
+
+      const spinningIcon = container.querySelector('.animate-spin');
+      expect(spinningIcon).toBeInTheDocument();
+      expect(spinningIcon?.closest('button')).toBeDisabled();
     });
   });
 });

--- a/__tests__/unit/components/AlertRuleList.test.tsx
+++ b/__tests__/unit/components/AlertRuleList.test.tsx
@@ -159,6 +159,29 @@ describe('AlertRuleList', () => {
 
       expect(screen.getByText(/no alert rules/i)).toBeInTheDocument();
     });
+
+    // Regression test for a real crash caught by e2e/alerts.spec.ts against
+    // live seeded data: a rule with no constraints at all (the seeded "Low
+    // battery" and "High anomaly score" rules both persist `selector: {}`)
+    // has its `selector` field stripped entirely by Mongoose's default
+    // `minimize` behavior before it ever reaches Mongo, so every API read is
+    // genuinely missing the key -- `AlertRuleV2Response.selector` is typed
+    // optional for exactly this reason (types/v2/alert.types.ts). Before the
+    // fix, `selectorChips` did `selector.types` unguarded and threw
+    // "Cannot read properties of undefined (reading 'types')" the moment this
+    // row rendered, taking down the whole page.
+    it('should render a rule whose selector is entirely absent, without crashing', () => {
+      mockUseAlertRulesList.mockReturnValue({
+        data: [makeRule({ name: 'Low battery', metric: 'battery_level', selector: undefined })],
+        isLoading: false,
+        error: null,
+        refetch: mockRefetch,
+      });
+
+      render(<AlertRuleList />);
+
+      expect(screen.getByText('Low battery')).toBeInTheDocument();
+    });
   });
 
   // --- The three useAdminAction() branches --------------------------------

--- a/__tests__/unit/components/AlertToaster.test.tsx
+++ b/__tests__/unit/components/AlertToaster.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * AlertToaster Tests
+ *
+ * AlertToaster's entire job is deciding which alert envelopes become popups
+ * and which reconcile silently. `usePusherAlerts`, `react-toastify`, and
+ * `next/navigation` are all mocked so a test can hand the component an
+ * envelope directly and inspect exactly what it did with it.
+ *
+ * The two "storm"/"resolved" rows are the point of this file: a suite that
+ * only checks the positive (toast-raising) cases would pass just as happily
+ * against a component that toasts unconditionally. See the deletion-check
+ * evidence in the task report for proof these fail when the `of === 'fired'`
+ * guard is removed.
+ */
+
+import { render, act } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
+import { usePusherAlerts } from '@/lib/pusher-context';
+import { AlertToaster } from '@/components/alerts/AlertToaster';
+import { queryKeys } from '@/lib/query/queryClient';
+import type { AlertEvent, FiredAlert, ResolvedAlert } from '@/types/v2/alert.types';
+
+const push = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+}));
+
+jest.mock('react-toastify', () => ({
+  toast: {
+    error: jest.fn(),
+    warning: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/pusher-context', () => ({
+  usePusherAlerts: jest.fn(),
+}));
+
+function fired(overrides: Partial<FiredAlert> = {}): FiredAlert {
+  return {
+    _id: 'alert_1',
+    rule_id: 'rule_1',
+    rule_name: 'High temp',
+    device_id: 'device_001',
+    severity: 'critical',
+    metric: 'value',
+    comparison: 'gt',
+    threshold: 30,
+    trigger_value: 35,
+    fired_at: '2026-08-01T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function resolvedAlert(overrides: Partial<ResolvedAlert> = {}): ResolvedAlert {
+  return {
+    _id: 'alert_1',
+    rule_id: 'rule_1',
+    device_id: 'device_001',
+    severity: 'warning',
+    resolution: 'auto',
+    resolved_at: '2026-08-01T12:30:00.000Z',
+    actor: 'system',
+    ...overrides,
+  };
+}
+
+/**
+ * Renders AlertToaster under a real QueryClient (so useQueryClient() has
+ * something to find) and returns a spy on invalidateQueries plus the handler
+ * AlertToaster registered with the mocked usePusherAlerts — dispatching to
+ * that handler is how each test hands the component an envelope directly.
+ */
+function renderToaster() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <AlertToaster />
+    </QueryClientProvider>
+  );
+
+  const handleEvent = (usePusherAlerts as jest.Mock).mock.calls.at(-1)?.[0] as (
+    event: AlertEvent
+  ) => void;
+
+  return { invalidateSpy, handleEvent };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('AlertToaster', () => {
+  it('renders nothing', () => {
+    const queryClient = new QueryClient();
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <AlertToaster />
+      </QueryClientProvider>
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('registers exactly one alert-event handler via usePusherAlerts', () => {
+    renderToaster();
+
+    expect(usePusherAlerts).toHaveBeenCalledTimes(1);
+    expect(typeof (usePusherAlerts as jest.Mock).mock.calls[0][0]).toBe('function');
+  });
+
+  it('toasts once per fired alert, mapped by severity, and invalidates the alerts cache', () => {
+    const { invalidateSpy, handleEvent } = renderToaster();
+
+    const event: AlertEvent = {
+      kind: 'fired',
+      alerts: [
+        fired({ _id: 'a1', severity: 'critical', rule_name: 'High temp', device_id: 'device_001', trigger_value: 40 }),
+        fired({ _id: 'a2', severity: 'info', rule_name: 'Low battery', device_id: 'device_002', trigger_value: 12 }),
+      ],
+    };
+    act(() => handleEvent(event));
+
+    // Severity maps to toast type: critical -> error, info -> info.
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    expect(toast.error).toHaveBeenCalledWith(
+      expect.stringContaining('High temp'),
+      expect.objectContaining({ onClick: expect.any(Function) })
+    );
+    expect(toast.info).toHaveBeenCalledTimes(1);
+    expect(toast.info).toHaveBeenCalledWith(
+      expect.stringContaining('Low battery'),
+      expect.anything()
+    );
+    expect(toast.warning).not.toHaveBeenCalled();
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.alerts.all });
+  });
+
+  // Negative case #1: a resolved BATCH must never toast. Nobody wants a popup
+  // per device when a floor-wide condition clears; the acting admin already
+  // got feedback from their own mutation's optimistic update.
+  it('does NOT toast for a resolved batch, but still invalidates the alerts cache', () => {
+    const { invalidateSpy, handleEvent } = renderToaster();
+
+    const event: AlertEvent = {
+      kind: 'resolved',
+      alerts: [resolvedAlert({ _id: 'a1' }), resolvedAlert({ _id: 'a2' })],
+    };
+    act(() => handleEvent(event));
+
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(toast.warning).not.toHaveBeenCalled();
+    expect(toast.info).not.toHaveBeenCalled();
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.alerts.all });
+  });
+
+  it('toasts once for a FIRED storm, mentioning the count, and invalidates', () => {
+    const { invalidateSpy, handleEvent } = renderToaster();
+
+    const event: AlertEvent = {
+      kind: 'storm',
+      of: 'fired',
+      count: 312,
+      by_severity: { info: 0, warning: 12, critical: 300 },
+      since: '2026-08-01T12:00:00.000Z',
+    };
+    act(() => handleEvent(event));
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    expect(toast.error).toHaveBeenCalledWith(
+      expect.stringContaining('312'),
+      expect.objectContaining({ onClick: expect.any(Function) })
+    );
+    expect(toast.warning).not.toHaveBeenCalled();
+    expect(toast.info).not.toHaveBeenCalled();
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.alerts.all });
+  });
+
+  // Negative case #2: the whole reason `of` exists. A resolved storm is a mass
+  // RECOVERY (e.g. a floor-wide condition clearing) — announcing it with the
+  // same red "N alerts firing" banner would report the best news in the app as
+  // the worst. A suite that only asserts the fired-storm row above would pass
+  // just as happily against a component that toasts on every storm.
+  it('does NOT toast for a RESOLVED storm, but still invalidates', () => {
+    const { invalidateSpy, handleEvent } = renderToaster();
+
+    const event: AlertEvent = {
+      kind: 'storm',
+      of: 'resolved',
+      count: 312,
+      by_severity: { info: 0, warning: 12, critical: 300 },
+      since: '2026-08-01T12:00:00.000Z',
+    };
+    act(() => handleEvent(event));
+
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(toast.warning).not.toHaveBeenCalled();
+    expect(toast.info).not.toHaveBeenCalled();
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.alerts.all });
+  });
+});

--- a/__tests__/unit/components/AlertToaster.test.tsx
+++ b/__tests__/unit/components/AlertToaster.test.tsx
@@ -209,3 +209,97 @@ describe('AlertToaster', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.alerts.all });
   });
 });
+
+/**
+ * Toast lifetime. These rows are about a config value whose meaning changed
+ * underneath it: `autoClose={false}` was fine while every toast was raised by a
+ * user, one at a time. Alerts come from a background evaluator that can emit up
+ * to ALERT_EVENT_MAX (20) from one ingest, so a toast that never expires and
+ * cannot be clicked away stacks past the top of the viewport and follows the
+ * viewer across every route until they reload.
+ *
+ * Asserting `expect.any(Number)` is not enough on its own — `autoClose: false`
+ * would fail that, but so would a `0`, which react-toastify treats as "never
+ * close". Each row therefore checks the value is a positive finite number.
+ */
+describe('AlertToaster toast lifetime', () => {
+  function optionsOf(mock: jest.Mock) {
+    return mock.mock.calls.at(-1)?.[1] as {
+      autoClose?: number | false;
+      closeOnClick?: boolean;
+      toastId?: string;
+    };
+  }
+
+  it('gives every fired toast a finite dismissal, click-to-close, and a stable id', () => {
+    const { handleEvent } = renderToaster();
+
+    act(() =>
+      handleEvent({
+        kind: 'fired',
+        alerts: [fired({ _id: 'alert_42', severity: 'critical' })],
+      })
+    );
+
+    const options = optionsOf(toast.error as jest.Mock);
+    expect(typeof options.autoClose).toBe('number');
+    expect(options.autoClose).toBeGreaterThan(0);
+    expect(Number.isFinite(options.autoClose as number)).toBe(true);
+    expect(options.closeOnClick).toBe(true);
+    expect(options.toastId).toBe('alert_42');
+  });
+
+  it('gives each severity a finite dismissal', () => {
+    const { handleEvent } = renderToaster();
+
+    act(() =>
+      handleEvent({
+        kind: 'fired',
+        alerts: [
+          fired({ _id: 'a_crit', severity: 'critical' }),
+          fired({ _id: 'a_warn', severity: 'warning' }),
+          fired({ _id: 'a_info', severity: 'info' }),
+        ],
+      })
+    );
+
+    for (const mock of [toast.error, toast.warning, toast.info] as jest.Mock[]) {
+      const options = optionsOf(mock);
+      expect(typeof options.autoClose).toBe('number');
+      expect(options.autoClose).toBeGreaterThan(0);
+      expect(options.closeOnClick).toBe(true);
+    }
+  });
+
+  it('reuses the toastId when the same alert is re-broadcast, so it cannot stack', () => {
+    const { handleEvent } = renderToaster();
+
+    const event: AlertEvent = { kind: 'fired', alerts: [fired({ _id: 'alert_dupe' })] };
+    act(() => handleEvent(event));
+    act(() => handleEvent(event));
+
+    const ids = (toast.error as jest.Mock).mock.calls.map(call => call[1]?.toastId);
+    expect(ids).toEqual(['alert_dupe', 'alert_dupe']);
+  });
+
+  it('gives the storm toast a finite dismissal and click-to-close too', () => {
+    const { handleEvent } = renderToaster();
+
+    act(() =>
+      handleEvent({
+        kind: 'storm',
+        of: 'fired',
+        count: 312,
+        by_severity: { info: 0, warning: 12, critical: 300 },
+        since: '2026-08-01T12:00:00.000Z',
+      })
+    );
+
+    const options = optionsOf(toast.error as jest.Mock);
+    expect(typeof options.autoClose).toBe('number');
+    expect(options.autoClose).toBeGreaterThan(0);
+    expect(options.closeOnClick).toBe(true);
+    // Distinct storms stay distinct; a re-broadcast of the same one does not stack.
+    expect(options.toastId).toContain('2026-08-01T12:00:00.000Z');
+  });
+});

--- a/__tests__/unit/components/CreateAlertRuleModal.test.tsx
+++ b/__tests__/unit/components/CreateAlertRuleModal.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * CreateAlertRuleModal Tests
+ *
+ * `@/lib/api/v2-client` is mocked (not `@/lib/query/hooks`) so the real
+ * `useCreateAlertRule` mutation hook runs, exercising the actual wiring from
+ * form submit through the hook to the API client — the class of bug this
+ * phase keeps hitting is a mock that never intercepts the code under test.
+ *
+ * `components/ui/select.tsx` is NOT a native `<select>` (no onChange, no
+ * event.target.value): the metric field is a custom listbox button. Tests
+ * interact with it via `chooseSelectOption`, which clicks the trigger (found
+ * by its associated `<label htmlFor>`) then clicks the matching
+ * `role="option"` entry — never `fireEvent.change`.
+ *
+ * The two negative-validation tests ("blocks submit when metric is 'value'
+ * and no type is selected" and "rejects an anomaly_score threshold above 1")
+ * each assert BOTH that the error message renders AND that
+ * `v2Api.alertRules.create` was NOT called — asserting only the message would
+ * pass against a component that shows the error and submits anyway.
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { CreateAlertRuleModal } from '@/components/alerts/CreateAlertRuleModal';
+import { v2Api } from '@/lib/api/v2-client';
+
+jest.mock('@/lib/api/v2-client', () => ({
+  v2Api: { alertRules: { create: jest.fn().mockResolvedValue({ data: { _id: 'r1' } }) } },
+}));
+
+jest.mock('react-toastify', () => ({ toast: { success: jest.fn(), error: jest.fn() } }));
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return React.createElement(QueryClientProvider, { client }, children);
+}
+
+/**
+ * Opens a components/ui/select.tsx dropdown (found via its <label htmlFor>
+ * association, matching the accessibility requirement every input in this
+ * form must satisfy) and picks an option by its visible listbox-option text.
+ */
+function chooseSelectOption(labelMatch: RegExp, optionName: RegExp) {
+  fireEvent.click(screen.getByLabelText(labelMatch));
+  fireEvent.click(screen.getByRole('option', { name: optionName }));
+}
+
+describe('CreateAlertRuleModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should block submit when metric is 'value' and no type is selected", async () => {
+    render(<CreateAlertRuleModal isOpen onClose={jest.fn()} />, { wrapper });
+
+    fireEvent.click(screen.getByRole('button', { name: /create rule/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/select at least one reading type/i)).toBeInTheDocument()
+    );
+    expect(v2Api.alertRules.create).not.toHaveBeenCalled();
+  });
+
+  it('should reject an anomaly_score threshold above 1', async () => {
+    render(<CreateAlertRuleModal isOpen onClose={jest.fn()} />, { wrapper });
+
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'Bad anomaly rule' } });
+    chooseSelectOption(/metric/i, /anomaly score/i);
+    fireEvent.change(screen.getByLabelText(/threshold/i), { target: { value: '30' } });
+    fireEvent.click(screen.getByRole('button', { name: /create rule/i }));
+
+    await waitFor(() => expect(screen.getByText(/between 0 and 1/i)).toBeInTheDocument());
+    expect(v2Api.alertRules.create).not.toHaveBeenCalled();
+  });
+
+  it('should reject a battery_level threshold above 100', async () => {
+    render(<CreateAlertRuleModal isOpen onClose={jest.fn()} />, { wrapper });
+
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'Bad battery rule' } });
+    chooseSelectOption(/metric/i, /battery level/i);
+    fireEvent.change(screen.getByLabelText(/threshold/i), { target: { value: '150' } });
+    fireEvent.click(screen.getByRole('button', { name: /create rule/i }));
+
+    await waitFor(() => expect(screen.getByText(/between 0 and 100/i)).toBeInTheDocument());
+    expect(v2Api.alertRules.create).not.toHaveBeenCalled();
+  });
+
+  it('should submit a valid rule', async () => {
+    render(<CreateAlertRuleModal isOpen onClose={jest.fn()} />, { wrapper });
+
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'High temp' } });
+    fireEvent.change(screen.getByLabelText(/threshold/i), { target: { value: '30' } });
+    fireEvent.click(screen.getByLabelText(/temperature/i));
+    fireEvent.click(screen.getByRole('button', { name: /create rule/i }));
+
+    await waitFor(() => expect(v2Api.alertRules.create).toHaveBeenCalled());
+
+    const payload = (v2Api.alertRules.create as jest.Mock).mock.calls[0][0];
+    expect(payload.name).toBe('High temp');
+    expect(payload.metric).toBe('value');
+    expect(payload.threshold).toBe(30);
+    expect(payload.selector.types).toContain('temperature');
+  });
+
+  it('should submit a valid anomaly_score rule with an empty selector object (no types key required)', async () => {
+    render(<CreateAlertRuleModal isOpen onClose={jest.fn()} />, { wrapper });
+
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'Anomaly rule' } });
+    chooseSelectOption(/metric/i, /anomaly score/i);
+    fireEvent.change(screen.getByLabelText(/threshold/i), { target: { value: '0.8' } });
+    fireEvent.click(screen.getByRole('button', { name: /create rule/i }));
+
+    await waitFor(() => expect(v2Api.alertRules.create).toHaveBeenCalled());
+
+    const payload = (v2Api.alertRules.create as jest.Mock).mock.calls[0][0];
+    expect(payload.metric).toBe('anomaly_score');
+    expect(payload.threshold).toBe(0.8);
+    expect(payload.selector).toEqual({});
+  });
+
+  it('should convert the duration field from minutes to seconds on submit', async () => {
+    render(<CreateAlertRuleModal isOpen onClose={jest.fn()} />, { wrapper });
+
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'High temp' } });
+    fireEvent.change(screen.getByLabelText(/threshold/i), { target: { value: '30' } });
+    fireEvent.click(screen.getByLabelText(/temperature/i));
+    fireEvent.change(screen.getByLabelText(/duration/i), { target: { value: '5' } });
+    fireEvent.click(screen.getByRole('button', { name: /create rule/i }));
+
+    await waitFor(() => expect(v2Api.alertRules.create).toHaveBeenCalled());
+
+    const payload = (v2Api.alertRules.create as jest.Mock).mock.calls[0][0];
+    expect(payload.for_duration_seconds).toBe(300);
+  });
+
+  it('should toast an error and stay open when the API call fails', async () => {
+    (v2Api.alertRules.create as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+    const onClose = jest.fn();
+    const { toast } = jest.requireMock('react-toastify');
+
+    render(<CreateAlertRuleModal isOpen onClose={onClose} />, { wrapper });
+
+    fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'High temp' } });
+    fireEvent.change(screen.getByLabelText(/threshold/i), { target: { value: '30' } });
+    fireEvent.click(screen.getByLabelText(/temperature/i));
+    fireEvent.click(screen.getByRole('button', { name: /create rule/i }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('boom'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/components/CreateAlertRuleModal.test.tsx
+++ b/__tests__/unit/components/CreateAlertRuleModal.test.tsx
@@ -17,6 +17,27 @@
  * each assert BOTH that the error message renders AND that
  * `v2Api.alertRules.create` was NOT called — asserting only the message would
  * pass against a component that shows the error and submits anyway.
+ *
+ * The `scoping` block is about the worst failure this form can produce: a rule
+ * the operator scoped to one building silently going fleet-wide, arming every
+ * device in the estate. Nothing downstream would flag it — the request is
+ * valid, the rule saves, and the first symptom is a pager storm. So each of the
+ * four scoping dimensions the form exposes (Building, Floor, Zone, Tags) is
+ * asserted to reach `v2Api.alertRules.create`, and the selector is compared
+ * with `toEqual` (exact key set) rather than by probing individual keys, so an
+ * extra or missing constraint fails too.
+ *
+ * Its paired fleet-wide test is what makes the scoped ones bite: a genuine
+ * fleet-wide rule must submit a selector carrying no scoping keys at all. With
+ * both present, "the selector was dropped" is distinguishable from "the user
+ * asked for fleet-wide", which a scoped-only test cannot do.
+ *
+ * `enabled` and `severity` are asserted to travel from the control the user
+ * touched into the body, in both directions where the form allows one — a
+ * component that hardcoded either would still satisfy a single-value test.
+ *
+ * Every assertion here is against the arguments the mocked API client received,
+ * never against component state.
  */
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
@@ -47,6 +68,34 @@ function wrapper({ children }: { children: React.ReactNode }) {
 function chooseSelectOption(labelMatch: RegExp, optionName: RegExp) {
   fireEvent.click(screen.getByLabelText(labelMatch));
   fireEvent.click(screen.getByRole('option', { name: optionName }));
+}
+
+/**
+ * The minimum a `metric: 'value'` rule needs to pass validate(): a name, a
+ * threshold, and one reading type. Scoping tests layer their own fields on top
+ * of this so the only difference between them is the dimension under test.
+ */
+function fillMinimalValueRule(name = 'High temp') {
+  fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: name } });
+  fireEvent.change(screen.getByLabelText(/threshold/i), { target: { value: '30' } });
+  fireEvent.click(screen.getByLabelText(/temperature/i));
+}
+
+/** TagInput commits on Enter, not on change — a change alone submits no tags. */
+function addTag(tag: string) {
+  const input = screen.getByLabelText(/tags/i);
+  fireEvent.change(input, { target: { value: tag } });
+  fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+}
+
+function submitForm() {
+  fireEvent.click(screen.getByRole('button', { name: /create rule/i }));
+}
+
+/** The body the component actually handed to the API client. */
+async function submittedBody() {
+  await waitFor(() => expect(v2Api.alertRules.create).toHaveBeenCalled());
+  return (v2Api.alertRules.create as jest.Mock).mock.calls[0][0];
 }
 
 describe('CreateAlertRuleModal', () => {
@@ -135,6 +184,170 @@ describe('CreateAlertRuleModal', () => {
 
     const payload = (v2Api.alertRules.create as jest.Mock).mock.calls[0][0];
     expect(payload.for_duration_seconds).toBe(300);
+  });
+
+  // ==========================================================================
+  // D2 — scoping. A scoped rule that goes out fleet-wide arms the estate.
+  // ==========================================================================
+
+  describe('scoping', () => {
+    it('should send a building-scoped rule scoped to that building', async () => {
+      render(<CreateAlertRuleModal isOpen onClose={jest.fn()} />, { wrapper });
+
+      fillMinimalValueRule();
+      fireEvent.change(screen.getByLabelText(/building/i), { target: { value: 'bldg-a' } });
+      submitForm();
+
+      const body = await submittedBody();
+      expect(body.metric).toBe('value'); // the discriminant buildCreateBody branches on
+      expect(body.selector).toEqual({ types: ['temperature'], building_id: 'bldg-a' });
+    });
+
+    it('should send a floor-scoped rule with the floor as a number, not the raw input string', async () => {
+      render(<CreateAlertRuleModal isOpen onClose={jest.fn()} />, { wrapper });
+
+      fillMinimalValueRule();
+      fireEvent.change(screen.getByLabelText(/floor/i), { target: { value: '3' } });
+      submitForm();
+
+      const body = await submittedBody();
+      expect(body.selector).toEqual({ types: ['temperature'], floor: 3 });
+      expect(typeof body.selector.floor).toBe('number');
+    });
+
+    it('should send a zone-scoped rule scoped to that zone', async () => {
+      render(<CreateAlertRuleModal isOpen onClose={jest.fn()} />, { wrapper });
+
+      fillMinimalValueRule();
+      fireEvent.change(screen.getByLabelText(/zone/i), { target: { value: 'north-wing' } });
+      submitForm();
+
+      const body = await submittedBody();
+      expect(body.selector).toEqual({ types: ['temperature'], zone: 'north-wing' });
+    });
+
+    it('should send a tag-scoped rule scoped to those tags', async () => {
+      render(<CreateAlertRuleModal isOpen onClose={jest.fn()} />, { wrapper });
+
+      fillMinimalValueRule();
+      addTag('hvac');
+      addTag('critical-path');
+      submitForm();
+
+      const body = await submittedBody();
+      expect(body.selector).toEqual({
+        types: ['temperature'],
+        tags: ['hvac', 'critical-path'],
+      });
+    });
+
+    it('should carry all four scoping dimensions at once', async () => {
+      render(<CreateAlertRuleModal isOpen onClose={jest.fn()} />, { wrapper });
+
+      fillMinimalValueRule();
+      fireEvent.change(screen.getByLabelText(/building/i), { target: { value: 'bldg-a' } });
+      fireEvent.change(screen.getByLabelText(/floor/i), { target: { value: '2' } });
+      fireEvent.change(screen.getByLabelText(/zone/i), { target: { value: 'east' } });
+      addTag('hvac');
+      submitForm();
+
+      const body = await submittedBody();
+      expect(body.selector).toEqual({
+        types: ['temperature'],
+        building_id: 'bldg-a',
+        floor: 2,
+        zone: 'east',
+        tags: ['hvac'],
+      });
+    });
+
+    it('should scope a non-value metric too, on buildCreateBody\'s other branch', async () => {
+      render(<CreateAlertRuleModal isOpen onClose={jest.fn()} />, { wrapper });
+
+      fireEvent.change(screen.getByLabelText(/^name/i), { target: { value: 'Anomaly in B' } });
+      chooseSelectOption(/metric/i, /anomaly score/i);
+      fireEvent.change(screen.getByLabelText(/threshold/i), { target: { value: '0.8' } });
+      fireEvent.change(screen.getByLabelText(/building/i), { target: { value: 'bldg-b' } });
+      submitForm();
+
+      const body = await submittedBody();
+      expect(body.metric).toBe('anomaly_score');
+      expect(body.selector).toEqual({ building_id: 'bldg-b' });
+    });
+
+    /**
+     * The pair. Without this, "the selector was dropped" and "the user asked
+     * for fleet-wide" produce the same body and no test can tell them apart.
+     */
+    it('should send NO scoping keys when the user scoped nothing', async () => {
+      render(<CreateAlertRuleModal isOpen onClose={jest.fn()} />, { wrapper });
+
+      fillMinimalValueRule('Fleet-wide high temp');
+      submitForm();
+
+      const body = await submittedBody();
+      expect(body.selector).toEqual({ types: ['temperature'] });
+      expect(body.selector).not.toHaveProperty('building_id');
+      expect(body.selector).not.toHaveProperty('floor');
+      expect(body.selector).not.toHaveProperty('zone');
+      expect(body.selector).not.toHaveProperty('tags');
+    });
+  });
+
+  // ==========================================================================
+  // D2 — enabled and severity travel from the control the user touched
+  // ==========================================================================
+
+  describe('enabled', () => {
+    it('should submit enabled:true for a rule left enabled', async () => {
+      render(<CreateAlertRuleModal isOpen onClose={jest.fn()} />, { wrapper });
+
+      fillMinimalValueRule();
+      submitForm();
+
+      expect((await submittedBody()).enabled).toBe(true);
+    });
+
+    it('should submit enabled:false once the user unchecks Enabled', async () => {
+      render(<CreateAlertRuleModal isOpen onClose={jest.fn()} />, { wrapper });
+
+      fillMinimalValueRule();
+      fireEvent.click(screen.getByLabelText(/^enabled$/i));
+      submitForm();
+
+      expect((await submittedBody()).enabled).toBe(false);
+    });
+  });
+
+  describe('severity', () => {
+    it('should submit the form default of warning when the user does not change it', async () => {
+      render(<CreateAlertRuleModal isOpen onClose={jest.fn()} />, { wrapper });
+
+      fillMinimalValueRule();
+      submitForm();
+
+      expect((await submittedBody()).severity).toBe('warning');
+    });
+
+    it('should submit critical once the user selects Critical', async () => {
+      render(<CreateAlertRuleModal isOpen onClose={jest.fn()} />, { wrapper });
+
+      fillMinimalValueRule();
+      chooseSelectOption(/severity/i, /critical/i);
+      submitForm();
+
+      expect((await submittedBody()).severity).toBe('critical');
+    });
+
+    it('should submit info once the user selects Info', async () => {
+      render(<CreateAlertRuleModal isOpen onClose={jest.fn()} />, { wrapper });
+
+      fillMinimalValueRule();
+      chooseSelectOption(/severity/i, /info/i);
+      submitForm();
+
+      expect((await submittedBody()).severity).toBe('info');
+    });
   });
 
   it('should toast an error and stay open when the API call fails', async () => {

--- a/__tests__/unit/components/DashboardStatCards.test.tsx
+++ b/__tests__/unit/components/DashboardStatCards.test.tsx
@@ -41,6 +41,7 @@ jest.mock('@/components/dashboard', () => {
   const Actual = jest.requireActual('@/components/dashboard');
   return {
     ...Actual,
+    ActiveAlertsWidget: () => null,
     AnomalyDetectionChart: () => null,
     CriticalIssuesPanel: () => null,
     MaintenanceWidget: () => null,

--- a/__tests__/unit/components/RealtimeStatusBanner.test.tsx
+++ b/__tests__/unit/components/RealtimeStatusBanner.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * RealtimeStatusBanner Tests
+ *
+ * The banner exists to make an invisible failure visible: a dead socket and a
+ * quiet building render the same "No open alerts." screen. Two negative rows
+ * carry most of the weight — it must stay silent while healthy AND while
+ * merely connecting, or it fires on every cold page load and gets ignored the
+ * one time it matters.
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { RealtimeStatusBanner } from '@/components/alerts/RealtimeStatusBanner';
+import { useRealtimeConnection, type RealtimeConnection } from '@/lib/pusher-context';
+
+jest.mock('@/lib/pusher-context', () => ({
+  useRealtimeConnection: jest.fn(),
+}));
+
+const mockConnection = useRealtimeConnection as jest.Mock;
+
+function connection(overrides: Partial<RealtimeConnection> = {}): RealtimeConnection {
+  return {
+    connected: true,
+    state: 'connected',
+    degraded: false,
+    message: null,
+    terminal: false,
+    ...overrides,
+  };
+}
+
+describe('RealtimeStatusBanner', () => {
+  it('renders nothing while the connection is healthy', () => {
+    mockConnection.mockReturnValue(connection());
+
+    const { container } = render(<RealtimeStatusBanner />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing during the ordinary connecting window', () => {
+    // Not connected, but nothing is wrong yet. A banner here would appear on
+    // every page load and train viewers to ignore it.
+    mockConnection.mockReturnValue(
+      connection({ connected: false, state: 'connecting', degraded: false })
+    );
+
+    const { container } = render(<RealtimeStatusBanner />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('announces a degraded connection with its explanation', () => {
+    mockConnection.mockReturnValue(
+      connection({
+        connected: false,
+        state: 'reconnecting',
+        degraded: true,
+        message: 'Lost the real-time connection — retrying.',
+      })
+    );
+
+    render(<RealtimeStatusBanner />);
+
+    expect(screen.getByTestId('realtime-status-banner')).toBeInTheDocument();
+    expect(screen.getByText(/Live updates unavailable/i)).toBeInTheDocument();
+    expect(screen.getByText(/Lost the real-time connection/i)).toBeInTheDocument();
+  });
+
+  it('is announced to assistive technology', () => {
+    mockConnection.mockReturnValue(
+      connection({ connected: false, state: 'failed', degraded: true, terminal: true, message: 'x' })
+    );
+
+    render(<RealtimeStatusBanner />);
+
+    const banner = screen.getByRole('status');
+    expect(banner).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('still renders when the degraded state carries no message', () => {
+    mockConnection.mockReturnValue(
+      connection({ connected: false, state: 'failed', degraded: true, message: null })
+    );
+
+    render(<RealtimeStatusBanner />);
+
+    expect(screen.getByTestId('realtime-status-banner')).toBeInTheDocument();
+  });
+});

--- a/__tests__/unit/components/TopNav.test.tsx
+++ b/__tests__/unit/components/TopNav.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * TopNav Tests
+ *
+ * Focused on the two things Task 18 adds to TopNav: the "/alerts" nav item
+ * (desktop and mobile) and its live open-alert-count badge.
+ *
+ * `@/lib/query/hooks` and `@/lib/pusher-context` are mocked at the exact
+ * module specifiers TopNav.tsx imports from, matching the working pattern in
+ * AlertToaster.test.tsx / AlertList.test.tsx, so the mocks actually intercept
+ * the imports TopNav uses.
+ *
+ * `@clerk/nextjs` is re-mocked locally (the global jsdom setup mock has no
+ * `useAuth`, `SignedIn`, `SignedOut`, or `SignInButton` — all of which
+ * TopNav needs) — confirmed by running this file; see the task report for
+ * the run that proves the local mock, not the global one, is what executes.
+ *
+ * The badge's ">0" gate is the focus of the deletion-check evidence recorded
+ * in the task report: both the "hidden at zero" and "shown above zero" tests
+ * are proven to fail against a component that gets that gate wrong.
+ */
+
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import TopNav from '@/components/TopNav';
+import { usePusherAlerts } from '@/lib/pusher-context';
+import { queryKeys } from '@/lib/query/queryClient';
+import type { AlertEvent } from '@/types/v2';
+
+const mockUseOpenAlertCount = jest.fn();
+jest.mock('@/lib/query/hooks', () => ({
+  useOpenAlertCount: () => mockUseOpenAlertCount(),
+}));
+
+jest.mock('@/lib/pusher-context', () => ({
+  usePusherAlerts: jest.fn(),
+}));
+
+const mockUseAuth = jest.fn();
+jest.mock('@clerk/nextjs', () => ({
+  useAuth: () => mockUseAuth(),
+  SignedIn: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SignedOut: () => null,
+  SignInButton: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Not under test here — it pulls in next-themes/UserButton, neither of which
+// this suite cares about.
+jest.mock('@/components/user-button-with-theme', () => ({
+  UserButtonWithTheme: () => null,
+}));
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}));
+
+function setOpenAlertCount(count: number) {
+  mockUseOpenAlertCount.mockReturnValue({ data: count, isLoading: false, error: null });
+}
+
+/** Renders TopNav under a real QueryClient and returns a spy on invalidateQueries
+ *  plus the handler TopNav registered with the mocked usePusherAlerts. */
+function renderTopNav() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+  const utils = render(
+    <QueryClientProvider client={queryClient}>
+      <TopNav />
+    </QueryClientProvider>
+  );
+
+  const handleEvent = (usePusherAlerts as jest.Mock).mock.calls.at(-1)?.[0] as (
+    event: AlertEvent
+  ) => void;
+
+  return { ...utils, invalidateSpy, handleEvent };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseAuth.mockReturnValue({
+    isLoaded: true,
+    isSignedIn: true,
+    orgRole: 'org:admin',
+    orgSlug: 'users',
+  });
+  setOpenAlertCount(0);
+});
+
+describe('TopNav', () => {
+  it('renders an Alerts nav item linking to /alerts', () => {
+    renderTopNav();
+
+    const link = screen.getByRole('link', { name: /alerts/i });
+    expect(link).toHaveAttribute('href', '/alerts');
+  });
+
+  describe('open-alert count badge', () => {
+    it('should NOT show a badge when there are no open alerts', () => {
+      setOpenAlertCount(0);
+
+      renderTopNav();
+
+      const link = screen.getByRole('link', { name: /alerts/i });
+      expect(link.querySelector('.bg-destructive')).not.toBeInTheDocument();
+    });
+
+    it('should show a badge with the count when there are open alerts', () => {
+      setOpenAlertCount(7);
+
+      renderTopNav();
+
+      const link = screen.getByRole('link', { name: /alerts/i });
+      const badge = link.querySelector('.bg-destructive');
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent('7');
+    });
+
+    it('should default to 0 (no badge) while the count is still loading (data undefined)', () => {
+      mockUseOpenAlertCount.mockReturnValue({ data: undefined, isLoading: true, error: null });
+
+      renderTopNav();
+
+      const link = screen.getByRole('link', { name: /alerts/i });
+      expect(link.querySelector('.bg-destructive')).not.toBeInTheDocument();
+    });
+
+    it('should render the badge in the mobile menu too, once opened', () => {
+      setOpenAlertCount(3);
+
+      renderTopNav();
+      fireEvent.click(screen.getByRole('button', { name: /open main menu/i }));
+
+      const links = screen.getAllByRole('link', { name: /alerts/i });
+      expect(links).toHaveLength(2); // desktop + mobile
+      for (const link of links) expect(link.querySelector('.bg-destructive')).toHaveTextContent('3');
+    });
+  });
+
+  describe('live updates via Pusher', () => {
+    it('registers exactly one alert-event handler via usePusherAlerts', () => {
+      renderTopNav();
+
+      expect(usePusherAlerts).toHaveBeenCalledTimes(1);
+      expect(typeof (usePusherAlerts as jest.Mock).mock.calls[0][0]).toBe('function');
+    });
+
+    it('invalidates the alerts query cache on an alert-event, same as AlertToaster', () => {
+      const { invalidateSpy, handleEvent } = renderTopNav();
+
+      act(() =>
+        handleEvent({
+          kind: 'fired',
+          alerts: [
+            {
+              _id: 'a1',
+              rule_id: 'rule_1',
+              rule_name: 'High temp',
+              device_id: 'device_001',
+              severity: 'critical',
+              metric: 'value',
+              comparison: 'gt',
+              threshold: 30,
+              trigger_value: 40,
+              fired_at: '2026-08-01T12:00:00.000Z',
+            },
+          ],
+        })
+      );
+
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.alerts.all });
+    });
+
+    it('passes a memoized (referentially stable) callback to usePusherAlerts across re-renders', () => {
+      renderTopNav();
+      const firstCallback = (usePusherAlerts as jest.Mock).mock.calls[0][0];
+
+      // Trigger a re-render via unrelated state (opening the mobile menu).
+      fireEvent.click(screen.getByRole('button', { name: /open main menu/i }));
+
+      const lastCallback = (usePusherAlerts as jest.Mock).mock.calls.at(-1)?.[0];
+      expect(lastCallback).toBe(firstCallback);
+    });
+  });
+});

--- a/__tests__/unit/components/TopNav.test.tsx
+++ b/__tests__/unit/components/TopNav.test.tsx
@@ -145,6 +145,106 @@ describe('TopNav', () => {
     });
   });
 
+  // --- A1: a failed count must render as visibly DEGRADED, never as the
+  // all-clear (no badge) — the two states must produce different output. ---
+  describe('open alert count failure (A1)', () => {
+    function setOpenAlertCountError() {
+      mockUseOpenAlertCount.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error('500'),
+      });
+    }
+
+    it('should render a visibly distinct degraded badge (not the zero/all-clear state) when the count fails to load', () => {
+      setOpenAlertCountError();
+
+      renderTopNav();
+
+      const link = screen.getByRole('link', { name: /alerts/i });
+      // Not the numeric "open alerts" badge — a failed fetch must not borrow
+      // that styling/semantics.
+      expect(link.querySelector('.bg-destructive')).not.toBeInTheDocument();
+      // A real, distinct affordance IS present — this is what makes the fix
+      // real: the zero state renders nothing at all here (see the "should
+      // NOT show a badge when there are no open alerts" test above), while
+      // the error state renders this.
+      const badge = screen.getByLabelText('Open alert count unavailable');
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent('!');
+    });
+
+    it('should not present the degraded badge as if it were the numeric all-clear (zero) state', () => {
+      setOpenAlertCountError();
+
+      renderTopNav();
+
+      // The all-clear state shows no badge and no unavailable-affordance;
+      // proving both absences here is what makes this test able to fail if
+      // the two states were ever collapsed back into one rendering.
+      expect(screen.queryByText('0')).not.toBeInTheDocument();
+    });
+
+    it('should render the degraded badge in both desktop and mobile nav', () => {
+      setOpenAlertCountError();
+
+      renderTopNav();
+      fireEvent.click(screen.getByRole('button', { name: /open main menu/i }));
+
+      const badges = screen.getAllByLabelText('Open alert count unavailable');
+      expect(badges).toHaveLength(2); // desktop + mobile
+      for (const badge of badges) expect(badge).toHaveTextContent('!');
+    });
+
+    it('should NOT show the degraded badge while signed out, even if the count query errors', () => {
+      mockUseAuth.mockReturnValue({
+        isLoaded: true,
+        isSignedIn: false,
+        orgRole: null,
+        orgSlug: null,
+      });
+      setOpenAlertCountError();
+
+      renderTopNav();
+
+      expect(screen.queryByLabelText('Open alert count unavailable')).not.toBeInTheDocument();
+      // And it must not fall back to showing a numeric badge either.
+      expect(screen.getByRole('link', { name: /alerts/i }).querySelector('.bg-destructive')).not.toBeInTheDocument();
+    });
+
+    it('should NOT show the degraded badge while the auth state is still loading, even if the count query errors', () => {
+      mockUseAuth.mockReturnValue({
+        isLoaded: false,
+        isSignedIn: false,
+        orgRole: null,
+        orgSlug: null,
+      });
+      setOpenAlertCountError();
+
+      renderTopNav();
+
+      expect(screen.queryByLabelText('Open alert count unavailable')).not.toBeInTheDocument();
+    });
+
+    it('should prefer the degraded badge over a stale non-zero count when both are present', () => {
+      // A background refetch that fails after a prior success can leave a
+      // stale positive count sitting in `data` alongside a populated
+      // `error`. The degraded state must win — a fetch failure is not safe
+      // to paper over with whatever number happened to be cached.
+      mockUseOpenAlertCount.mockReturnValue({
+        data: 5,
+        isLoading: false,
+        error: new Error('500'),
+      });
+
+      renderTopNav();
+
+      const link = screen.getByRole('link', { name: /alerts/i });
+      expect(link.querySelector('.bg-destructive')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('Open alert count unavailable')).toBeInTheDocument();
+    });
+  });
+
   describe('live updates via Pusher', () => {
     it('registers exactly one alert-event handler via usePusherAlerts', () => {
       renderTopNav();

--- a/__tests__/unit/components/TopNav.test.tsx
+++ b/__tests__/unit/components/TopNav.test.tsx
@@ -115,6 +115,9 @@ describe('TopNav', () => {
       const badge = link.querySelector('.bg-destructive');
       expect(badge).toBeInTheDocument();
       expect(badge).toHaveTextContent('7');
+      // The digit alone ("7") is meaningless to a screen reader — it must
+      // announce a unit, not just a bare number.
+      expect(badge).toHaveAccessibleName('7 open alerts');
     });
 
     it('should default to 0 (no badge) while the count is still loading (data undefined)', () => {
@@ -134,7 +137,11 @@ describe('TopNav', () => {
 
       const links = screen.getAllByRole('link', { name: /alerts/i });
       expect(links).toHaveLength(2); // desktop + mobile
-      for (const link of links) expect(link.querySelector('.bg-destructive')).toHaveTextContent('3');
+      for (const link of links) {
+        const badge = link.querySelector('.bg-destructive');
+        expect(badge).toHaveTextContent('3');
+        expect(badge).toHaveAccessibleName('3 open alerts');
+      }
     });
   });
 

--- a/__tests__/unit/components/useAlertFilterParams.test.tsx
+++ b/__tests__/unit/components/useAlertFilterParams.test.tsx
@@ -1,0 +1,243 @@
+/**
+ * useAlertFilterParams Tests
+ *
+ * Mirrors __tests__/unit/lib/useDeviceFilterParams.test.tsx: `push` records the
+ * URL and updates what `useSearchParams` returns, so the hook's read path and
+ * write path are exercised against each other exactly as they are in the
+ * browser. next/navigation is mocked in full — no Suspense boundary is needed
+ * here because the hook is exercised directly via renderHook, not through a
+ * page render.
+ *
+ * Three behavioral rules are pinned deliberately hard, per the task brief:
+ *  1. setStatus/setSeverity reset page to 1 IN THE SAME URL write — asserted by
+ *     starting on page 3 (not page 1, which would make the assertion vacuous)
+ *     and checking the pushed URL has no page param at all.
+ *  2. Default values are omitted from the query string — asserted by parsing
+ *     the pushed URL and checking `.has(key)` is false, not just that the
+ *     hook's return value equals the default.
+ *  3. Unparseable values fall back to defaults — using genuinely unparseable
+ *     input ('banana' for a number, 'purple' for an enum), not merely absent
+ *     input.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { useAlertFilterParams } from '@/components/alerts/useAlertFilterParams';
+
+const pushHistory: string[] = [];
+let currentSearch = '';
+
+const push = jest.fn((url: string) => {
+  pushHistory.push(url);
+  currentSearch = url.includes('?') ? url.slice(url.indexOf('?') + 1) : '';
+});
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+  usePathname: () => '/alerts',
+  useSearchParams: () => new URLSearchParams(currentSearch),
+}));
+
+/** Simulates a back/forward navigation, which changes the URL without a push. */
+function navigateTo(search: string) {
+  currentSearch = search;
+}
+
+/** Parses the query string out of the most recent push call. */
+function lastPushedQuery(): URLSearchParams {
+  const [url] = push.mock.calls.at(-1) ?? [];
+  if (!url) throw new Error('push was not called');
+  const queryIndex = url.indexOf('?');
+  return new URLSearchParams(queryIndex === -1 ? '' : url.slice(queryIndex + 1));
+}
+
+beforeEach(() => {
+  pushHistory.length = 0;
+  currentSearch = '';
+  push.mockClear();
+});
+
+describe('useAlertFilterParams', () => {
+  describe('reading state from the URL', () => {
+    it('should default to open/all/page-1 when the URL is bare', () => {
+      const { result } = renderHook(() => useAlertFilterParams());
+
+      expect(result.current.status).toBe('open');
+      expect(result.current.severity).toBe('all');
+      expect(result.current.page).toBe(1);
+    });
+
+    it('should restore a filtered view from a shared link', () => {
+      navigateTo('status=resolved&severity=critical&page=3');
+
+      const { result } = renderHook(() => useAlertFilterParams());
+
+      expect(result.current.status).toBe('resolved');
+      expect(result.current.severity).toBe('critical');
+      expect(result.current.page).toBe(3);
+    });
+
+    // --- Rule 3: unparseable values fall back to defaults ---------------
+
+    it('should fall back to page 1 for a genuinely unparseable page', () => {
+      navigateTo('page=banana');
+
+      const { result } = renderHook(() => useAlertFilterParams());
+
+      expect(result.current.page).toBe(1);
+    });
+
+    it('should fall back to page 1 for an out-of-range page', () => {
+      navigateTo('page=0');
+
+      const { result } = renderHook(() => useAlertFilterParams());
+
+      expect(result.current.page).toBe(1);
+    });
+
+    it('should fall back to "all" for an unrecognized severity rather than passing it through', () => {
+      navigateTo('severity=purple');
+
+      const { result } = renderHook(() => useAlertFilterParams());
+
+      expect(result.current.severity).toBe('all');
+    });
+
+    it('should fall back to "open" for an unrecognized status rather than passing it through', () => {
+      navigateTo('status=bogus');
+
+      const { result } = renderHook(() => useAlertFilterParams());
+
+      expect(result.current.status).toBe('open');
+    });
+  });
+
+  describe('writing state to the URL', () => {
+    it('should put the selected status in the URL', () => {
+      const { result } = renderHook(() => useAlertFilterParams());
+
+      act(() => result.current.setStatus('firing'));
+
+      expect(push).toHaveBeenCalledWith('/alerts?status=firing', { scroll: false });
+    });
+
+    it('should put the selected severity in the URL', () => {
+      const { result } = renderHook(() => useAlertFilterParams());
+
+      act(() => result.current.setSeverity('critical'));
+
+      expect(push).toHaveBeenCalledWith('/alerts?severity=critical', { scroll: false });
+    });
+
+    it('should put an explicit page in the URL', () => {
+      const { result } = renderHook(() => useAlertFilterParams());
+
+      act(() => result.current.setPage(5));
+
+      expect(push).toHaveBeenCalledWith('/alerts?page=5', { scroll: false });
+    });
+
+    it('should keep the current status/severity when only the page changes', () => {
+      navigateTo('status=firing&severity=warning');
+      const { result } = renderHook(() => useAlertFilterParams());
+
+      act(() => result.current.setPage(2));
+
+      expect(push).toHaveBeenCalledWith('/alerts?status=firing&severity=warning&page=2', {
+        scroll: false,
+      });
+    });
+
+    it('should return to a bare path when the only non-default filter is reset', () => {
+      navigateTo('status=firing');
+      const { result } = renderHook(() => useAlertFilterParams());
+
+      act(() => result.current.setStatus('open'));
+
+      expect(push).toHaveBeenCalledWith('/alerts', { scroll: false });
+    });
+
+    // --- Rule 2: defaults are omitted from the query string --------------
+    // Asserted by parsing the pushed URL and checking for ABSENCE of the key,
+    // not merely that result.current.<field> equals the default value.
+
+    it('should never write "status=open" or "severity=all" to the URL', () => {
+      const { result } = renderHook(() => useAlertFilterParams());
+
+      act(() => result.current.setPage(2));
+
+      const query = lastPushedQuery();
+      expect(query.has('status')).toBe(false);
+      expect(query.has('severity')).toBe(false);
+      expect(query.get('page')).toBe('2');
+    });
+
+    it('should never write "page=1" to the URL', () => {
+      navigateTo('page=4');
+      const { result } = renderHook(() => useAlertFilterParams());
+
+      act(() => result.current.setStatus('firing'));
+
+      const query = lastPushedQuery();
+      expect(query.has('page')).toBe(false);
+      expect(query.get('status')).toBe('firing');
+    });
+
+    // --- Rule 1: page resets to 1 in the SAME url write as a filter change --
+    // Deliberately starts on page 3 (not page 1) so the assertion is not
+    // vacuous — if the reset were missing, the pushed URL would contain
+    // "page=3" and this would fail.
+
+    it('should reset page to 1 in the same write when status changes, starting from page 3', () => {
+      navigateTo('page=3');
+      const { result } = renderHook(() => useAlertFilterParams());
+      expect(result.current.page).toBe(3);
+
+      act(() => result.current.setStatus('firing'));
+
+      expect(push).toHaveBeenCalledTimes(1);
+      expect(push).toHaveBeenCalledWith('/alerts?status=firing', { scroll: false });
+      const query = lastPushedQuery();
+      expect(query.has('page')).toBe(false);
+    });
+
+    it('should reset page to 1 in the same write when severity changes, starting from page 3', () => {
+      navigateTo('page=3');
+      const { result } = renderHook(() => useAlertFilterParams());
+      expect(result.current.page).toBe(3);
+
+      act(() => result.current.setSeverity('warning'));
+
+      expect(push).toHaveBeenCalledTimes(1);
+      expect(push).toHaveBeenCalledWith('/alerts?severity=warning', { scroll: false });
+      const query = lastPushedQuery();
+      expect(query.has('page')).toBe(false);
+    });
+
+    it('should preserve an already-selected severity when status changes, dropping page 3 to 1', () => {
+      navigateTo('severity=critical&page=3');
+      const { result } = renderHook(() => useAlertFilterParams());
+
+      act(() => result.current.setStatus('acknowledged'));
+
+      expect(push).toHaveBeenCalledWith('/alerts?status=acknowledged&severity=critical', {
+        scroll: false,
+      });
+    });
+  });
+
+  describe('initialFilters seeding', () => {
+    it('should seed status from initialFilters when the URL does not specify one', () => {
+      const { result } = renderHook(() => useAlertFilterParams({ status: 'firing' }));
+
+      expect(result.current.status).toBe('firing');
+    });
+
+    it('should let an explicit URL parameter win over initialFilters', () => {
+      navigateTo('status=resolved');
+
+      const { result } = renderHook(() => useAlertFilterParams({ status: 'firing' }));
+
+      expect(result.current.status).toBe('resolved');
+    });
+  });
+});

--- a/__tests__/unit/lib/alerting/evaluate.test.ts
+++ b/__tests__/unit/lib/alerting/evaluate.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Alert Evaluation Tests
+ */
+
+import AlertRuleV2 from '@/models/v2/AlertRuleV2';
+import AlertV2 from '@/models/v2/AlertV2';
+import { evaluateReadings, extractWriteErrors } from '@/lib/alerting/evaluate';
+import { createAlertRuleInput, resetCounters } from '../../../setup/factories';
+import type { EvaluableDevice, EvaluableReading } from '@/lib/alerting/types';
+
+const DEVICE: EvaluableDevice = {
+  _id: 'device_001',
+  type: 'temperature',
+  location: { building_id: 'HQ', floor: 3, room_name: 'Lab A', zone: 'north' },
+  metadata: { tags: ['critical'], department: 'Facilities' },
+} as EvaluableDevice;
+
+function reading(value: number, at: Date, overrides: Partial<EvaluableReading> = {}): EvaluableReading {
+  return {
+    metadata: { device_id: 'device_001', type: 'temperature', unit: 'celsius', source: 'sensor' },
+    timestamp: at,
+    value,
+    quality: { is_valid: true, is_anomaly: false, anomaly_score: 0 },
+    ...overrides,
+  } as EvaluableReading;
+}
+
+async function seedRule(overrides = {}) {
+  return AlertRuleV2.create(
+    createAlertRuleInput({
+      name: 'High temp',
+      metric: 'value',
+      comparison: 'gt',
+      threshold: 30,
+      severity: 'critical',
+      selector: { types: ['temperature'] },
+      cooldown_seconds: 0,
+      ...overrides,
+    })
+  );
+}
+
+describe('extractWriteErrors', () => {
+  it('should normalize an array of write errors', () => {
+    const err = { writeErrors: [{ index: 0, code: 11000 }, { index: 2, code: 121 }] };
+    expect(extractWriteErrors(err)).toEqual([{ index: 0, code: 11000 }, { index: 2, code: 121 }]);
+  });
+
+  it('should normalize a single non-array write error', () => {
+    const err = { writeErrors: { index: 1, code: 11000 } };
+    expect(extractWriteErrors(err)).toEqual([{ index: 1, code: 11000 }]);
+  });
+
+  it('should return an empty array for an unrelated error', () => {
+    expect(extractWriteErrors(new Error('boom'))).toEqual([]);
+  });
+});
+
+describe('evaluateReadings', () => {
+  beforeEach(() => {
+    resetCounters();
+  });
+
+  it('should return an empty result for empty inputs', async () => {
+    const result = await evaluateReadings([], []);
+
+    expect(result.fired).toEqual([]);
+    expect(result.evaluatedPairs).toBe(0);
+  });
+
+  it('should open a firing alert immediately when for_duration_seconds is 0', async () => {
+    const rule = await seedRule();
+
+    const result = await evaluateReadings([reading(35, new Date())], [DEVICE]);
+
+    expect(result.fired).toHaveLength(1);
+    expect(result.fired[0].trigger_value).toBe(35);
+    expect(result.fired[0].rule_name).toBe('High temp');
+
+    const stored = await AlertV2.findOne({ device_id: 'device_001' }).lean();
+    expect(stored!.status).toBe('firing');
+    expect(stored!.is_open).toBe(true);
+    expect(String(stored!.rule_id)).toBe(String(rule._id));
+    expect(stored!.fired_at).toBeInstanceOf(Date);
+  });
+
+  it('should not fire when the reading is within bounds', async () => {
+    await seedRule();
+
+    const result = await evaluateReadings([reading(20, new Date())], [DEVICE]);
+
+    expect(result.fired).toHaveLength(0);
+    expect(await AlertV2.countDocuments({})).toBe(0);
+  });
+
+  it('should open a pending alert when for_duration_seconds is set', async () => {
+    await seedRule({ for_duration_seconds: 300 });
+
+    const result = await evaluateReadings([reading(35, new Date())], [DEVICE]);
+
+    expect(result.fired).toHaveLength(0);
+    expect(result.pendingOpened).toBe(1);
+
+    const stored = await AlertV2.findOne({}).lean();
+    expect(stored!.status).toBe('pending');
+    expect(stored!.fired_at).toBeUndefined();
+  });
+
+  it('should promote pending to firing once the duration elapses', async () => {
+    await seedRule({ for_duration_seconds: 60 });
+    const t0 = new Date('2026-08-01T12:00:00.000Z');
+    const t1 = new Date('2026-08-01T12:02:00.000Z');
+
+    await evaluateReadings([reading(35, t0)], [DEVICE]);
+    const result = await evaluateReadings([reading(36, t1)], [DEVICE]);
+
+    expect(result.fired).toHaveLength(1);
+
+    const stored = await AlertV2.findOne({}).lean();
+    expect(stored!.status).toBe('firing');
+    expect(stored!.last_value).toBe(36);
+    expect(new Date(stored!.breached_since).toISOString()).toBe(t0.toISOString());
+  });
+
+  it('should delete a pending alert when the condition clears first', async () => {
+    await seedRule({ for_duration_seconds: 600 });
+    const t0 = new Date('2026-08-01T12:00:00.000Z');
+    const t1 = new Date('2026-08-01T12:01:00.000Z');
+
+    await evaluateReadings([reading(35, t0)], [DEVICE]);
+    const result = await evaluateReadings([reading(20, t1)], [DEVICE]);
+
+    expect(result.pendingCleared).toBe(1);
+    expect(await AlertV2.countDocuments({})).toBe(0);
+  });
+
+  it('should auto-resolve a firing alert when the condition clears', async () => {
+    await seedRule();
+    const t0 = new Date('2026-08-01T12:00:00.000Z');
+    const t1 = new Date('2026-08-01T12:05:00.000Z');
+
+    await evaluateReadings([reading(35, t0)], [DEVICE]);
+    const result = await evaluateReadings([reading(20, t1)], [DEVICE]);
+
+    expect(result.resolved).toHaveLength(1);
+    expect(result.resolved[0].resolution).toBe('auto');
+    expect(result.resolved[0].actor).toBe('system');
+
+    const stored = await AlertV2.findOne({}).lean();
+    expect(stored!.status).toBe('resolved');
+    expect(stored!.is_open).toBe(false);
+    expect(stored!.resolved_value).toBe(20);
+  });
+
+  it('should not open a second episode while one is already open', async () => {
+    await seedRule();
+
+    await evaluateReadings([reading(35, new Date('2026-08-01T12:00:00.000Z'))], [DEVICE]);
+    const result = await evaluateReadings([reading(40, new Date('2026-08-01T12:01:00.000Z'))], [DEVICE]);
+
+    expect(result.fired).toHaveLength(0);
+    expect(await AlertV2.countDocuments({})).toBe(1);
+
+    const stored = await AlertV2.findOne({}).lean();
+    expect(stored!.last_value).toBe(40);
+    expect(stored!.trigger_value).toBe(35);
+  });
+
+  it('should reduce by breach, not by recency', async () => {
+    // breach -> clear -> breach inside ONE batch yields ONE episode whose
+    // breached_since is the EARLIEST breaching reading.
+    await seedRule();
+    const t0 = new Date('2026-08-01T12:00:00.000Z');
+    const t1 = new Date('2026-08-01T12:01:00.000Z');
+    const t2 = new Date('2026-08-01T12:02:00.000Z');
+
+    const result = await evaluateReadings(
+      [reading(35, t0), reading(20, t1), reading(33, t2)],
+      [DEVICE]
+    );
+
+    expect(result.fired).toHaveLength(1);
+    expect(await AlertV2.countDocuments({})).toBe(1);
+
+    const stored = await AlertV2.findOne({}).lean();
+    expect(new Date(stored!.breached_since).toISOString()).toBe(t0.toISOString());
+    expect(stored!.trigger_value).toBe(35);
+    expect(stored!.last_value).toBe(33);
+    expect(new Date(stored!.last_observed_at).toISOString()).toBe(t2.toISOString());
+  });
+
+  it('should take last_value from the latest reading even when it does not breach', async () => {
+    await seedRule();
+    const t0 = new Date('2026-08-01T12:00:00.000Z');
+    const t1 = new Date('2026-08-01T12:05:00.000Z');
+
+    await evaluateReadings([reading(35, t0), reading(28, t1)], [DEVICE]);
+
+    const stored = await AlertV2.findOne({}).lean();
+    expect(stored!.last_value).toBe(28);
+    expect(stored!.trigger_value).toBe(35);
+  });
+
+  it('should not rewind last_observed_at for an out-of-order batch', async () => {
+    await seedRule();
+    const late = new Date('2026-08-01T12:10:00.000Z');
+    const early = new Date('2026-08-01T12:00:00.000Z');
+
+    await evaluateReadings([reading(35, late)], [DEVICE]);
+    await evaluateReadings([reading(99, early)], [DEVICE]);
+
+    const stored = await AlertV2.findOne({}).lean();
+    expect(new Date(stored!.last_observed_at).toISOString()).toBe(late.toISOString());
+    expect(stored!.last_value).toBe(35);
+  });
+
+  it('should suppress a new episode inside the cooldown window', async () => {
+    await seedRule({ cooldown_seconds: 3600 });
+    const t0 = new Date('2026-08-01T12:00:00.000Z');
+    const t1 = new Date('2026-08-01T12:01:00.000Z');
+    const t2 = new Date('2026-08-01T12:02:00.000Z');
+
+    await evaluateReadings([reading(35, t0)], [DEVICE]);
+    await evaluateReadings([reading(20, t1)], [DEVICE]); // auto-resolves
+    const result = await evaluateReadings([reading(35, t2)], [DEVICE]);
+
+    expect(result.fired).toHaveLength(0);
+    expect(result.suppressed).toBe(1);
+    expect(await AlertV2.countDocuments({ is_open: true })).toBe(0);
+  });
+
+  it('should skip readings whose metric field is absent', async () => {
+    await seedRule({ metric: 'battery_level', comparison: 'lt', threshold: 20, selector: {} });
+
+    const result = await evaluateReadings([reading(35, new Date())], [DEVICE]);
+
+    expect(result.fired).toHaveLength(0);
+    expect(result.evaluatedPairs).toBe(0);
+  });
+
+  it('should fire on anomaly_score', async () => {
+    await seedRule({ metric: 'anomaly_score', comparison: 'gte', threshold: 0.8, selector: {} });
+
+    const result = await evaluateReadings(
+      [reading(22, new Date(), { quality: { is_valid: true, is_anomaly: true, anomaly_score: 0.9 } } as Partial<EvaluableReading>)],
+      [DEVICE]
+    );
+
+    expect(result.fired).toHaveLength(1);
+  });
+
+  it('should skip a reading whose device was not supplied', async () => {
+    await seedRule();
+
+    const orphan = reading(35, new Date());
+    (orphan.metadata as { device_id: string }).device_id = 'device_999';
+
+    const result = await evaluateReadings([orphan], [DEVICE]);
+
+    expect(result.evaluatedPairs).toBe(0);
+  });
+
+  it('should not match a device outside the selector', async () => {
+    await seedRule({ selector: { types: ['temperature'], building_id: 'Warehouse' } });
+
+    const result = await evaluateReadings([reading(35, new Date())], [DEVICE]);
+
+    expect(result.fired).toHaveLength(0);
+  });
+
+  it('should rethrow a non-11000 bulk write error', async () => {
+    await seedRule();
+    const spy = jest.spyOn(AlertV2, 'bulkWrite').mockRejectedValueOnce(
+      Object.assign(new Error('validation failed'), {
+        writeErrors: [{ index: 0, code: 121 }],
+      })
+    );
+
+    await expect(evaluateReadings([reading(35, new Date())], [DEVICE])).rejects.toThrow(
+      'validation failed'
+    );
+
+    spy.mockRestore();
+  });
+
+  it('should absorb an 11000 duplicate and drop its notification', async () => {
+    await seedRule();
+    const spy = jest.spyOn(AlertV2, 'bulkWrite').mockRejectedValueOnce(
+      Object.assign(new Error('E11000 duplicate key'), {
+        writeErrors: [{ index: 0, code: 11000 }],
+      })
+    );
+
+    const result = await evaluateReadings([reading(35, new Date())], [DEVICE]);
+
+    expect(result.fired).toHaveLength(0); // the other request won the race
+
+    spy.mockRestore();
+  });
+
+  it('should handle a fleet-wide rule across many devices in one write', async () => {
+    await seedRule({ selector: { types: ['temperature'] } });
+    const devices = Array.from({ length: 20 }, (_, i) => ({
+      ...DEVICE,
+      _id: `device_${String(i).padStart(3, '0')}`,
+    })) as EvaluableDevice[];
+    const now = new Date();
+    const readings = devices.map(d => {
+      const r = reading(35, now);
+      (r.metadata as { device_id: string }).device_id = String(d._id);
+      return r;
+    });
+
+    const bulkSpy = jest.spyOn(AlertV2, 'bulkWrite');
+    const result = await evaluateReadings(readings, devices);
+
+    expect(result.fired).toHaveLength(20);
+    expect(bulkSpy).toHaveBeenCalledTimes(1);
+
+    bulkSpy.mockRestore();
+  });
+});

--- a/__tests__/unit/lib/alerting/evaluate.test.ts
+++ b/__tests__/unit/lib/alerting/evaluate.test.ts
@@ -529,6 +529,71 @@ describe('evaluateReadings', () => {
     bulkWriteSpy.mockRestore();
   });
 
+  it('should not confirm a promotion via audit.updated_at alone when a concurrent write shares only that stamp', async () => {
+    await seedRule({ for_duration_seconds: 60 });
+    const t0 = new Date('2026-08-01T12:00:00.000Z');
+    const t1 = new Date('2026-08-01T12:02:00.000Z');
+
+    await evaluateReadings([reading(35, t0)], [DEVICE]);
+    const pending = await AlertV2.findOne({}).lean();
+
+    // Freeze the clock so THIS run's internal `now` (used for both its own
+    // $set write and the Step 8 reconciliation query) is a value the test
+    // knows in advance — without that, a same-millisecond collision cannot
+    // be expressed deterministically, since `new Date()` would otherwise
+    // return real wall-clock time that the test cannot predict. Only `Date`
+    // is faked (see doNotFake) so the real mongodb-memory-server connection's
+    // own timers are untouched.
+    const now = new Date('2026-08-01T12:02:00.500Z');
+    jest.useFakeTimers({
+      doNotFake: [
+        'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval',
+        'setImmediate', 'clearImmediate', 'nextTick', 'hrtime', 'performance',
+        'queueMicrotask',
+      ],
+    });
+    jest.setSystemTime(now);
+
+    try {
+      // A concurrent writer promotes the SAME episode with ITS OWN fired_at
+      // timestamp (raceStamp, deliberately different from `now`), but its
+      // write also happens to stamp audit.updated_at to exactly `now` — as a
+      // genuinely concurrent evaluator's own `now` landing in the same
+      // millisecond would. Under the OLD predicate (`audit.updated_at: now`
+      // alone), that alone was enough to confirm THIS run's promotion
+      // notification, even though this run's own guarded updateOne (below,
+      // via the real bulkWrite) never matches anything — status is no
+      // longer 'pending' by the time it runs.
+      const raceStamp = new Date('2026-08-01T12:01:45.000Z');
+      const realBulkWrite = AlertV2.bulkWrite.bind(AlertV2);
+      const bulkWriteSpy = jest
+        .spyOn(AlertV2, 'bulkWrite')
+        .mockImplementationOnce(async (writes, options) => {
+          await AlertV2.updateOne(
+            { _id: pending!._id },
+            { $set: { status: 'firing', fired_at: raceStamp, 'audit.updated_at': now } }
+          );
+          return realBulkWrite(writes, options);
+        });
+
+      const result = await evaluateReadings([reading(36, t1)], [DEVICE]);
+
+      // This run's own guarded update matched nothing — the document's
+      // audit.updated_at equals this run's `now` only because the RACER set
+      // it, not because this run's promotion landed. fired_at was never
+      // touched by this run, so the fixed predicate must not confirm it.
+      expect(result.fired).toHaveLength(0);
+      expect(getPrometheusMetrics()).not.toContain('alerts_fired_total{severity="critical"}');
+
+      const stored = await AlertV2.findOne({}).lean();
+      expect(stored!.fired_at!.toISOString()).toBe(raceStamp.toISOString());
+
+      bulkWriteSpy.mockRestore();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('should count pending clears from the deletes that actually landed', async () => {
     await seedRule({ for_duration_seconds: 600 });
     const t0 = new Date('2026-08-01T12:00:00.000Z');

--- a/__tests__/unit/lib/alerting/evaluate.test.ts
+++ b/__tests__/unit/lib/alerting/evaluate.test.ts
@@ -6,6 +6,7 @@ import { Types } from 'mongoose';
 import AlertRuleV2 from '@/models/v2/AlertRuleV2';
 import AlertV2 from '@/models/v2/AlertV2';
 import { evaluateReadings, extractWriteErrors } from '@/lib/alerting/evaluate';
+import * as selectorModule from '@/lib/alerting/selector';
 import { getMetricsSnapshot, getPrometheusMetrics, logger, resetMetrics } from '@/lib/monitoring';
 import { createAlertInput, createAlertRuleInput, resetCounters } from '../../../setup/factories';
 import type { EvaluableDevice, EvaluableReading } from '@/lib/alerting/types';
@@ -594,6 +595,132 @@ describe('evaluateReadings', () => {
     }
   });
 
+  // The resolve-side twin of the promotion test above, and NOT covered by it.
+  //
+  // `fired_at` is written by evaluate.ts and nothing else, so confirming a
+  // promotion on `fired_at: now` is exclusive on its own. `audit.resolved_at`
+  // is different: the staleness sweep (sweep.ts) and AlertV2.resolve() — the
+  // manual PATCH path — both write it too, and ingest (evaluate) vs cron
+  // (sweep), or a human clicking Resolve as a fresh reading lands, are ordinary
+  // concurrency rather than exotic. A collision to the millisecond therefore
+  // lets a run confirm a transition it did not cause, and broadcast it as
+  // `resolution: 'auto'` while the stored document says otherwise. The
+  // predicate additionally matches `audit.resolution: 'auto'`, which this
+  // branch is the only writer of.
+  describe('resolve confirmation is exact, not merely same-instant', () => {
+    /** Open a firing episode, then race a foreign resolution into `now`. */
+    async function raceForeignResolution(
+      now: Date,
+      resolveRacer: (id: Types.ObjectId) => Promise<unknown>
+    ) {
+      await seedRule();
+      const t0 = new Date('2026-08-01T12:00:00.000Z');
+      const t1 = new Date('2026-08-01T12:05:00.000Z');
+
+      await evaluateReadings([reading(35, t0)], [DEVICE]);
+      const firing = await AlertV2.findOne({}).lean();
+
+      // Freeze the clock so THIS run's internal `now` — used for both its own
+      // $set and the Step 8 reconciliation query — is a value the test knows in
+      // advance. A same-millisecond collision cannot be expressed
+      // deterministically otherwise. Only Date is faked, so the real
+      // mongodb-memory-server connection's timers are untouched.
+      jest.useFakeTimers({
+        doNotFake: [
+          'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval',
+          'setImmediate', 'clearImmediate', 'nextTick', 'hrtime', 'performance',
+          'queueMicrotask',
+        ],
+      });
+      jest.setSystemTime(now);
+
+      try {
+        const realBulkWrite = AlertV2.bulkWrite.bind(AlertV2);
+        const bulkWriteSpy = jest
+          .spyOn(AlertV2, 'bulkWrite')
+          .mockImplementationOnce(async (writes, options) => {
+            await resolveRacer(firing!._id);
+            return realBulkWrite(writes, options);
+          });
+
+        const result = await evaluateReadings([reading(20, t1)], [DEVICE]);
+        bulkWriteSpy.mockRestore();
+        return result;
+      } finally {
+        jest.useRealTimers();
+      }
+    }
+
+    it('should not report a sweep resolution landing in the same millisecond as its own', async () => {
+      const now = new Date('2026-08-01T12:05:00.500Z');
+
+      const result = await raceForeignResolution(now, async id => {
+        // Exactly what sweepStaleAlerts' bulk op writes, stamped with the same
+        // `now` this evaluator run will use.
+        await AlertV2.updateOne(
+          { _id: id, is_open: true },
+          {
+            $set: {
+              status: 'resolved',
+              is_open: false,
+              'audit.updated_at': now,
+              'audit.updated_by': 'system',
+              'audit.resolved_at': now,
+              'audit.resolved_by': 'system',
+              'audit.resolution': 'stale',
+            },
+          }
+        );
+      });
+
+      // This run's own guarded resolve op matched nothing — is_open was already
+      // false by the time it ran. audit.resolved_at equals this run's `now` only
+      // because the SWEEP set it.
+      expect(result.resolved).toHaveLength(0);
+      expect(getPrometheusMetrics()).not.toContain('alerts_resolved_total{resolution="auto"}');
+
+      const stored = await AlertV2.findOne({}).lean();
+      expect(stored!.audit.resolution).toBe('stale'); // history is not relabelled
+      expect(stored!.resolved_value).toBeUndefined(); // nothing this run intended landed
+    });
+
+    it('should not report a manual resolution landing in the same millisecond as its own', async () => {
+      const now = new Date('2026-08-01T12:05:00.500Z');
+
+      // The real static the PATCH /alerts/[id] route calls — it stamps its own
+      // `new Date()`, which under the frozen clock is exactly this run's `now`.
+      const result = await raceForeignResolution(now, id =>
+        AlertV2.resolve(String(id), 'human@example.com', 'manual')
+      );
+
+      expect(result.resolved).toHaveLength(0);
+      expect(getPrometheusMetrics()).not.toContain('alerts_resolved_total{resolution="auto"}');
+
+      const stored = await AlertV2.findOne({}).lean();
+      expect(stored!.audit.resolution).toBe('manual');
+      expect(stored!.audit.resolved_by).toBe('human@example.com');
+    });
+
+    // The counter must still move when the evaluator genuinely does resolve the
+    // episode — a predicate tightened until it never matches would pass both
+    // tests above while breaking auto-resolution entirely.
+    it('should still report its own auto-resolve under the same frozen clock', async () => {
+      const now = new Date('2026-08-01T12:05:00.500Z');
+
+      const result = await raceForeignResolution(now, async () => {
+        /* no racer: this run's own resolve op is the only writer */
+      });
+
+      expect(result.resolved).toHaveLength(1);
+      expect(result.resolved[0].resolution).toBe('auto');
+      expect(getPrometheusMetrics()).toContain('alerts_resolved_total{resolution="auto"} 1');
+
+      const stored = await AlertV2.findOne({}).lean();
+      expect(stored!.audit.resolution).toBe('auto');
+      expect(stored!.resolved_value).toBe(20);
+    });
+  });
+
   it('should count pending clears from the deletes that actually landed', async () => {
     await seedRule({ for_duration_seconds: 600 });
     const t0 = new Date('2026-08-01T12:00:00.000Z');
@@ -760,6 +887,14 @@ describe('evaluateReadings', () => {
     findSpy.mockRestore();
   });
 
+  // Two layers, deliberately. `normalizeRule` (rule-cache.ts) now Zod-validates
+  // every cached rule and drops the unusable ones before they are ever bucketed,
+  // so the malformed-DATA cases below are caught there and never reach the loop
+  // — which is why the reason counters still move while `logger.error` no longer
+  // does (rule-cache logs at warn). The evaluator keeps its own boundary for
+  // what validation cannot predict: a rule whose shape is legal but whose
+  // MATCHING throws. Both layers are exercised here; the assertions say which
+  // is which.
   describe('per-rule error boundary', () => {
     it('should skip a rule with an unknown metric and still fire the valid rule', async () => {
       await seedRawRule({ name: 'Bad metric rule', metric: 'not_a_real_metric' });
@@ -787,6 +922,30 @@ describe('evaluateReadings', () => {
       );
     });
 
+    // E5's second named consequence, asserted where it actually bites. A rule
+    // whose `severity` is not in the enum used to survive the cache's cast,
+    // reach the evaluator, and be written into an AlertV2 insert — where it
+    // fails schema validation and takes the batch's integrity with it. The
+    // valid rule alongside it must be entirely unaffected: its episode stored,
+    // its notification emitted, and NO notification emitted for the rule that
+    // never produced a document.
+    it('should not let a rule that cannot be written cost the valid rule its alert', async () => {
+      await seedRawRule({ name: 'Bad severity rule', severity: 'apocalyptic' });
+      await seedRule(); // 'High temp'
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+
+      const result = await evaluateReadings([reading(35, new Date())], [DEVICE]);
+
+      expect(result.fired).toHaveLength(1);
+      expect(result.fired[0].rule_name).toBe('High temp');
+      // The document really landed — `fired` is not just an in-memory list.
+      expect(await AlertV2.countDocuments({ rule_name: 'High temp', is_open: true })).toBe(1);
+      // And nothing else did: no half-written episode for the unusable rule.
+      expect(await AlertV2.countDocuments({})).toBe(1);
+
+      warnSpy.mockRestore();
+    });
+
     it('should count a skipped rule via getMetricsSnapshot()', async () => {
       await seedRawRule({ name: 'Bad metric rule', metric: 'not_a_real_metric' });
 
@@ -799,41 +958,45 @@ describe('evaluateReadings', () => {
       expect(rulesSkipped.unknown_metric).toBe(1);
     });
 
-    it('should log the skipped rule with ruleId, ruleName, metric, and error', async () => {
+    it('should log the skipped rule with its id, name and the failing field', async () => {
       const bad = await seedRawRule({ name: 'Bad metric rule', metric: 'not_a_real_metric' });
-      const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+      // Caught by rule-cache's Zod gate before bucketing, so the signal is a
+      // warn there rather than the evaluator's own error. Asserted on the same
+      // identifying fields either way — the point of the finding is that the
+      // drop is attributable, not which module emits it.
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
 
       await evaluateReadings([reading(35, new Date())], [DEVICE]);
 
-      expect(errorSpy).toHaveBeenCalledWith(
+      expect(warnSpy).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
           ruleId: String(bad._id),
           ruleName: 'Bad metric rule',
-          metric: 'not_a_real_metric',
-          error: expect.any(String),
+          reason: 'unknown_metric',
+          issues: expect.arrayContaining([expect.stringContaining('metric')]),
         })
       );
 
-      errorSpy.mockRestore();
+      warnSpy.mockRestore();
     });
 
-    it('should log and count a fleet-wide bad rule at most once per call, not once per reading', async () => {
-      // A valid metric and a valid (auto-generated) _id, so this rule clears
-      // validateRule and is cached there as GOOD — proving this test exercises
-      // the dedup around the general matching try/catch, not validateRule's own
-      // per-rule cache, which a rule rejected for an unknown metric or a bad id
-      // would never get past in the first place.
-      //
-      // `selector.tags` is a string, not an array: `.every` is not a function on
-      // a string, so matchesSelector throws on every reading, not just the first.
+    // A malformed selector is DATA, so it is now rejected upstream — the rule
+    // never reaches the evaluation loop at all, which is strictly better than
+    // throwing once per reading and catching it. Both halves are asserted: the
+    // rule is gone (no pair evaluated) and the drop is counted once.
+    it('should reject a rule with a malformed selector before it reaches the loop', async () => {
+      // `selector.tags` is a string, not an array — `.every` is not a function
+      // on a string, so this used to throw inside matchesSelector on every
+      // reading.
       await seedRawRule({
         name: 'Bad selector rule',
         selector: { types: ['temperature'], tags: 'not-an-array' },
       });
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
       const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
 
-      await evaluateReadings(
+      const result = await evaluateReadings(
         [
           reading(35, new Date('2026-08-01T12:00:00.000Z')),
           reading(36, new Date('2026-08-01T12:01:00.000Z')),
@@ -842,13 +1005,61 @@ describe('evaluateReadings', () => {
         [DEVICE]
       );
 
-      // Three readings against the bad rule, one bad rule: without the per-call
-      // dedup this would log and count three times, not one.
+      expect(result.evaluatedPairs).toBe(0);
+      expect(errorSpy).not.toHaveBeenCalled(); // nothing threw during matching
+      // Three readings, one bad rule: counted once per load, not once per reading.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(getPrometheusMetrics()).toContain(
+        'alert_rules_skipped_total{reason="unexpected_error"} 1'
+      );
+
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    // The evaluator's OWN boundary, which validation cannot subsume: a rule
+    // whose stored shape is entirely legal but whose matching still throws.
+    // Forced with a spy because — by construction — no legal rule document can
+    // produce this any more, which is exactly why the boundary needs a test
+    // that does not depend on finding one.
+    it('should skip a rule whose matching throws and still fire the valid rule', async () => {
+      // The two rules are told apart by a perfectly legal selector dimension —
+      // NOT by an injected marker field, which the cache's strict selector
+      // schema would (correctly) reject before the evaluator ever saw it.
+      await seedRule({
+        name: 'Explodes on match',
+        selector: { types: ['temperature'], zone: 'explode-zone' },
+      });
+      await seedRule({ name: 'High temp' });
+      const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+      const matchSpy = jest
+        .spyOn(selectorModule, 'matchesSelector')
+        .mockImplementation((_device, sel) => {
+          if (sel?.zone === 'explode-zone')
+            throw new TypeError('selector.tags.every is not a function');
+          return true;
+        });
+
+      const result = await evaluateReadings(
+        [
+          reading(35, new Date('2026-08-01T12:00:00.000Z')),
+          reading(36, new Date('2026-08-01T12:01:00.000Z')),
+          reading(37, new Date('2026-08-01T12:02:00.000Z')),
+        ],
+        [DEVICE]
+      );
+
+      // The good rule is unaffected: one bad rule costs only itself.
+      expect(result.fired).toHaveLength(1);
+      expect(result.fired[0].rule_name).toBe('High temp');
+      // Three readings against the throwing rule, logged and counted ONCE —
+      // the evaluator's per-call dedup.
       expect(errorSpy).toHaveBeenCalledTimes(1);
       expect(getPrometheusMetrics()).toContain(
         'alert_rules_skipped_total{reason="unexpected_error"} 1'
       );
 
+      matchSpy.mockRestore();
       errorSpy.mockRestore();
     });
   });

--- a/__tests__/unit/lib/alerting/evaluate.test.ts
+++ b/__tests__/unit/lib/alerting/evaluate.test.ts
@@ -28,6 +28,20 @@ function reading(value: number, at: Date, overrides: Partial<EvaluableReading> =
   } as EvaluableReading;
 }
 
+/**
+ * A reading whose stored `metadata.type` is NOT a legal reading type.
+ *
+ * The cast is the whole point: `EvaluableReading` will not let this be written
+ * in TypeScript, which is exactly why the situation is a runtime-only one — it
+ * arrives from a seed script, a migration, or a cache entry written before a
+ * schema change, none of which type-check against `ReadingType`.
+ */
+function readingOfType(type: string, value: number, at: Date): EvaluableReading {
+  const r = reading(value, at);
+  (r.metadata as { type: string }).type = type;
+  return r;
+}
+
 /** A reading attributed to a device other than DEVICE. */
 function readingFor(deviceId: string, value: number, at: Date): EvaluableReading {
   const r = reading(value, at);
@@ -1061,6 +1075,69 @@ describe('evaluateReadings', () => {
 
       matchSpy.mockRestore();
       errorSpy.mockRestore();
+    });
+
+    // The RUNTIME half of the missing-reading-type finding. Its compile-time
+    // half already holds: `READING_TYPES` (models/v2/AlertRuleV2.ts) is
+    // exhaustiveness-asserted against `ReadingType`, so a type added to the
+    // union but not to that list is a `tsc` error and every LEGAL type is
+    // guaranteed a bucket. Nothing type-checks a stored document, though — a
+    // seed script, a migration, or a Redis entry written before a schema
+    // change can hand the evaluator a reading whose `metadata.type` is not a
+    // legal reading type at all. That lookup misses, and the old `?? []` made
+    // it mean "no rules apply" instead of "this reading was not evaluated".
+    it('should report a reading whose type has no rule bucket instead of dropping it silently', async () => {
+      await seedRule(); // 'High temp': would have covered a temperature reading
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+
+      const result = await evaluateReadings(
+        [readingOfType('plasma_flux', 35, new Date('2026-08-01T12:00:00.000Z'))],
+        [DEVICE]
+      );
+
+      // The reading really was dropped — that part is unavoidable, there is no
+      // bucket to evaluate it against. What must not happen is dropping it in
+      // silence.
+      expect(result.evaluatedPairs).toBe(0);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ type: 'plasma_flux', deviceId: 'device_001' })
+      );
+      expect(getPrometheusMetrics()).toContain(
+        'alert_rules_skipped_total{reason="unexpected_error"} 1'
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    // The dedup half: without it a bad type on every reading of a
+    // 10,000-reading ingest emits 10,000 identical log lines and inflates the
+    // counter by 10,000, which is how an observable failure becomes an ignored
+    // one. Counted once per call, exactly like the throwing-rule case above.
+    it('should report an unbucketed reading type once per call, not once per reading', async () => {
+      await seedRule();
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+
+      const result = await evaluateReadings(
+        [
+          readingOfType('plasma_flux', 35, new Date('2026-08-01T12:00:00.000Z')),
+          readingOfType('plasma_flux', 36, new Date('2026-08-01T12:01:00.000Z')),
+          readingOfType('plasma_flux', 37, new Date('2026-08-01T12:02:00.000Z')),
+          // A legal reading in the SAME batch still evaluates normally: the
+          // bad type costs only itself, and the skip does not abort the loop.
+          reading(38, new Date('2026-08-01T12:03:00.000Z')),
+        ],
+        [DEVICE]
+      );
+
+      expect(result.fired).toHaveLength(1);
+      expect(result.fired[0].rule_name).toBe('High temp');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(getPrometheusMetrics()).toContain(
+        'alert_rules_skipped_total{reason="unexpected_error"} 1'
+      );
+
+      warnSpy.mockRestore();
     });
   });
 

--- a/__tests__/unit/lib/alerting/evaluate.test.ts
+++ b/__tests__/unit/lib/alerting/evaluate.test.ts
@@ -5,7 +5,7 @@
 import AlertRuleV2 from '@/models/v2/AlertRuleV2';
 import AlertV2 from '@/models/v2/AlertV2';
 import { evaluateReadings, extractWriteErrors } from '@/lib/alerting/evaluate';
-import { getPrometheusMetrics, resetMetrics } from '@/lib/monitoring';
+import { getMetricsSnapshot, getPrometheusMetrics, logger, resetMetrics } from '@/lib/monitoring';
 import { createAlertInput, createAlertRuleInput, resetCounters } from '../../../setup/factories';
 import type { EvaluableDevice, EvaluableReading } from '@/lib/alerting/types';
 
@@ -46,6 +46,32 @@ async function seedRule(overrides = {}) {
       ...overrides,
     })
   );
+}
+
+/**
+ * Insert a rule document straight through the driver, bypassing Mongoose
+ * schema validation. This is how a malformed rule actually reaches the
+ * evaluator: a seed or migration script writing directly, or a Redis cache
+ * entry written before a schema change — a `.lean()` read or a cache hit
+ * hands the evaluator whatever is stored, with no re-validation.
+ */
+async function seedRawRule(overrides: Record<string, unknown> = {}) {
+  const now = new Date();
+  const doc = {
+    name: 'Raw rule',
+    enabled: true,
+    selector: { types: ['temperature'] },
+    metric: 'value',
+    comparison: 'gt',
+    threshold: 30,
+    for_duration_seconds: 0,
+    severity: 'critical',
+    cooldown_seconds: 0,
+    audit: { created_at: now, created_by: 'test', updated_at: now, updated_by: 'test' },
+    ...overrides,
+  };
+  const { insertedId } = await AlertRuleV2.collection.insertOne(doc as never);
+  return { ...doc, _id: insertedId };
 }
 
 describe('extractWriteErrors', () => {
@@ -537,5 +563,98 @@ describe('evaluateReadings', () => {
     expect(bulkSpy).toHaveBeenCalledTimes(1);
 
     bulkSpy.mockRestore();
+  });
+
+  describe('per-rule error boundary', () => {
+    it('should skip a rule with an unknown metric and still fire the valid rule', async () => {
+      await seedRawRule({ name: 'Bad metric rule', metric: 'not_a_real_metric' });
+      await seedRule(); // 'High temp': metric 'value', threshold 30
+
+      const result = await evaluateReadings([reading(35, new Date())], [DEVICE]);
+
+      expect(result.fired).toHaveLength(1);
+      expect(result.fired[0].rule_name).toBe('High temp');
+      expect(getPrometheusMetrics()).toContain(
+        'alert_rules_skipped_total{reason="unknown_metric"} 1'
+      );
+    });
+
+    it('should skip a rule with a non-hex _id and still fire the valid rule', async () => {
+      await seedRawRule({ name: 'Bad id rule', _id: 'not-a-valid-object-id' });
+      await seedRule();
+
+      const result = await evaluateReadings([reading(35, new Date())], [DEVICE]);
+
+      expect(result.fired).toHaveLength(1);
+      expect(result.fired[0].rule_name).toBe('High temp');
+      expect(getPrometheusMetrics()).toContain(
+        'alert_rules_skipped_total{reason="invalid_rule_id"} 1'
+      );
+    });
+
+    it('should count a skipped rule via getMetricsSnapshot()', async () => {
+      await seedRawRule({ name: 'Bad metric rule', metric: 'not_a_real_metric' });
+
+      const result = await evaluateReadings([reading(35, new Date())], [DEVICE]);
+
+      expect(result.evaluatedPairs).toBe(0); // the only rule in play was unusable
+      const snapshot = getMetricsSnapshot();
+      const alerts = snapshot.alerts as Record<string, unknown>;
+      const rulesSkipped = alerts.rulesSkipped as Record<string, number>;
+      expect(rulesSkipped.unknown_metric).toBe(1);
+    });
+
+    it('should log the skipped rule with ruleId, ruleName, metric, and error', async () => {
+      const bad = await seedRawRule({ name: 'Bad metric rule', metric: 'not_a_real_metric' });
+      const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+
+      await evaluateReadings([reading(35, new Date())], [DEVICE]);
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          ruleId: String(bad._id),
+          ruleName: 'Bad metric rule',
+          metric: 'not_a_real_metric',
+          error: expect.any(String),
+        })
+      );
+
+      errorSpy.mockRestore();
+    });
+
+    it('should log and count a fleet-wide bad rule at most once per call, not once per reading', async () => {
+      // A valid metric and a valid (auto-generated) _id, so this rule clears
+      // validateRule and is cached there as GOOD — proving this test exercises
+      // the dedup around the general matching try/catch, not validateRule's own
+      // per-rule cache, which a rule rejected for an unknown metric or a bad id
+      // would never get past in the first place.
+      //
+      // `selector.tags` is a string, not an array: `.every` is not a function on
+      // a string, so matchesSelector throws on every reading, not just the first.
+      await seedRawRule({
+        name: 'Bad selector rule',
+        selector: { types: ['temperature'], tags: 'not-an-array' },
+      });
+      const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+
+      await evaluateReadings(
+        [
+          reading(35, new Date('2026-08-01T12:00:00.000Z')),
+          reading(36, new Date('2026-08-01T12:01:00.000Z')),
+          reading(37, new Date('2026-08-01T12:02:00.000Z')),
+        ],
+        [DEVICE]
+      );
+
+      // Three readings against the bad rule, one bad rule: without the per-call
+      // dedup this would log and count three times, not one.
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(getPrometheusMetrics()).toContain(
+        'alert_rules_skipped_total{reason="unexpected_error"} 1'
+      );
+
+      errorSpy.mockRestore();
+    });
   });
 });

--- a/__tests__/unit/lib/alerting/evaluate.test.ts
+++ b/__tests__/unit/lib/alerting/evaluate.test.ts
@@ -5,7 +5,8 @@
 import AlertRuleV2 from '@/models/v2/AlertRuleV2';
 import AlertV2 from '@/models/v2/AlertV2';
 import { evaluateReadings, extractWriteErrors } from '@/lib/alerting/evaluate';
-import { createAlertRuleInput, resetCounters } from '../../../setup/factories';
+import { getPrometheusMetrics, resetMetrics } from '@/lib/monitoring';
+import { createAlertInput, createAlertRuleInput, resetCounters } from '../../../setup/factories';
 import type { EvaluableDevice, EvaluableReading } from '@/lib/alerting/types';
 
 const DEVICE: EvaluableDevice = {
@@ -23,6 +24,13 @@ function reading(value: number, at: Date, overrides: Partial<EvaluableReading> =
     quality: { is_valid: true, is_anomaly: false, anomaly_score: 0 },
     ...overrides,
   } as EvaluableReading;
+}
+
+/** A reading attributed to a device other than DEVICE. */
+function readingFor(deviceId: string, value: number, at: Date): EvaluableReading {
+  const r = reading(value, at);
+  (r.metadata as { device_id: string }).device_id = deviceId;
+  return r;
 }
 
 async function seedRule(overrides = {}) {
@@ -59,6 +67,7 @@ describe('extractWriteErrors', () => {
 describe('evaluateReadings', () => {
   beforeEach(() => {
     resetCounters();
+    resetMetrics();
   });
 
   it('should return an empty result for empty inputs', async () => {
@@ -316,6 +325,192 @@ describe('evaluateReadings', () => {
     expect(result.fired).toHaveLength(0); // the other request won the race
 
     spy.mockRestore();
+  });
+
+  it('should not report a promotion whose guarded update matched nothing', async () => {
+    await seedRule({ for_duration_seconds: 60 });
+    const t0 = new Date('2026-08-01T12:00:00.000Z');
+    const t1 = new Date('2026-08-01T12:02:00.000Z');
+
+    await evaluateReadings([reading(35, t0)], [DEVICE]);
+    const pending = await AlertV2.findOne({}).lean();
+
+    // A concurrent evaluation promotes the SAME episode between this run's read
+    // and its write, so this run's guarded updateOne (status: 'pending') matches
+    // zero documents — a driver success that must not fire a notification.
+    // Spying on bulkWrite is the only hook with the right timing; promoting
+    // before the call would make this run's own `find` see 'firing' and never
+    // construct the guarded op at all.
+    //
+    // The racing stamps are fixed values, deliberately NOT `new Date()`: the
+    // reconciliation query keys on `audit.updated_at === now`, and a racing
+    // write landing in the same millisecond as this run's `now` would confirm
+    // the notification for the wrong reason.
+    const raceStamp = new Date('2026-08-01T12:01:30.000Z');
+    const realBulkWrite = AlertV2.bulkWrite.bind(AlertV2);
+    const bulkWriteSpy = jest
+      .spyOn(AlertV2, 'bulkWrite')
+      .mockImplementationOnce(async (writes, options) => {
+        await AlertV2.updateOne(
+          { _id: pending!._id },
+          { $set: { status: 'firing', fired_at: raceStamp, 'audit.updated_at': raceStamp } }
+        );
+        return realBulkWrite(writes, options);
+      });
+
+    const result = await evaluateReadings([reading(36, t1)], [DEVICE]);
+
+    expect(result.fired).toHaveLength(0);
+    expect(getPrometheusMetrics()).not.toContain('alerts_fired_total{severity="critical"}');
+
+    // Nothing this run intended reached the document: the other writer's
+    // fired_at stands, and last_value/last_observed_at are still the t0 batch's.
+    const stored = await AlertV2.findOne({}).lean();
+    expect(stored!.fired_at!.toISOString()).toBe(raceStamp.toISOString());
+    expect(stored!.last_value).toBe(35);
+    expect(new Date(stored!.last_observed_at).toISOString()).toBe(t0.toISOString());
+
+    bulkWriteSpy.mockRestore();
+  });
+
+  it('should not report an auto-resolve whose guarded update matched nothing', async () => {
+    await seedRule();
+    const t0 = new Date('2026-08-01T12:00:00.000Z');
+    const t1 = new Date('2026-08-01T12:05:00.000Z');
+
+    await evaluateReadings([reading(35, t0)], [DEVICE]);
+    const firing = await AlertV2.findOne({}).lean();
+
+    // A human resolves the same episode through PATCH /alerts/[id] between this
+    // run's read and its write, so this run's resolve op (is_open: true) matches
+    // zero documents. Fixed stamps for the same reason as the test above.
+    const raceStamp = new Date('2026-08-01T12:03:00.000Z');
+    const realBulkWrite = AlertV2.bulkWrite.bind(AlertV2);
+    const bulkWriteSpy = jest
+      .spyOn(AlertV2, 'bulkWrite')
+      .mockImplementationOnce(async (writes, options) => {
+        await AlertV2.updateOne(
+          { _id: firing!._id },
+          {
+            $set: {
+              status: 'resolved',
+              is_open: false,
+              'audit.updated_at': raceStamp,
+              'audit.resolved_at': raceStamp,
+              'audit.resolved_by': 'human@example.com',
+              'audit.resolution': 'manual',
+            },
+          }
+        );
+        return realBulkWrite(writes, options);
+      });
+
+    const result = await evaluateReadings([reading(20, t1)], [DEVICE]);
+
+    expect(result.resolved).toHaveLength(0);
+    expect(getPrometheusMetrics()).not.toContain('alerts_resolved_total{resolution="auto"}');
+
+    const stored = await AlertV2.findOne({}).lean();
+    expect(stored!.audit.resolution).toBe('manual'); // untouched by the evaluator
+    expect(stored!.resolved_value).toBeUndefined();
+
+    bulkWriteSpy.mockRestore();
+  });
+
+  it('should count pending clears from the deletes that actually landed', async () => {
+    await seedRule({ for_duration_seconds: 600 });
+    const t0 = new Date('2026-08-01T12:00:00.000Z');
+    const t1 = new Date('2026-08-01T12:01:00.000Z');
+    const otherDevice = { ...DEVICE, _id: 'device_002' } as EvaluableDevice;
+
+    await evaluateReadings(
+      [readingFor('device_001', 35, t0), readingFor('device_002', 35, t0)],
+      [DEVICE, otherDevice]
+    );
+    expect(await AlertV2.countDocuments({ status: 'pending' })).toBe(2);
+
+    // Both episodes clear in the next batch, so both are delete candidates. Only
+    // one of them races to 'firing' before the write, and its deleteOne is
+    // guarded on status: 'pending', so only one delete can land.
+    const promoted = await AlertV2.findOne({ device_id: 'device_002' }).lean();
+    const realBulkWrite = AlertV2.bulkWrite.bind(AlertV2);
+    const bulkWriteSpy = jest
+      .spyOn(AlertV2, 'bulkWrite')
+      .mockImplementationOnce(async (writes, options) => {
+        await AlertV2.updateOne({ _id: promoted!._id }, { $set: { status: 'firing' } });
+        return realBulkWrite(writes, options);
+      });
+
+    const result = await evaluateReadings(
+      [readingFor('device_001', 20, t1), readingFor('device_002', 20, t1)],
+      [DEVICE, otherDevice]
+    );
+
+    expect(result.pendingCleared).toBe(1);
+    expect(await AlertV2.countDocuments({})).toBe(1);
+    expect((await AlertV2.findOne({}).lean())!.device_id).toBe('device_002');
+
+    bulkWriteSpy.mockRestore();
+  });
+
+  it('should absorb a real duplicate key error and still count the delete that landed', async () => {
+    await AlertV2.init(); // the partial unique index must exist to produce E11000
+    const rule = await seedRule({ for_duration_seconds: 600 });
+    const t0 = new Date('2026-08-01T12:00:00.000Z');
+    const t1 = new Date('2026-08-01T12:01:00.000Z');
+    const otherDevice = { ...DEVICE, _id: 'device_002' } as EvaluableDevice;
+
+    await evaluateReadings([readingFor('device_001', 35, t0)], [DEVICE]);
+
+    // Another request opens the episode this batch is about to insert for
+    // device_002, so the partial unique index turns the evaluator's insertOne
+    // into a genuine E11000 — while `ordered: false` still lets the deleteOne
+    // for device_001's cleared episode through.
+    const realBulkWrite = AlertV2.bulkWrite.bind(AlertV2);
+    const bulkWriteSpy = jest
+      .spyOn(AlertV2, 'bulkWrite')
+      .mockImplementationOnce(async (writes, options) => {
+        await AlertV2.create(
+          createAlertInput({ rule_id: rule._id, device_id: 'device_002', status: 'pending' })
+        );
+        return realBulkWrite(writes, options);
+      });
+
+    const result = await evaluateReadings(
+      [readingFor('device_001', 20, t1), readingFor('device_002', 35, t1)],
+      [DEVICE, otherDevice]
+    );
+
+    // The duplicate is absorbed, and the delete that ran alongside it is still
+    // counted — the driver reports it on the error rather than on a result.
+    expect(result.pendingCleared).toBe(1);
+    expect(await AlertV2.countDocuments({ device_id: 'device_001' })).toBe(0);
+    expect(await AlertV2.countDocuments({ device_id: 'device_002' })).toBe(1);
+
+    bulkWriteSpy.mockRestore();
+  });
+
+  it('should record evaluation duration when the bulk write throws', async () => {
+    await seedRule();
+    const spy = jest.spyOn(AlertV2, 'bulkWrite').mockRejectedValueOnce(
+      Object.assign(new Error('validation failed'), {
+        writeErrors: [{ index: 0, code: 121 }],
+      })
+    );
+
+    await expect(evaluateReadings([reading(35, new Date())], [DEVICE])).rejects.toThrow(
+      'validation failed'
+    );
+
+    expect(getPrometheusMetrics()).toContain('alert_evaluation_duration_ms_count 1');
+
+    spy.mockRestore();
+  });
+
+  it('should record evaluation duration on the empty-input early return', async () => {
+    await evaluateReadings([], []);
+
+    expect(getPrometheusMetrics()).toContain('alert_evaluation_duration_ms_count 1');
   });
 
   it('should handle a fleet-wide rule across many devices in one write', async () => {

--- a/__tests__/unit/lib/alerting/evaluate.test.ts
+++ b/__tests__/unit/lib/alerting/evaluate.test.ts
@@ -166,6 +166,26 @@ describe('evaluateReadings', () => {
     expect(stored!.trigger_value).toBe(35);
   });
 
+  it('should not re-fire an acknowledged episode, but should keep tracking observations', async () => {
+    await seedRule();
+    const t0 = new Date('2026-08-01T12:00:00.000Z');
+    const t1 = new Date('2026-08-01T12:05:00.000Z'); // later than the acknowledged episode's last_observed_at
+
+    await evaluateReadings([reading(35, t0)], [DEVICE]);
+    const opened = await AlertV2.findOne({}).lean();
+    await AlertV2.acknowledge(String(opened!._id), 'user_test');
+
+    const result = await evaluateReadings([reading(40, t1)], [DEVICE]);
+
+    expect(result.fired).toHaveLength(0);
+
+    const stored = await AlertV2.findOne({}).lean();
+    expect(stored!.status).toBe('acknowledged');
+    expect(stored!.is_open).toBe(true);
+    expect(stored!.fired_at!.toISOString()).toBe(opened!.fired_at!.toISOString());
+    expect(stored!.last_value).toBe(40);
+  });
+
   it('should reduce by breach, not by recency', async () => {
     // breach -> clear -> breach inside ONE batch yields ONE episode whose
     // breached_since is the EARLIEST breaching reading.

--- a/__tests__/unit/lib/alerting/evaluate.test.ts
+++ b/__tests__/unit/lib/alerting/evaluate.test.ts
@@ -85,6 +85,9 @@ describe('evaluateReadings', () => {
     expect(result.fired).toHaveLength(1);
     expect(result.fired[0].trigger_value).toBe(35);
     expect(result.fired[0].rule_name).toBe('High temp');
+    // The counter moves with the notification, not just against it: the race
+    // tests below prove it does not overcount, this proves it still counts.
+    expect(getPrometheusMetrics()).toContain('alerts_fired_total{severity="critical"} 1');
 
     const stored = await AlertV2.findOne({ device_id: 'device_001' }).lean();
     expect(stored!.status).toBe('firing');
@@ -154,6 +157,7 @@ describe('evaluateReadings', () => {
     expect(result.resolved).toHaveLength(1);
     expect(result.resolved[0].resolution).toBe('auto');
     expect(result.resolved[0].actor).toBe('system');
+    expect(getPrometheusMetrics()).toContain('alerts_resolved_total{resolution="auto"} 1');
 
     const stored = await AlertV2.findOne({}).lean();
     expect(stored!.status).toBe('resolved');

--- a/__tests__/unit/lib/alerting/evaluate.test.ts
+++ b/__tests__/unit/lib/alerting/evaluate.test.ts
@@ -144,6 +144,65 @@ describe('evaluateReadings', () => {
     expect(stored!.fired_at).toBeUndefined();
   });
 
+  // `for_duration_seconds` symmetry: a NEW episode (no pending episode already
+  // open) must fire immediately when the batch's OWN breach span already
+  // satisfies the rule's duration, not only when a pending episode already
+  // exists from a prior batch. See the promotion branch below for the mirror
+  // case (a pending episode promoted across two batches).
+  it('should fire immediately when a single batch already spans the full for_duration_seconds', async () => {
+    await seedRule({ for_duration_seconds: 60 });
+    const t0 = new Date('2026-08-01T12:00:00.000Z');
+    const t1 = new Date('2026-08-01T12:02:00.000Z'); // 120s later: twice the required duration
+
+    const before = new Date();
+    const result = await evaluateReadings([reading(35, t0), reading(36, t1)], [DEVICE]);
+    const after = new Date();
+
+    expect(result.fired).toHaveLength(1);
+    expect(result.fired[0].trigger_value).toBe(35); // earliest breaching reading
+
+    const stored = await AlertV2.findOne({}).lean();
+    expect(stored!.status).toBe('firing');
+    expect(stored!.is_open).toBe(true);
+    expect(new Date(stored!.breached_since).toISOString()).toBe(t0.toISOString());
+
+    // fired_at must be the evaluation's wall-clock `now`, not the in-batch t1 —
+    // matching the promotion branch, which also stamps `now`.
+    const firedAtMs = new Date(stored!.fired_at!).getTime();
+    expect(firedAtMs).toBeGreaterThanOrEqual(before.getTime());
+    expect(firedAtMs).toBeLessThanOrEqual(after.getTime());
+  });
+
+  it("should stay pending when a single batch's breach span is shorter than for_duration_seconds", async () => {
+    await seedRule({ for_duration_seconds: 60 });
+    const t0 = new Date('2026-08-01T12:00:00.000Z');
+    const t1 = new Date('2026-08-01T12:00:30.000Z'); // 30s later: half the required duration
+
+    const result = await evaluateReadings([reading(35, t0), reading(36, t1)], [DEVICE]);
+
+    expect(result.fired).toHaveLength(0);
+    expect(result.pendingOpened).toBe(1);
+
+    const stored = await AlertV2.findOne({}).lean();
+    expect(stored!.status).toBe('pending');
+    expect(stored!.fired_at).toBeUndefined();
+    expect(new Date(stored!.breached_since).toISOString()).toBe(t0.toISOString());
+  });
+
+  it('should fire when a single batch spans exactly for_duration_seconds (inclusive boundary)', async () => {
+    await seedRule({ for_duration_seconds: 60 });
+    const t0 = new Date('2026-08-01T12:00:00.000Z');
+    const t1 = new Date('2026-08-01T12:01:00.000Z'); // exactly 60s later: elapsedMs === duration * 1000
+
+    const result = await evaluateReadings([reading(35, t0), reading(36, t1)], [DEVICE]);
+
+    expect(result.fired).toHaveLength(1);
+
+    const stored = await AlertV2.findOne({}).lean();
+    expect(stored!.status).toBe('firing');
+    expect(stored!.fired_at).toBeInstanceOf(Date);
+  });
+
   it('should promote pending to firing once the duration elapses', async () => {
     await seedRule({ for_duration_seconds: 60 });
     const t0 = new Date('2026-08-01T12:00:00.000Z');

--- a/__tests__/unit/lib/alerting/evaluate.test.ts
+++ b/__tests__/unit/lib/alerting/evaluate.test.ts
@@ -2,6 +2,7 @@
  * Alert Evaluation Tests
  */
 
+import { Types } from 'mongoose';
 import AlertRuleV2 from '@/models/v2/AlertRuleV2';
 import AlertV2 from '@/models/v2/AlertV2';
 import { evaluateReadings, extractWriteErrors } from '@/lib/alerting/evaluate';
@@ -229,6 +230,28 @@ describe('evaluateReadings', () => {
 
     expect(result.pendingCleared).toBe(1);
     expect(await AlertV2.countDocuments({})).toBe(0);
+  });
+
+  // The deleteOne for a cleared pending episode (unlike every update op around
+  // it) carries no last_observed_at guard of its own — the ONLY protection on
+  // that path is the out-of-order check earlier in the loop that skips a pair
+  // whose incoming observation is not newer than what is already stored. A
+  // reading that arrives late (e.g. retried, replayed, or reordered in
+  // transit) must not be able to destroy a live pending episode just because
+  // it happens to be non-breaching.
+  it('should not delete a live pending episode when a stale non-breaching reading arrives out of order', async () => {
+    await seedRule({ for_duration_seconds: 600 });
+    const late = new Date('2026-08-01T12:10:00.000Z');
+    const stale = new Date('2026-08-01T12:00:00.000Z'); // earlier than `late`
+
+    await evaluateReadings([reading(35, late)], [DEVICE]); // opens pending, last_observed_at = 12:10
+    const result = await evaluateReadings([reading(20, stale)], [DEVICE]); // stale non-breach, arrives late
+
+    expect(result.pendingCleared).toBe(0);
+    expect(await AlertV2.countDocuments({ status: 'pending' })).toBe(1);
+
+    const stored = await AlertV2.findOne({}).lean();
+    expect(new Date(stored!.last_observed_at).toISOString()).toBe(late.toISOString());
   });
 
   it('should auto-resolve a firing alert when the condition clears', async () => {
@@ -624,6 +647,54 @@ describe('evaluateReadings', () => {
     bulkSpy.mockRestore();
   });
 
+  // The module's central cost claim (evaluate.ts:6-13): the number of AlertV2
+  // round trips does not scale with batch size. Both phases below are FRESH
+  // inserts against disjoint device ids — no existing episode, and
+  // cooldown_seconds: 0 from seedRule()'s defaults — so both take the exact
+  // same query shape: one `find` for openEpisodes, no cooldown lookback (
+  // maxCooldownSeconds stays 0), and no write-confirmation reconciliation
+  // query (insertOne notifications are confirmed via failedIndices, which
+  // costs nothing extra — only a guarded updateOne needs the follow-up
+  // `find`). What is asserted is that the two counts are EQUAL to each
+  // other, not that either equals some specific number: the post-Task-2
+  // reconciliation query changed the absolute count without breaking the
+  // constant-per-batch-size invariant this test is about.
+  it('should keep the AlertV2.find call count constant regardless of batch size', async () => {
+    await seedRule({ selector: { types: ['temperature'] } });
+
+    const findSpy = jest.spyOn(AlertV2, 'find');
+
+    await evaluateReadings([reading(35, new Date())], [DEVICE]);
+    const smallBatchCalls = findSpy.mock.calls.length;
+    findSpy.mockClear();
+
+    const devices = Array.from({ length: 50 }, (_, i) => ({
+      ...DEVICE,
+      _id: `device_bulk_${String(i).padStart(3, '0')}`,
+    })) as EvaluableDevice[];
+    const now = new Date();
+    const readings: EvaluableReading[] = [];
+    // 10 readings per device (500 total), all breaching, at distinct
+    // timestamps within the batch — exercises the same per-pair reduction as
+    // a real high-volume ingest, not just "50 pairs of 1 reading each".
+    for (const d of devices)
+      for (let j = 0; j < 10; j++) {
+        const r = reading(35 + (j % 5), new Date(now.getTime() + j * 1000));
+        (r.metadata as { device_id: string }).device_id = String(d._id);
+        readings.push(r);
+      }
+    expect(readings).toHaveLength(500);
+
+    const result = await evaluateReadings(readings, devices);
+    const largeBatchCalls = findSpy.mock.calls.length;
+
+    expect(result.fired).toHaveLength(50); // sanity: the batch actually reduced to 50 pairs
+    expect(smallBatchCalls).toBeGreaterThan(0); // sanity: the spy actually observed calls
+    expect(largeBatchCalls).toBe(smallBatchCalls);
+
+    findSpy.mockRestore();
+  });
+
   describe('per-rule error boundary', () => {
     it('should skip a rule with an unknown metric and still fire the valid rule', async () => {
       await seedRawRule({ name: 'Bad metric rule', metric: 'not_a_real_metric' });
@@ -714,6 +785,55 @@ describe('evaluateReadings', () => {
       );
 
       errorSpy.mockRestore();
+    });
+  });
+
+  describe('index-enforced dedup', () => {
+    // evaluate.test.ts's other "should not open a second episode" coverage
+    // (see above) only proves the in-memory `openByPair` map works WITHIN one
+    // call — it is rebuilt fresh on every invocation and cannot see a write a
+    // different, concurrent call has not committed yet. What actually keeps
+    // two INDEPENDENT calls from opening two open episodes for the same
+    // (rule, device) pair is MongoDB's partial unique index
+    // (models/v2/AlertV2.ts) — see rule-cache.ts:24-32 for the failure mode
+    // this guards: a rule_id written as a string rather than an ObjectId
+    // would silently stop colliding with itself under that index.
+    it("should let the partial unique index — not the in-memory map — dedupe two concurrent evaluateReadings calls", async () => {
+      await AlertV2.init(); // the partial unique index must exist to be exercised
+      await seedRule();
+      const t0 = new Date('2026-08-01T12:00:00.000Z');
+
+      // Force the two calls to genuinely race: the "concurrent" call is run
+      // to completion strictly between this run's own `find` (which sees no
+      // existing episode, since neither call has written yet) and its
+      // `bulkWrite` (which is about to insert one). Spying on bulkWrite is
+      // the only hook with that timing — the same technique used throughout
+      // this file for the other read/write races. The nested call's OWN
+      // bulkWrite is NOT intercepted: mockImplementationOnce's queue is
+      // already consumed by THIS invocation, so it falls through to the real
+      // implementation automatically.
+      const realBulkWrite = AlertV2.bulkWrite.bind(AlertV2);
+      const bulkWriteSpy = jest
+        .spyOn(AlertV2, 'bulkWrite')
+        .mockImplementationOnce(async (writes, options) => {
+          const nested = await evaluateReadings([reading(35, t0)], [DEVICE]);
+          expect(nested.fired).toHaveLength(1); // the "other request" that wins the race
+          return realBulkWrite(writes, options);
+        });
+
+      const result = await evaluateReadings([reading(35, t0)], [DEVICE]);
+
+      // The two assertions the brief calls for, checked first so a mutation
+      // that breaks either one is never masked by the supporting checks below.
+      expect(await AlertV2.countDocuments({ is_open: true })).toBe(1);
+      const stored = await AlertV2.findOne({ is_open: true }).lean();
+      expect(stored!.rule_id).toBeInstanceOf(Types.ObjectId);
+
+      // Supporting detail: this run's own insert lost the race (E11000,
+      // absorbed) — its notification must not have landed either.
+      expect(result.fired).toHaveLength(0);
+
+      bulkWriteSpy.mockRestore();
     });
   });
 });

--- a/__tests__/unit/lib/alerting/notify.test.ts
+++ b/__tests__/unit/lib/alerting/notify.test.ts
@@ -74,6 +74,7 @@ describe('buildFiredEnvelope', () => {
 
     expect(envelope).toMatchObject({
       kind: 'storm',
+      of: 'fired',
       count: 25,
       by_severity: { critical: 15, warning: 0, info: 10 },
     });
@@ -93,7 +94,7 @@ describe('buildFiredEnvelope', () => {
       rule_name: 'x'.repeat(2000),
     }));
 
-    expect(buildFiredEnvelope(alerts)!.kind).toBe('storm');
+    expect(buildFiredEnvelope(alerts)).toMatchObject({ kind: 'storm', of: 'fired' });
   });
 });
 
@@ -102,8 +103,8 @@ describe('buildResolvedEnvelope', () => {
     expect(buildResolvedEnvelope([])).toBeNull();
     expect(buildResolvedEnvelope([resolved(1)])!.kind).toBe('resolved');
     expect(
-      buildResolvedEnvelope(Array.from({ length: 25 }, (_, i) => resolved(i)))!.kind
-    ).toBe('storm');
+      buildResolvedEnvelope(Array.from({ length: 25 }, (_, i) => resolved(i)))
+    ).toMatchObject({ kind: 'storm', of: 'resolved' });
   });
 });
 

--- a/__tests__/unit/lib/alerting/notify.test.ts
+++ b/__tests__/unit/lib/alerting/notify.test.ts
@@ -6,6 +6,7 @@ import {
   buildFiredEnvelope,
   buildResolvedEnvelope,
   publishAlertEvents,
+  ALERT_CHANNEL,
   ALERT_EVENT_NAME,
   ALERT_EVENT_MAX,
 } from '@/lib/alerting/notify';
@@ -114,9 +115,18 @@ describe('publishAlertEvents', () => {
 
     expect(pusherServer.trigger).toHaveBeenCalledTimes(2);
     for (const call of (pusherServer.trigger as jest.Mock).mock.calls) {
-      expect(call[0]).toBe('InfraSight');
+      expect(call[0]).toBe(ALERT_CHANNEL);
       expect(call[1]).toBe(ALERT_EVENT_NAME);
     }
+  });
+
+  // Alerts do not share the public readings channel. The `private-` prefix is
+  // what makes pusher-js authorize through /api/pusher/auth before it will
+  // deliver anything; publishing to a public name would put rule names, device
+  // ids and trigger values in reach of anyone holding NEXT_PUBLIC_PUSHER_KEY.
+  it('should publish alerts on a private channel', () => {
+    expect(ALERT_CHANNEL.startsWith('private-')).toBe(true);
+    expect(ALERT_CHANNEL).not.toBe('InfraSight');
   });
 
   it('should send nothing when both lists are empty', async () => {

--- a/__tests__/unit/lib/alerting/notify.test.ts
+++ b/__tests__/unit/lib/alerting/notify.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Bounded Pusher Alert Delivery Tests
+ */
+
+import {
+  buildFiredEnvelope,
+  buildResolvedEnvelope,
+  publishAlertEvents,
+  ALERT_EVENT_NAME,
+  ALERT_EVENT_MAX,
+} from '@/lib/alerting/notify';
+import { pusherServer } from '@/lib/pusher';
+import type { FiredAlert, ResolvedAlert } from '@/types/v2/alert.types';
+
+jest.mock('@/lib/pusher', () => ({
+  pusherServer: { trigger: jest.fn().mockResolvedValue(undefined) },
+}));
+
+function fired(i: number, severity: FiredAlert['severity'] = 'warning'): FiredAlert {
+  return {
+    _id: `alert_${i}`,
+    rule_id: 'rule_1',
+    rule_name: 'High temp',
+    device_id: `device_${i}`,
+    severity,
+    metric: 'value',
+    comparison: 'gt',
+    threshold: 30,
+    trigger_value: 35,
+    fired_at: `2026-08-01T12:0${i % 10}:00.000Z`,
+  };
+}
+
+function resolved(i: number): ResolvedAlert {
+  return {
+    _id: `alert_${i}`,
+    rule_id: 'rule_1',
+    device_id: `device_${i}`,
+    severity: 'warning',
+    resolution: 'auto',
+    resolved_at: '2026-08-01T12:30:00.000Z',
+    actor: 'system',
+  };
+}
+
+beforeEach(() => {
+  (pusherServer.trigger as jest.Mock).mockClear();
+});
+
+describe('buildFiredEnvelope', () => {
+  it('should return null for an empty list', () => {
+    expect(buildFiredEnvelope([])).toBeNull();
+  });
+
+  it('should tag a small batch as fired', () => {
+    const envelope = buildFiredEnvelope([fired(1), fired(2)]);
+
+    expect(envelope).toEqual({ kind: 'fired', alerts: [fired(1), fired(2)] });
+  });
+
+  it('should carry exactly ALERT_EVENT_MAX alerts without degrading', () => {
+    const alerts = Array.from({ length: ALERT_EVENT_MAX }, (_, i) => fired(i));
+
+    expect(buildFiredEnvelope(alerts)!.kind).toBe('fired');
+  });
+
+  it('should degrade to a storm above ALERT_EVENT_MAX', () => {
+    const alerts = [
+      ...Array.from({ length: 15 }, (_, i) => fired(i, 'critical')),
+      ...Array.from({ length: 10 }, (_, i) => fired(i + 15, 'info')),
+    ];
+
+    const envelope = buildFiredEnvelope(alerts);
+
+    expect(envelope).toMatchObject({
+      kind: 'storm',
+      count: 25,
+      by_severity: { critical: 15, warning: 0, info: 10 },
+    });
+  });
+
+  it('should set storm.since to the earliest fired_at', () => {
+    const alerts = Array.from({ length: 25 }, (_, i) => fired(i));
+    const envelope = buildFiredEnvelope(alerts) as { since: string };
+
+    expect(envelope.since).toBe('2026-08-01T12:00:00.000Z');
+  });
+
+  it('should degrade to a storm when the measured body exceeds the byte cap', () => {
+    // Under the count cap but over the byte cap: a long rule_name inflates each row.
+    const alerts = Array.from({ length: 10 }, (_, i) => ({
+      ...fired(i),
+      rule_name: 'x'.repeat(2000),
+    }));
+
+    expect(buildFiredEnvelope(alerts)!.kind).toBe('storm');
+  });
+});
+
+describe('buildResolvedEnvelope', () => {
+  it('should apply the same bounds', () => {
+    expect(buildResolvedEnvelope([])).toBeNull();
+    expect(buildResolvedEnvelope([resolved(1)])!.kind).toBe('resolved');
+    expect(
+      buildResolvedEnvelope(Array.from({ length: 25 }, (_, i) => resolved(i)))!.kind
+    ).toBe('storm');
+  });
+});
+
+describe('publishAlertEvents', () => {
+  it('should send both envelopes on the single alert-event name', async () => {
+    await publishAlertEvents([fired(1)], [resolved(2)]);
+
+    expect(pusherServer.trigger).toHaveBeenCalledTimes(2);
+    for (const call of (pusherServer.trigger as jest.Mock).mock.calls) {
+      expect(call[0]).toBe('InfraSight');
+      expect(call[1]).toBe(ALERT_EVENT_NAME);
+    }
+  });
+
+  it('should send nothing when both lists are empty', async () => {
+    await publishAlertEvents([], []);
+
+    expect(pusherServer.trigger).not.toHaveBeenCalled();
+  });
+
+  it('should swallow a Pusher failure', async () => {
+    (pusherServer.trigger as jest.Mock).mockRejectedValueOnce(new Error('pusher down'));
+
+    await expect(publishAlertEvents([fired(1)], [])).resolves.toBeUndefined();
+  });
+});

--- a/__tests__/unit/lib/alerting/rule-cache.test.ts
+++ b/__tests__/unit/lib/alerting/rule-cache.test.ts
@@ -10,6 +10,7 @@ import {
   normalizeRule,
   ALERT_RULE_CACHE_TTL_SECONDS,
 } from '@/lib/alerting/rule-cache';
+import { getMetricsSnapshot, getPrometheusMetrics, logger, resetMetrics } from '@/lib/monitoring';
 import { createAlertRuleInput, resetCounters } from '../../../setup/factories';
 import type { CachedAlertRule } from '@/lib/alerting/types';
 
@@ -35,24 +36,153 @@ function cachedRule(overrides: Partial<CachedAlertRule> = {}): CachedAlertRule {
   } as CachedAlertRule;
 }
 
+/**
+ * Write a rule document straight through the driver, bypassing Mongoose schema
+ * validation. This is how a malformed rule actually reaches the cache: a seed
+ * or migration script writing directly, or a Redis entry written before a
+ * schema change — a `.lean()` read or a cache hit hands whatever is stored
+ * onward with no re-validation.
+ */
+async function seedRawRule(overrides: Record<string, unknown> = {}) {
+  const now = new Date();
+  const doc = {
+    name: 'Raw rule',
+    enabled: true,
+    selector: { types: ['temperature'] },
+    metric: 'value',
+    comparison: 'gt',
+    threshold: 30,
+    for_duration_seconds: 0,
+    severity: 'critical',
+    cooldown_seconds: 0,
+    audit: { created_at: now, created_by: 'test', updated_at: now, updated_by: 'test' },
+    ...overrides,
+  };
+  const { insertedId } = await AlertRuleV2.collection.insertOne(doc as never);
+  return { ...doc, _id: insertedId };
+}
+
 describe('normalizeRule', () => {
+  beforeEach(() => {
+    resetMetrics();
+  });
+
   it('should stringify an ObjectId _id', () => {
     const oid = new Types.ObjectId();
-    const normalized = normalizeRule({ _id: oid, name: 'X' });
+    const normalized = normalizeRule(cachedRule({ _id: oid as unknown as string }));
 
-    expect(normalized._id).toBe(String(oid));
-    expect(typeof normalized._id).toBe('string');
+    expect(normalized!._id).toBe(String(oid));
+    expect(typeof normalized!._id).toBe('string');
   });
 
   it('should leave an already-stringified _id alone (Redis round trip)', () => {
     const id = '507f1f77bcf86cd799439011';
-    expect(normalizeRule({ _id: id, name: 'X' })._id).toBe(id);
+    expect(normalizeRule(cachedRule({ _id: id }))!._id).toBe(id);
+  });
+
+  it('should return the original object, not the schema-stripped parse output', () => {
+    const rule = cachedRule();
+
+    const normalized = normalizeRule(rule)!;
+
+    // `audit` and `enabled` are not in the validation schema (the evaluator
+    // never reads them). Returning `parsed.data` would silently delete them.
+    expect(normalized.audit).toEqual(rule.audit);
+    expect(normalized.enabled).toBe(true);
+  });
+
+  // ------------------------------------------------------------------------
+  // E5: the cached shape is validated, not asserted.
+  //
+  // Each of these used to be waved through by an `as CachedAlertRule` cast. The
+  // two named consequences: a bad `comparison` reached `compare()`'s
+  // `default: return false` and silently never fired, and a bad `severity`
+  // produced a non-E11000 write error that cost the WHOLE evaluation batch.
+  // ------------------------------------------------------------------------
+  describe('validation', () => {
+    // The field list is the contract, so it is enumerated rather than
+    // spot-checked: the pre-fix compensating checks covered 2 of these.
+    it.each([
+      ['_id', 'invalid_rule_id', { _id: 'not-a-hex-object-id' }],
+      ['metric', 'unknown_metric', { metric: 'not_a_metric' }],
+      ['comparison', 'unexpected_error', { comparison: 'approximately' }],
+      ['severity', 'unexpected_error', { severity: 'apocalyptic' }],
+      ['threshold', 'unexpected_error', { threshold: 'thirty' }],
+      ['name', 'unexpected_error', { name: '' }],
+      ['selector', 'unexpected_error', { selector: { types: ['temperature'], tags: 'not-an-array' } }],
+      ['for_duration_seconds', 'unexpected_error', { for_duration_seconds: '300' }],
+      ['cooldown_seconds', 'unexpected_error', { cooldown_seconds: -1 }],
+    ])('should skip a rule with an invalid %s and count it as %s', (_field, reason, bad) => {
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+
+      const result = normalizeRule(cachedRule(bad as Partial<CachedAlertRule>));
+
+      expect(result).toBeNull();
+      const skipped = (getMetricsSnapshot().alerts as Record<string, unknown>)
+        .rulesSkipped as Record<string, number>;
+      expect(skipped[reason as string]).toBe(1);
+
+      // Skipped is not the same as silent — the whole point of the finding.
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      warnSpy.mockRestore();
+    });
+
+    it('should skip a cached entry that is not an object at all', () => {
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+
+      expect(normalizeRule(null)).toBeNull();
+      expect(normalizeRule('a string')).toBeNull();
+      expect(normalizeRule([])).toBeNull();
+
+      expect(warnSpy).toHaveBeenCalledTimes(3);
+      expect(getPrometheusMetrics()).toContain(
+        'alert_rules_skipped_total{reason="unexpected_error"} 3'
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it('should log the rule id, the reason, and the failing field', () => {
+      const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      const id = '507f1f77bcf86cd799439011';
+
+      normalizeRule(cachedRule({ _id: id, name: 'Broken rule', comparison: 'sideways' as never }));
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          ruleId: id,
+          ruleName: 'Broken rule',
+          reason: 'unexpected_error',
+          issues: expect.arrayContaining([expect.stringContaining('comparison')]),
+        })
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it('should accept a rule that omits the optional duration fields', () => {
+      const rule = cachedRule();
+      delete (rule as Partial<CachedAlertRule>).for_duration_seconds;
+      delete (rule as Partial<CachedAlertRule>).cooldown_seconds;
+
+      expect(normalizeRule(rule)).not.toBeNull();
+    });
+
+    it('should accept a fleet-wide rule with no selector at all', () => {
+      const rule = cachedRule({ metric: 'battery_level' });
+      delete (rule as Partial<CachedAlertRule>).selector;
+
+      expect(normalizeRule(rule)).not.toBeNull();
+    });
   });
 });
 
 describe('loadActiveRules', () => {
   beforeEach(() => {
     resetCounters();
+    resetMetrics();
   });
 
   it('should load only enabled, non-deleted rules', async () => {
@@ -81,6 +211,27 @@ describe('loadActiveRules', () => {
 
   it('should use a 60 second TTL', () => {
     expect(ALERT_RULE_CACHE_TTL_SECONDS).toBe(60);
+  });
+
+  // E5's second named consequence, at the level where it actually bites: one
+  // unusable rule must cost only itself. Before the fix a bad `severity`
+  // survived the cast, reached the evaluator's bulk write as a schema
+  // violation, and produced a non-E11000 error that lost the entire batch —
+  // so every OTHER rule's alerts were lost too.
+  it('should drop only the invalid rule and keep the rest of the batch', async () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    await seedRawRule({ name: 'Bad severity', severity: 'apocalyptic' });
+    await seedRawRule({ name: 'Bad comparison', comparison: 'approximately' });
+    await AlertRuleV2.create(createAlertRuleInput({ name: 'Good rule' }));
+
+    const rules = await loadActiveRules();
+
+    expect(rules.map(r => r.name)).toEqual(['Good rule']);
+    expect(getPrometheusMetrics()).toContain(
+      'alert_rules_skipped_total{reason="unexpected_error"} 2'
+    );
+
+    warnSpy.mockRestore();
   });
 });
 

--- a/__tests__/unit/lib/alerting/rule-cache.test.ts
+++ b/__tests__/unit/lib/alerting/rule-cache.test.ts
@@ -261,25 +261,41 @@ describe('buildRuleBuckets', () => {
     expect(byType.get('power')).toHaveLength(1);
   });
 
-  it('should report the longest cooldown across all rules', () => {
-    const buckets = buildRuleBuckets([
-      cachedRule({ cooldown_seconds: 300 }),
-      cachedRule({ cooldown_seconds: 900 }),
-      cachedRule({ cooldown_seconds: 0 }),
-    ]);
-
-    expect(buckets.maxCooldownSeconds).toBe(900);
-  });
-
-  it('should report zero max cooldown when no rule has one', () => {
-    expect(buildRuleBuckets([cachedRule({ cooldown_seconds: 0 })]).maxCooldownSeconds).toBe(0);
-  });
+  // Two tests covering `RuleBuckets.maxCooldownSeconds` used to sit here. That
+  // field has been removed: it had no production consumer, and its doc comment
+  // claimed it "bounds the cooldown lookback" when the lookback is computed
+  // independently — and more narrowly — inside evaluateReadings()
+  // (lib/alerting/evaluate.ts), over only the rules that actually matched a
+  // reading in the batch. Nothing observable was lost with it.
 
   it('should produce empty buckets for an empty rule set', () => {
-    const { byType, ruleCount, maxCooldownSeconds } = buildRuleBuckets([]);
+    const { byType, ruleCount } = buildRuleBuckets([]);
 
     expect(ruleCount).toBe(0);
-    expect(maxCooldownSeconds).toBe(0);
     for (const rules of byType.values()) expect(rules).toHaveLength(0);
+  });
+
+  it('should count and log a rule whose selector names a type with no bucket', () => {
+    resetMetrics();
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => undefined);
+
+    // Reaching this branch requires a rule that got past normalizeRule's
+    // selector validation carrying a type READING_TYPES has no bucket for — a
+    // divergence the compile-time guard on READING_TYPES exists to prevent.
+    // Constructed by hand here precisely because it must not be SILENT if that
+    // guard is ever removed or bypassed: `byType.get(type)?.push(rule)` used to
+    // drop the rule with no error, no metric and no log.
+    const rogue = cachedRule({ selector: { types: ['plasma' as unknown as 'temperature'] } });
+
+    const { byType } = buildRuleBuckets([rogue]);
+
+    for (const rules of byType.values()) expect(rules).toHaveLength(0);
+
+    const skipped = (getMetricsSnapshot().alerts as Record<string, unknown>)
+      .rulesSkipped as Record<string, number>;
+    expect(skipped.unexpected_error).toBe(1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
   });
 });

--- a/__tests__/unit/lib/alerting/rule-cache.test.ts
+++ b/__tests__/unit/lib/alerting/rule-cache.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Alert Rule Cache and Bucketing Tests
+ */
+
+import { Types } from 'mongoose';
+import AlertRuleV2 from '@/models/v2/AlertRuleV2';
+import {
+  loadActiveRules,
+  buildRuleBuckets,
+  normalizeRule,
+  ALERT_RULE_CACHE_TTL_SECONDS,
+} from '@/lib/alerting/rule-cache';
+import { createAlertRuleInput, resetCounters } from '../../../setup/factories';
+import type { CachedAlertRule } from '@/lib/alerting/types';
+
+function cachedRule(overrides: Partial<CachedAlertRule> = {}): CachedAlertRule {
+  return {
+    _id: String(new Types.ObjectId()),
+    name: 'Rule',
+    enabled: true,
+    selector: { types: ['temperature'] },
+    metric: 'value',
+    comparison: 'gt',
+    threshold: 30,
+    for_duration_seconds: 0,
+    severity: 'warning',
+    cooldown_seconds: 300,
+    audit: {
+      created_at: new Date(),
+      created_by: 'test',
+      updated_at: new Date(),
+      updated_by: 'test',
+    },
+    ...overrides,
+  } as CachedAlertRule;
+}
+
+describe('normalizeRule', () => {
+  it('should stringify an ObjectId _id', () => {
+    const oid = new Types.ObjectId();
+    const normalized = normalizeRule({ _id: oid, name: 'X' });
+
+    expect(normalized._id).toBe(String(oid));
+    expect(typeof normalized._id).toBe('string');
+  });
+
+  it('should leave an already-stringified _id alone (Redis round trip)', () => {
+    const id = '507f1f77bcf86cd799439011';
+    expect(normalizeRule({ _id: id, name: 'X' })._id).toBe(id);
+  });
+});
+
+describe('loadActiveRules', () => {
+  beforeEach(() => {
+    resetCounters();
+  });
+
+  it('should load only enabled, non-deleted rules', async () => {
+    await AlertRuleV2.create(createAlertRuleInput({ name: 'Enabled' }));
+    await AlertRuleV2.create(createAlertRuleInput({ name: 'Disabled', enabled: false }));
+    const deleted = await AlertRuleV2.create(createAlertRuleInput({ name: 'Deleted' }));
+    await AlertRuleV2.softDelete(String(deleted._id), 'admin');
+
+    const rules = await loadActiveRules();
+
+    expect(rules).toHaveLength(1);
+    expect(rules[0].name).toBe('Enabled');
+  });
+
+  it('should return _id as a string on the fresh path', async () => {
+    await AlertRuleV2.create(createAlertRuleInput());
+
+    const rules = await loadActiveRules();
+
+    expect(typeof rules[0]._id).toBe('string');
+  });
+
+  it('should return an empty array when no rules exist', async () => {
+    expect(await loadActiveRules()).toEqual([]);
+  });
+
+  it('should use a 60 second TTL', () => {
+    expect(ALERT_RULE_CACHE_TTL_SECONDS).toBe(60);
+  });
+});
+
+describe('buildRuleBuckets', () => {
+  it('should bucket a typed rule into exactly its own types', () => {
+    const rule = cachedRule({ selector: { types: ['temperature', 'humidity'] } });
+
+    const { byType } = buildRuleBuckets([rule]);
+
+    expect(byType.get('temperature')).toHaveLength(1);
+    expect(byType.get('humidity')).toHaveLength(1);
+    expect(byType.get('power')).toHaveLength(0);
+  });
+
+  it('should append a type-less rule to every bucket', () => {
+    const fleetWide = cachedRule({ metric: 'battery_level', selector: {} });
+
+    const { byType } = buildRuleBuckets([fleetWide]);
+
+    expect(byType.size).toBe(15);
+    for (const rules of byType.values()) expect(rules).toHaveLength(1);
+  });
+
+  it('should treat an empty types array the same as absent', () => {
+    const { byType } = buildRuleBuckets([cachedRule({ selector: { types: [] } })]);
+
+    expect(byType.get('power')).toHaveLength(1);
+  });
+
+  it('should report the longest cooldown across all rules', () => {
+    const buckets = buildRuleBuckets([
+      cachedRule({ cooldown_seconds: 300 }),
+      cachedRule({ cooldown_seconds: 900 }),
+      cachedRule({ cooldown_seconds: 0 }),
+    ]);
+
+    expect(buckets.maxCooldownSeconds).toBe(900);
+  });
+
+  it('should report zero max cooldown when no rule has one', () => {
+    expect(buildRuleBuckets([cachedRule({ cooldown_seconds: 0 })]).maxCooldownSeconds).toBe(0);
+  });
+
+  it('should produce empty buckets for an empty rule set', () => {
+    const { byType, ruleCount, maxCooldownSeconds } = buildRuleBuckets([]);
+
+    expect(ruleCount).toBe(0);
+    expect(maxCooldownSeconds).toBe(0);
+    for (const rules of byType.values()) expect(rules).toHaveLength(0);
+  });
+});

--- a/__tests__/unit/lib/alerting/selector.test.ts
+++ b/__tests__/unit/lib/alerting/selector.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Alert Selector and Metric Accessor Tests
+ */
+
+import { matchesSelector, compare, METRIC_ACCESSORS } from '@/lib/alerting/selector';
+import type { EvaluableDevice, EvaluableReading } from '@/lib/alerting/types';
+
+function device(overrides: Partial<EvaluableDevice> = {}): EvaluableDevice {
+  return {
+    _id: 'device_001',
+    type: 'temperature',
+    location: { building_id: 'HQ', floor: 3, room_name: 'Lab A', zone: 'north' },
+    metadata: { tags: ['critical', 'hvac'], department: 'Facilities' },
+    ...overrides,
+  } as EvaluableDevice;
+}
+
+describe('matchesSelector', () => {
+  it('should match an empty selector against any device', () => {
+    expect(matchesSelector(device(), {})).toBe(true);
+  });
+
+  it('should match on building_id', () => {
+    expect(matchesSelector(device(), { building_id: 'HQ' })).toBe(true);
+    expect(matchesSelector(device(), { building_id: 'Warehouse' })).toBe(false);
+  });
+
+  it('should match on floor, including floor 0', () => {
+    expect(matchesSelector(device(), { floor: 3 })).toBe(true);
+    expect(matchesSelector(device(), { floor: 4 })).toBe(false);
+    expect(matchesSelector(device({ location: { building_id: 'HQ', floor: 0, room_name: 'Lobby' } }), { floor: 0 })).toBe(true);
+  });
+
+  it('should match on zone', () => {
+    expect(matchesSelector(device(), { zone: 'north' })).toBe(true);
+    expect(matchesSelector(device(), { zone: 'south' })).toBe(false);
+  });
+
+  it('should require ALL listed tags, not any', () => {
+    expect(matchesSelector(device(), { tags: ['critical'] })).toBe(true);
+    expect(matchesSelector(device(), { tags: ['critical', 'hvac'] })).toBe(true);
+    expect(matchesSelector(device(), { tags: ['critical', 'rooftop'] })).toBe(false);
+  });
+
+  it('should treat an empty tags array as no constraint', () => {
+    expect(matchesSelector(device(), { tags: [] })).toBe(true);
+  });
+
+  it('should require every present dimension simultaneously', () => {
+    expect(matchesSelector(device(), { building_id: 'HQ', floor: 3, zone: 'north' })).toBe(true);
+    expect(matchesSelector(device(), { building_id: 'HQ', floor: 9, zone: 'north' })).toBe(false);
+  });
+
+  it('should not match a device missing the selected dimension', () => {
+    const noZone = device({ location: { building_id: 'HQ', floor: 3, room_name: 'Lab A' } } as Partial<EvaluableDevice>);
+    expect(matchesSelector(noZone, { zone: 'north' })).toBe(false);
+  });
+
+  it('should tolerate a device with no metadata', () => {
+    const bare = { _id: 'device_002', type: 'power', location: { building_id: 'HQ', floor: 1, room_name: 'X' } } as EvaluableDevice;
+    expect(matchesSelector(bare, {})).toBe(true);
+    expect(matchesSelector(bare, { tags: ['critical'] })).toBe(false);
+  });
+
+  it('should ignore selector.types — the type dimension is handled by rule bucketing', () => {
+    expect(matchesSelector(device(), { types: ['power'] })).toBe(true);
+  });
+});
+
+describe('compare', () => {
+  it.each([
+    ['gt', 31, 30, true],
+    ['gt', 30, 30, false],
+    ['gte', 30, 30, true],
+    ['gte', 29, 30, false],
+    ['lt', 29, 30, true],
+    ['lt', 30, 30, false],
+    ['lte', 30, 30, true],
+    ['lte', 31, 30, false],
+  ] as const)('%s %d vs %d -> %s', (comparison, value, threshold, expected) => {
+    expect(compare(value, comparison, threshold)).toBe(expected);
+  });
+});
+
+describe('METRIC_ACCESSORS', () => {
+  const reading: EvaluableReading = {
+    value: 35,
+    quality: { is_valid: true, is_anomaly: true, anomaly_score: 0.82 },
+    context: { battery_level: 14 },
+  } as EvaluableReading;
+
+  it('should read value', () => {
+    expect(METRIC_ACCESSORS.value(reading)).toBe(35);
+  });
+
+  it('should read anomaly_score', () => {
+    expect(METRIC_ACCESSORS.anomaly_score(reading)).toBe(0.82);
+  });
+
+  it('should read battery_level', () => {
+    expect(METRIC_ACCESSORS.battery_level(reading)).toBe(14);
+  });
+
+  it('should return undefined for an absent field rather than zero', () => {
+    const bare: EvaluableReading = { value: 10 } as EvaluableReading;
+
+    expect(METRIC_ACCESSORS.anomaly_score(bare)).toBeUndefined();
+    expect(METRIC_ACCESSORS.battery_level(bare)).toBeUndefined();
+  });
+
+  it('should distinguish a real zero from an absent field', () => {
+    const zero: EvaluableReading = { value: 0, context: { battery_level: 0 } } as EvaluableReading;
+
+    expect(METRIC_ACCESSORS.value(zero)).toBe(0);
+    expect(METRIC_ACCESSORS.battery_level(zero)).toBe(0);
+  });
+});

--- a/__tests__/unit/lib/alerting/sentry-escalation.test.ts
+++ b/__tests__/unit/lib/alerting/sentry-escalation.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Alerting -> Sentry escalation.
+ *
+ * `safeEvaluateReadings` / `safeSweepStaleAlerts` swallow evaluator failures by
+ * design so an alerting fault can never drop a committed reading. That makes
+ * the escalation in `reportToSentry()` the only thing standing between a
+ * silently broken evaluator and nobody finding out: the response stays 2xx, the
+ * log line is a console write, and the `evaluation_error` counter is
+ * per-process memory behind an admin-gated, off-by-default metrics endpoint.
+ *
+ * These tests therefore assert against the REAL `@sentry/nextjs` client (mocked
+ * here, but it is the same module singleton `instrumentation.ts` initializes in
+ * production), never against state private to `lib/monitoring/sentry.ts`, and
+ * they never call `initSentry()`. Production does not call it; a test that does
+ * is how this escalation shipped as dead code in the first place.
+ */
+
+import * as SentryClient from '@sentry/nextjs';
+import { logger } from '@/lib/monitoring';
+import { safeEvaluateReadings, safeSweepStaleAlerts } from '@/lib/alerting';
+import { evaluateReadings } from '@/lib/alerting/evaluate';
+import { sweepStaleAlerts } from '@/lib/alerting/sweep';
+import { publishAlertEvents } from '@/lib/alerting/notify';
+import {
+  emptyEvaluationResult,
+  type EvaluableDevice,
+  type EvaluableReading,
+} from '@/lib/alerting/types';
+
+jest.mock('@sentry/nextjs', () => ({
+  init: jest.fn(),
+  captureException: jest.fn().mockReturnValue('alerting-event-id'),
+  captureMessage: jest.fn(),
+  addBreadcrumb: jest.fn(),
+  setUser: jest.fn(),
+  setTag: jest.fn(),
+  setExtra: jest.fn(),
+  startInactiveSpan: jest.fn().mockReturnValue({ end: jest.fn() }),
+}));
+
+// The units under test are the `safe*` wrappers, so the work they wrap is
+// stubbed: what matters is what happens to a throw, not what threw. Each mock
+// spreads the real module and replaces exactly one function, so the barrel's
+// re-exports keep working and adding an export to any of these modules cannot
+// quietly turn it into `undefined` here.
+jest.mock('@/lib/alerting/evaluate', () => ({
+  ...jest.requireActual('@/lib/alerting/evaluate'),
+  evaluateReadings: jest.fn(),
+}));
+
+jest.mock('@/lib/alerting/sweep', () => ({
+  ...jest.requireActual('@/lib/alerting/sweep'),
+  sweepStaleAlerts: jest.fn(),
+}));
+
+jest.mock('@/lib/alerting/notify', () => ({
+  ...jest.requireActual('@/lib/alerting/notify'),
+  publishAlertEvents: jest.fn(),
+}));
+
+const sentry = SentryClient as unknown as {
+  init: jest.Mock;
+  captureException: jest.Mock;
+};
+const mockEvaluateReadings = evaluateReadings as jest.Mock;
+const mockSweepStaleAlerts = sweepStaleAlerts as jest.Mock;
+const mockPublishAlertEvents = publishAlertEvents as jest.Mock;
+
+const DSN = 'https://key@sentry.io/project';
+
+const READINGS = [
+  {
+    metadata: { device_id: 'device_001', type: 'temperature', unit: 'celsius', source: 'sensor' },
+    timestamp: new Date(),
+    value: 42,
+  },
+] as EvaluableReading[];
+
+const DEVICES = [{ _id: 'device_001', type: 'temperature' }] as EvaluableDevice[];
+
+describe('alerting -> Sentry escalation', () => {
+  const originalEnv = process.env;
+  let loggerError: jest.SpyInstance;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    process.env.SENTRY_DSN = DSN;
+
+    sentry.captureException.mockReturnValue('alerting-event-id');
+    mockPublishAlertEvents.mockResolvedValue(undefined);
+    // The wrappers log every swallowed failure; keep the suite output readable
+    // without weakening the Sentry assertions.
+    loggerError = jest.spyOn(logger, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    loggerError.mockRestore();
+    process.env = originalEnv;
+  });
+
+  describe('safeEvaluateReadings()', () => {
+    it('escalates a swallowed evaluator failure to the real Sentry client, tagged subsystem=alerting', async () => {
+      const boom = new Error('evaluator exploded');
+      mockEvaluateReadings.mockRejectedValue(boom);
+
+      const result = await safeEvaluateReadings(READINGS, DEVICES);
+
+      // Nothing in this test — or in production — initializes Sentry through
+      // the lib/monitoring shim. If the escalation only fires after
+      // initSentry(), it does not fire in production, and this assertion is
+      // what keeps that from passing unnoticed.
+      expect(sentry.init).not.toHaveBeenCalled();
+      expect(sentry.captureException).toHaveBeenCalledTimes(1);
+      expect(sentry.captureException).toHaveBeenCalledWith(boom, {
+        extra: undefined,
+        tags: { subsystem: 'alerting' },
+      });
+
+      // And the isolation contract still holds: swallowed, not rethrown.
+      expect(result).toEqual(emptyEvaluationResult());
+      expect(loggerError).toHaveBeenCalled();
+    });
+
+    it('sends subsystem as an indexed tag, not as Additional Data', async () => {
+      mockEvaluateReadings.mockRejectedValue(new Error('evaluator exploded'));
+
+      await safeEvaluateReadings(READINGS, DEVICES);
+
+      const [, options] = sentry.captureException.mock.calls[0];
+      // Sentry only indexes a top-level `tags` key as a filterable facet.
+      // Folded into `extra` it becomes unsearchable Additional Data and stops
+      // working as a triage classifier — silently, which is the whole problem.
+      expect(options.tags).toEqual({ subsystem: 'alerting' });
+      expect(options).not.toHaveProperty('extra.tags');
+    });
+
+    it('escalates a broadcast failure that follows a committed evaluation', async () => {
+      const committed = { ...emptyEvaluationResult(), evaluatedPairs: 3 };
+      mockEvaluateReadings.mockResolvedValue(committed);
+      const broadcastFailure = new Error('pusher unavailable');
+      mockPublishAlertEvents.mockRejectedValue(broadcastFailure);
+
+      const result = await safeEvaluateReadings(READINGS, DEVICES);
+
+      expect(sentry.captureException).toHaveBeenCalledWith(broadcastFailure, {
+        extra: undefined,
+        tags: { subsystem: 'alerting' },
+      });
+      // The DB write already committed; a broadcast fault must not discard it.
+      expect(result).toBe(committed);
+    });
+
+    it('does not escalate when the evaluation succeeds', async () => {
+      mockEvaluateReadings.mockResolvedValue(emptyEvaluationResult());
+
+      await safeEvaluateReadings(READINGS, DEVICES);
+
+      expect(sentry.captureException).not.toHaveBeenCalled();
+    });
+
+    it('wraps a non-Error throw so Sentry still receives an Error', async () => {
+      mockEvaluateReadings.mockRejectedValue('a bare string');
+
+      await safeEvaluateReadings(READINGS, DEVICES);
+
+      const [captured, options] = sentry.captureException.mock.calls[0];
+      expect(captured).toBeInstanceOf(Error);
+      expect((captured as Error).message).toBe('a bare string');
+      expect(options.tags).toEqual({ subsystem: 'alerting' });
+    });
+
+    it('stays a no-op when no DSN is configured, without breaking the swallow', async () => {
+      delete process.env.SENTRY_DSN;
+      mockEvaluateReadings.mockRejectedValue(new Error('evaluator exploded'));
+
+      const result = await safeEvaluateReadings(READINGS, DEVICES);
+
+      expect(sentry.captureException).not.toHaveBeenCalled();
+      expect(result).toEqual(emptyEvaluationResult());
+    });
+
+    it('survives a Sentry client that throws — escalation must never unswallow the error', async () => {
+      mockEvaluateReadings.mockRejectedValue(new Error('evaluator exploded'));
+      sentry.captureException.mockImplementation(() => {
+        throw new Error('sentry transport is down');
+      });
+
+      // A misbehaving SDK must not turn an already-handled evaluator error into
+      // an unhandled one and defeat the isolation these wrappers exist for.
+      await expect(safeEvaluateReadings(READINGS, DEVICES)).resolves.toEqual(
+        emptyEvaluationResult()
+      );
+    });
+  });
+
+  describe('safeSweepStaleAlerts()', () => {
+    it('escalates a swallowed sweep failure with the same subsystem tag', async () => {
+      const boom = new Error('sweep exploded');
+      mockSweepStaleAlerts.mockRejectedValue(boom);
+
+      const result = await safeSweepStaleAlerts(new Set(['device_001']));
+
+      expect(sentry.init).not.toHaveBeenCalled();
+      expect(sentry.captureException).toHaveBeenCalledWith(boom, {
+        extra: undefined,
+        tags: { subsystem: 'alerting' },
+      });
+      expect(result).toEqual({ deleted: 0, resolved: [] });
+    });
+
+    it('escalates a broadcast failure that follows a committed sweep', async () => {
+      const committed = { deleted: 2, resolved: [] };
+      mockSweepStaleAlerts.mockResolvedValue(committed);
+      const broadcastFailure = new Error('pusher unavailable');
+      mockPublishAlertEvents.mockRejectedValue(broadcastFailure);
+
+      const result = await safeSweepStaleAlerts(new Set(['device_001']));
+
+      expect(sentry.captureException).toHaveBeenCalledWith(broadcastFailure, {
+        extra: undefined,
+        tags: { subsystem: 'alerting' },
+      });
+      expect(result).toBe(committed);
+    });
+  });
+});

--- a/__tests__/unit/lib/alerting/sweep.test.ts
+++ b/__tests__/unit/lib/alerting/sweep.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Staleness Sweep Tests
+ */
+
+import AlertV2 from '@/models/v2/AlertV2';
+import { sweepStaleAlerts, STALE_AFTER_SECONDS } from '@/lib/alerting/sweep';
+import { safeEvaluateReadings, safeSweepStaleAlerts } from '@/lib/alerting';
+import { createAlertInput, resetCounters } from '../../../setup/factories';
+
+function minutesAgo(n: number): Date {
+  return new Date(Date.now() - n * 60 * 1000);
+}
+
+describe('STALE_AFTER_SECONDS', () => {
+  it('should default to 30 minutes', () => {
+    expect(STALE_AFTER_SECONDS).toBe(1800);
+  });
+});
+
+describe('sweepStaleAlerts', () => {
+  beforeEach(() => {
+    resetCounters();
+  });
+
+  it('should do nothing when there are no open alerts', async () => {
+    const result = await sweepStaleAlerts(new Set(['device_001']));
+
+    expect(result.deleted).toBe(0);
+    expect(result.resolved).toEqual([]);
+  });
+
+  it('should leave a fresh alert on a reporting device alone', async () => {
+    await AlertV2.create(
+      createAlertInput({ device_id: 'device_001', status: 'firing', last_observed_at: minutesAgo(1) })
+    );
+
+    const result = await sweepStaleAlerts(new Set(['device_001']));
+
+    expect(result.resolved).toHaveLength(0);
+    expect((await AlertV2.findOne({}).lean())!.status).toBe('firing');
+  });
+
+  it('should resolve a firing alert whose device stopped reporting', async () => {
+    await AlertV2.create(
+      createAlertInput({ device_id: 'device_gone', status: 'firing', last_observed_at: minutesAgo(1) })
+    );
+
+    const result = await sweepStaleAlerts(new Set(['device_001']));
+
+    expect(result.resolved).toHaveLength(1);
+    expect(result.resolved[0].resolution).toBe('device_inactive');
+
+    const stored = await AlertV2.findOne({}).lean();
+    expect(stored!.status).toBe('resolved');
+    expect(stored!.is_open).toBe(false);
+    expect(stored!.audit.resolution).toBe('device_inactive');
+  });
+
+  it('should resolve a firing alert that has gone stale', async () => {
+    await AlertV2.create(
+      createAlertInput({ device_id: 'device_001', status: 'firing', last_observed_at: minutesAgo(60) })
+    );
+
+    const result = await sweepStaleAlerts(new Set(['device_001']));
+
+    expect(result.resolved).toHaveLength(1);
+    expect(result.resolved[0].resolution).toBe('stale');
+  });
+
+  it('should resolve an acknowledged alert the same way', async () => {
+    await AlertV2.create(
+      createAlertInput({
+        device_id: 'device_001',
+        status: 'acknowledged',
+        last_observed_at: minutesAgo(60),
+      })
+    );
+
+    const result = await sweepStaleAlerts(new Set(['device_001']));
+
+    expect(result.resolved).toHaveLength(1);
+    expect((await AlertV2.findOne({}).lean())!.status).toBe('resolved');
+  });
+
+  it('should DELETE a swept pending alert rather than resolving it', async () => {
+    await AlertV2.create(
+      createAlertInput({ device_id: 'device_001', status: 'pending', last_observed_at: minutesAgo(60) })
+    );
+
+    const result = await sweepStaleAlerts(new Set(['device_001']));
+
+    expect(result.deleted).toBe(1);
+    expect(result.resolved).toHaveLength(0);
+    expect(await AlertV2.countDocuments({})).toBe(0);
+  });
+
+  it('should never touch an already-resolved alert', async () => {
+    await AlertV2.create(
+      createAlertInput({
+        device_id: 'device_gone',
+        status: 'resolved',
+        is_open: false,
+        last_observed_at: minutesAgo(600),
+      })
+    );
+
+    const result = await sweepStaleAlerts(new Set(['device_001']));
+
+    expect(result.deleted).toBe(0);
+    expect(result.resolved).toHaveLength(0);
+  });
+
+  it('should prefer device_inactive over stale when both apply', async () => {
+    await AlertV2.create(
+      createAlertInput({ device_id: 'device_gone', status: 'firing', last_observed_at: minutesAgo(600) })
+    );
+
+    const result = await sweepStaleAlerts(new Set(['device_001']));
+
+    expect(result.resolved[0].resolution).toBe('device_inactive');
+  });
+});
+
+describe('safe wrappers', () => {
+  it('should swallow an evaluation error and return an empty result', async () => {
+    const spy = jest.spyOn(AlertV2, 'find').mockImplementationOnce(() => {
+      throw new Error('database exploded');
+    });
+
+    const result = await safeEvaluateReadings(
+      [{ metadata: { device_id: 'device_001', type: 'temperature', unit: 'celsius', source: 'sensor' }, timestamp: new Date(), value: 1 }] as never,
+      [{ _id: 'device_001', type: 'temperature', location: { building_id: 'HQ', floor: 1, room_name: 'X' }, metadata: { tags: [], department: 'x' } }] as never
+    );
+
+    expect(result.fired).toEqual([]);
+    spy.mockRestore();
+  });
+
+  it('should swallow a sweep error', async () => {
+    const spy = jest.spyOn(AlertV2, 'find').mockImplementationOnce(() => {
+      throw new Error('database exploded');
+    });
+
+    const result = await safeSweepStaleAlerts(new Set(['device_001']));
+
+    expect(result).toEqual({ deleted: 0, resolved: [] });
+    spy.mockRestore();
+  });
+});

--- a/__tests__/unit/lib/alerting/sweep.test.ts
+++ b/__tests__/unit/lib/alerting/sweep.test.ts
@@ -58,6 +58,26 @@ describe('sweepStaleAlerts', () => {
     expect(stored!.audit.resolution).toBe('device_inactive');
   });
 
+  // sweep.ts has its own recordAlert('resolved', ...) call site, independent
+  // of evaluate.ts's — evaluate.test.ts asserting alerts_resolved_total on an
+  // auto-resolve does not exercise this one. Nothing elsewhere in the suite
+  // checks that a SWEEP resolve moves the counter, so deleting this call site
+  // alone would break zero tests.
+  it('should increment alerts_resolved_total on a real sweep resolve', async () => {
+    monitoring.resetMetrics();
+    await AlertV2.create(
+      createAlertInput({ device_id: 'device_gone', status: 'firing', last_observed_at: minutesAgo(1) })
+    );
+
+    const result = await sweepStaleAlerts(new Set(['device_001']));
+
+    expect(result.resolved).toHaveLength(1);
+    const snapshot = monitoring.getMetricsSnapshot();
+    const alerts = snapshot.alerts as Record<string, unknown>;
+    const resolvedCounts = alerts.resolved as Record<string, number>;
+    expect(resolvedCounts.device_inactive).toBe(1);
+  });
+
   it('should resolve a firing alert that has gone stale', async () => {
     await AlertV2.create(
       createAlertInput({ device_id: 'device_001', status: 'firing', last_observed_at: minutesAgo(60) })

--- a/__tests__/unit/lib/alerting/sweep.test.ts
+++ b/__tests__/unit/lib/alerting/sweep.test.ts
@@ -3,9 +3,11 @@
  */
 
 import AlertV2 from '@/models/v2/AlertV2';
+import AlertRuleV2 from '@/models/v2/AlertRuleV2';
 import { sweepStaleAlerts, STALE_AFTER_SECONDS } from '@/lib/alerting/sweep';
 import { safeEvaluateReadings, safeSweepStaleAlerts } from '@/lib/alerting';
-import { createAlertInput, resetCounters } from '../../../setup/factories';
+import { logger } from '@/lib/monitoring';
+import { createAlertInput, resetCounters, createAlertRuleInput } from '../../../setup/factories';
 
 function minutesAgo(n: number): Date {
   return new Date(Date.now() - n * 60 * 1000);
@@ -119,13 +121,51 @@ describe('sweepStaleAlerts', () => {
 
     expect(result.resolved[0].resolution).toBe('device_inactive');
   });
+
+  it('should not delete a pending alert promoted to firing concurrently', async () => {
+    // Seed a pending alert whose device is absent from the reporting set.
+    const alert = await AlertV2.create(
+      createAlertInput({ device_id: 'device_gone', status: 'pending', last_observed_at: minutesAgo(60) })
+    );
+
+    // Simulate concurrent promotion: flip it to 'firing' before the sweep runs.
+    // This models the race where evaluateReadings commits a status-guarded
+    // updateOne from 'pending' to 'firing' inside the sweep's window.
+    await AlertV2.updateOne({ _id: alert._id }, { $set: { status: 'firing' } });
+
+    const result = await sweepStaleAlerts(new Set(['device_001']));
+
+    // The document should NOT be deleted by our status-guarded deleteMany.
+    // Instead it should be resolved with device_inactive.
+    expect(result.deleted).toBe(0);
+    expect(result.resolved).toHaveLength(1);
+    expect(result.resolved[0].resolution).toBe('device_inactive');
+
+    const stored = await AlertV2.findOne({ _id: alert._id }).lean();
+    expect(stored).not.toBeNull();
+    expect(stored!.status).toBe('resolved');
+  });
 });
 
 describe('safe wrappers', () => {
   it('should swallow an evaluation error and return an empty result', async () => {
+    // A matching rule is MANDATORY here. Without one, no (rule, device) pair is
+    // formed, evaluateReadings short-circuits on `pairs.size === 0` BEFORE it
+    // ever calls AlertV2.find, and the mocked throw is never reached — the
+    // assertion would then pass whether or not the try/catch does anything.
+    await AlertRuleV2.create(
+      createAlertRuleInput({
+        metric: 'value',
+        comparison: 'gt',
+        threshold: 0,
+        selector: { types: ['temperature'] },
+      })
+    );
+
     const spy = jest.spyOn(AlertV2, 'find').mockImplementationOnce(() => {
       throw new Error('database exploded');
     });
+    const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
 
     const result = await safeEvaluateReadings(
       [{ metadata: { device_id: 'device_001', type: 'temperature', unit: 'celsius', source: 'sensor' }, timestamp: new Date(), value: 1 }] as never,
@@ -133,7 +173,13 @@ describe('safe wrappers', () => {
     );
 
     expect(result.fired).toEqual([]);
+    // Proves the catch block actually executed, rather than the happy path
+    // returning an empty result for unrelated reasons.
+    expect(spy).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+
     spy.mockRestore();
+    errorSpy.mockRestore();
   });
 
   it('should swallow a sweep error', async () => {

--- a/__tests__/unit/lib/alerting/sweep.test.ts
+++ b/__tests__/unit/lib/alerting/sweep.test.ts
@@ -18,6 +18,66 @@ describe('STALE_AFTER_SECONDS', () => {
   it('should default to 30 minutes', () => {
     expect(STALE_AFTER_SECONDS).toBe(1800);
   });
+
+  // STALE_AFTER_SECONDS is computed once at module load from
+  // ALERT_STALE_AFTER_SECONDS, so exercising a different env value requires a
+  // fresh module instance — jest.resetModules() + a dynamic require, the same
+  // technique __tests__/unit/lib/sentry.test.ts uses for its own
+  // env-driven, import-time configuration.
+  describe('malformed ALERT_STALE_AFTER_SECONDS', () => {
+    const original = process.env.ALERT_STALE_AFTER_SECONDS;
+
+    afterEach(() => {
+      if (original === undefined) delete process.env.ALERT_STALE_AFTER_SECONDS;
+      else process.env.ALERT_STALE_AFTER_SECONDS = original;
+      jest.resetModules();
+    });
+
+    it('should fall back to 1800 and warn on a non-numeric value, instead of silently disabling staleness detection', () => {
+      process.env.ALERT_STALE_AFTER_SECONDS = 'not-a-number';
+
+      jest.resetModules();
+      // Requiring monitoring fresh FIRST, then spying on its logger, then
+      // requiring sweep fresh: sweep's own internal require of
+      // '@/lib/monitoring' resolves to this exact cached instance (same
+      // resolved path, same fresh registry generation), so the spy actually
+      // intercepts the call sweep.ts makes — spying on the OLD top-level
+      // `monitoring` import (from before resetModules) would not, since that
+      // binds to a now-discarded module instance.
+      const freshMonitoring = require('@/lib/monitoring');
+      const warnSpy = jest.spyOn(freshMonitoring.logger, 'warn').mockImplementation(() => {});
+
+      const fresh = require('@/lib/alerting/sweep');
+
+      // Would be NaN under the old parseInt-with-no-guard code — proving
+      // this assertion alone is not vacuous even without the warn check.
+      expect(fresh.STALE_AFTER_SECONDS).toBe(1800);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Malformed ALERT_STALE_AFTER_SECONDS'),
+        expect.objectContaining({ value: 'not-a-number' })
+      );
+
+      warnSpy.mockRestore();
+    });
+
+    it('should fall back to 1800 on a non-positive value', () => {
+      process.env.ALERT_STALE_AFTER_SECONDS = '-30';
+
+      jest.resetModules();
+      const fresh = require('@/lib/alerting/sweep');
+
+      expect(fresh.STALE_AFTER_SECONDS).toBe(1800);
+    });
+
+    it('should use a valid override unchanged', () => {
+      process.env.ALERT_STALE_AFTER_SECONDS = '900';
+
+      jest.resetModules();
+      const fresh = require('@/lib/alerting/sweep');
+
+      expect(fresh.STALE_AFTER_SECONDS).toBe(900);
+    });
+  });
 });
 
 describe('sweepStaleAlerts', () => {

--- a/__tests__/unit/lib/alerting/sweep.test.ts
+++ b/__tests__/unit/lib/alerting/sweep.test.ts
@@ -309,9 +309,11 @@ describe('safe wrappers', () => {
     // counter resets on every cold start. Sentry is the one channel that
     // survives both, so a swallowed evaluator error must reach it — tagged so
     // it can be triaged as an alerting failure rather than a generic exception.
+    // The tag rides in the THIRD argument (Sentry tags), not folded into the
+    // second (context/"Additional Data") — see lib/monitoring/sentry.ts.
     expect(captureSpy).toHaveBeenCalledTimes(1);
-    expect(captureSpy).toHaveBeenCalledWith(expect.any(Error), {
-      tags: { subsystem: 'alerting' },
+    expect(captureSpy).toHaveBeenCalledWith(expect.any(Error), undefined, {
+      subsystem: 'alerting',
     });
     // Not just "called with an Error" — the SAME error that was thrown, not a
     // placeholder constructed independently of it.
@@ -348,8 +350,8 @@ describe('safe wrappers', () => {
     expect(errorSpy).toHaveBeenCalled();
 
     expect(captureSpy).toHaveBeenCalledTimes(1);
-    expect(captureSpy).toHaveBeenCalledWith(expect.any(Error), {
-      tags: { subsystem: 'alerting' },
+    expect(captureSpy).toHaveBeenCalledWith(expect.any(Error), undefined, {
+      subsystem: 'alerting',
     });
     expect(captureSpy.mock.calls[0][0].message).toBe('database exploded');
 

--- a/__tests__/unit/lib/alerting/sweep.test.ts
+++ b/__tests__/unit/lib/alerting/sweep.test.ts
@@ -405,6 +405,10 @@ describe('safe wrappers', () => {
     const publishSpy = jest
       .spyOn(notifyModule, 'publishAlertEvents')
       .mockRejectedValueOnce(new Error('pusher exploded'));
+    const errorSpy = jest.spyOn(monitoring.logger, 'error').mockImplementation(() => undefined);
+    const captureSpy = jest
+      .spyOn(monitoring, 'captureException')
+      .mockImplementation(() => undefined);
 
     const result = await safeEvaluateReadings(
       [{ metadata: { device_id: 'device_001', type: 'temperature', unit: 'celsius', source: 'sensor' }, timestamp: new Date(), value: 1 }] as never,
@@ -426,7 +430,23 @@ describe('safe wrappers', () => {
     // Proves the mocked rejection was actually reached, not skipped.
     expect(publishSpy).toHaveBeenCalledTimes(1);
 
+    // The nested catch around publishAlertEvents must still give the fault a
+    // voice — a bare `catch {}` here would pass every assertion above while
+    // producing zero log line and zero Sentry event. This is the exact gap
+    // the backend review already flagged once for the alerting subsystem.
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Alert broadcast failed after a committed write',
+      expect.objectContaining({ error: 'pusher exploded' })
+    );
+    expect(captureSpy).toHaveBeenCalledTimes(1);
+    expect(captureSpy).toHaveBeenCalledWith(expect.any(Error), undefined, {
+      subsystem: 'alerting',
+    });
+    expect(captureSpy.mock.calls[0][0].message).toBe('pusher exploded');
+
     publishSpy.mockRestore();
+    errorSpy.mockRestore();
+    captureSpy.mockRestore();
   });
 
   it('should return the real sweep result, not the empty fallback, when publishAlertEvents throws', async () => {
@@ -436,6 +456,10 @@ describe('safe wrappers', () => {
     const publishSpy = jest
       .spyOn(notifyModule, 'publishAlertEvents')
       .mockRejectedValueOnce(new Error('pusher exploded'));
+    const errorSpy = jest.spyOn(monitoring.logger, 'error').mockImplementation(() => undefined);
+    const captureSpy = jest
+      .spyOn(monitoring, 'captureException')
+      .mockImplementation(() => undefined);
 
     const result = await safeSweepStaleAlerts(new Set(['device_001']));
 
@@ -454,7 +478,20 @@ describe('safe wrappers', () => {
 
     expect(publishSpy).toHaveBeenCalledTimes(1);
 
+    // Same voice requirement as the evaluator path above.
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Alert broadcast failed after a committed write',
+      expect.objectContaining({ error: 'pusher exploded' })
+    );
+    expect(captureSpy).toHaveBeenCalledTimes(1);
+    expect(captureSpy).toHaveBeenCalledWith(expect.any(Error), undefined, {
+      subsystem: 'alerting',
+    });
+    expect(captureSpy.mock.calls[0][0].message).toBe('pusher exploded');
+
     publishSpy.mockRestore();
+    errorSpy.mockRestore();
+    captureSpy.mockRestore();
   });
 
   // The whole point of catching around captureException (see the doc comment

--- a/__tests__/unit/lib/alerting/sweep.test.ts
+++ b/__tests__/unit/lib/alerting/sweep.test.ts
@@ -6,7 +6,7 @@ import AlertV2 from '@/models/v2/AlertV2';
 import AlertRuleV2 from '@/models/v2/AlertRuleV2';
 import { sweepStaleAlerts, STALE_AFTER_SECONDS } from '@/lib/alerting/sweep';
 import { safeEvaluateReadings, safeSweepStaleAlerts } from '@/lib/alerting';
-import { logger } from '@/lib/monitoring';
+import * as monitoring from '@/lib/monitoring';
 import { createAlertInput, resetCounters, createAlertRuleInput } from '../../../setup/factories';
 
 function minutesAgo(n: number): Date {
@@ -268,6 +268,10 @@ describe('sweepStaleAlerts', () => {
 });
 
 describe('safe wrappers', () => {
+  beforeEach(() => {
+    monitoring.resetMetrics();
+  });
+
   it('should swallow an evaluation error and return an empty result', async () => {
     // A matching rule is MANDATORY here. Without one, no (rule, device) pair is
     // formed, evaluateReadings short-circuits on `pairs.size === 0` BEFORE it
@@ -285,7 +289,10 @@ describe('safe wrappers', () => {
     const spy = jest.spyOn(AlertV2, 'find').mockImplementationOnce(() => {
       throw new Error('database exploded');
     });
-    const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+    const errorSpy = jest.spyOn(monitoring.logger, 'error').mockImplementation(() => undefined);
+    const captureSpy = jest
+      .spyOn(monitoring, 'captureException')
+      .mockImplementation(() => undefined);
 
     const result = await safeEvaluateReadings(
       [{ metadata: { device_id: 'device_001', type: 'temperature', unit: 'celsius', source: 'sensor' }, timestamp: new Date(), value: 1 }] as never,
@@ -298,15 +305,38 @@ describe('safe wrappers', () => {
     expect(spy).toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalled();
 
+    // The console line the logger produces never leaves the process, and the
+    // counter resets on every cold start. Sentry is the one channel that
+    // survives both, so a swallowed evaluator error must reach it — tagged so
+    // it can be triaged as an alerting failure rather than a generic exception.
+    expect(captureSpy).toHaveBeenCalledTimes(1);
+    expect(captureSpy).toHaveBeenCalledWith(expect.any(Error), {
+      tags: { subsystem: 'alerting' },
+    });
+    // Not just "called with an Error" — the SAME error that was thrown, not a
+    // placeholder constructed independently of it.
+    expect(captureSpy.mock.calls[0][0].message).toBe('database exploded');
+
+    // Exact labelled value via getMetricsSnapshot(), per the brief — not
+    // "some metric changed". resetMetrics() in beforeEach makes 1 the whole
+    // count for this test, not a delta against unrelated prior activity.
+    const snapshot = monitoring.getMetricsSnapshot();
+    const alerts = snapshot.alerts as Record<string, unknown>;
+    expect(alerts.evaluationErrors).toBe(1);
+
     spy.mockRestore();
     errorSpy.mockRestore();
+    captureSpy.mockRestore();
   });
 
   it('should swallow a sweep error', async () => {
     const spy = jest.spyOn(AlertV2, 'find').mockImplementationOnce(() => {
       throw new Error('database exploded');
     });
-    const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
+    const errorSpy = jest.spyOn(monitoring.logger, 'error').mockImplementation(() => undefined);
+    const captureSpy = jest
+      .spyOn(monitoring, 'captureException')
+      .mockImplementation(() => undefined);
 
     const result = await safeSweepStaleAlerts(new Set(['device_001']));
 
@@ -317,7 +347,81 @@ describe('safe wrappers', () => {
     expect(spy).toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalled();
 
+    expect(captureSpy).toHaveBeenCalledTimes(1);
+    expect(captureSpy).toHaveBeenCalledWith(expect.any(Error), {
+      tags: { subsystem: 'alerting' },
+    });
+    expect(captureSpy.mock.calls[0][0].message).toBe('database exploded');
+
+    const snapshot = monitoring.getMetricsSnapshot();
+    const alerts = snapshot.alerts as Record<string, unknown>;
+    expect(alerts.evaluationErrors).toBe(1);
+
     spy.mockRestore();
     errorSpy.mockRestore();
+    captureSpy.mockRestore();
+  });
+
+  // The whole point of catching around captureException (see the doc comment
+  // on reportToSentry in lib/alerting/index.ts) is that a misbehaving Sentry
+  // SDK must not turn an already-handled evaluator/sweep error into an
+  // unhandled one. These two tests make captureException itself throw and
+  // rely on Jest failing the test via an unhandled rejection if the wrapper
+  // ever lets that propagate — there is no try/catch around the `await`
+  // below to hide it.
+
+  it('should not throw when captureException itself throws (evaluator path)', async () => {
+    await AlertRuleV2.create(
+      createAlertRuleInput({
+        metric: 'value',
+        comparison: 'gt',
+        threshold: 0,
+        selector: { types: ['temperature'] },
+      })
+    );
+
+    const findSpy = jest.spyOn(AlertV2, 'find').mockImplementationOnce(() => {
+      throw new Error('database exploded');
+    });
+    const errorSpy = jest.spyOn(monitoring.logger, 'error').mockImplementation(() => undefined);
+    const captureSpy = jest.spyOn(monitoring, 'captureException').mockImplementation(() => {
+      throw new Error('sentry sdk exploded');
+    });
+
+    const result = await safeEvaluateReadings(
+      [{ metadata: { device_id: 'device_001', type: 'temperature', unit: 'celsius', source: 'sensor' }, timestamp: new Date(), value: 1 }] as never,
+      [{ _id: 'device_001', type: 'temperature', location: { building_id: 'HQ', floor: 1, room_name: 'X' }, metadata: { tags: [], department: 'x' } }] as never
+    );
+
+    // Still the normal swallow-and-return-empty behavior, unchanged by the
+    // second failure.
+    expect(result.fired).toEqual([]);
+    expect(result.resolved).toEqual([]);
+    // Proves captureException was actually reached (and threw), not skipped
+    // for some unrelated reason.
+    expect(captureSpy).toHaveBeenCalledTimes(1);
+
+    findSpy.mockRestore();
+    errorSpy.mockRestore();
+    captureSpy.mockRestore();
+  });
+
+  it('should not throw when captureException itself throws (sweep path)', async () => {
+    const findSpy = jest.spyOn(AlertV2, 'find').mockImplementationOnce(() => {
+      throw new Error('database exploded');
+    });
+    const errorSpy = jest.spyOn(monitoring.logger, 'error').mockImplementation(() => undefined);
+    const captureSpy = jest.spyOn(monitoring, 'captureException').mockImplementation(() => {
+      throw new Error('sentry sdk exploded');
+    });
+
+    const result = await safeSweepStaleAlerts(new Set(['device_001']));
+
+    expect(result).toEqual({ deleted: 0, resolved: [] });
+    expect(captureSpy).toHaveBeenCalledTimes(1);
+
+    findSpy.mockRestore();
+    errorSpy.mockRestore();
+    captureSpy.mockRestore();
   });
 });

--- a/__tests__/unit/lib/alerting/sweep.test.ts
+++ b/__tests__/unit/lib/alerting/sweep.test.ts
@@ -346,6 +346,219 @@ describe('sweepStaleAlerts', () => {
 
     bulkWriteSpy.mockRestore();
   });
+
+  // The test above deliberately avoids the same-millisecond case (see its
+  // comment about `minutesAgo(5)`), which left exactly one hole: a foreign
+  // resolution whose `audit.resolved_at` happens to EQUAL this sweep's `now`.
+  // `audit.resolved_at` is written by three other paths — the evaluator's
+  // auto-resolve on the ingest path, PATCH /alerts/[id] via AlertV2.resolve(),
+  // and PATCH /alert-rules/[id]'s condition-change close — and ingest vs cron,
+  // or a human clicking Resolve as a sweep runs, is ordinary concurrency.
+  // Confirming on the timestamp alone would relabel any of them as the sweep's
+  // own 'stale'/'device_inactive'. The predicate now also matches the
+  // resolution the candidate's own op wrote.
+  //
+  // This is the resolve-side mirror of the fix applied to evaluateReadings'
+  // Step 8 confirmation, and it is what keeps the two from confirming each
+  // other: the sweep writes only 'stale'/'device_inactive', the evaluator only
+  // 'auto', the manual paths only 'manual'.
+  describe('resolve confirmation is exact, not merely same-instant', () => {
+    /**
+     * Seed one open episode, freeze the clock so the sweep's internal `now` is
+     * knowable, and land a foreign resolution stamped with that exact `now`
+     * between the sweep's snapshot read and its bulk write.
+     *
+     * `reportingDeviceIds` decides which branch the sweep takes:
+     * a device absent from it resolves as 'device_inactive', a present one with
+     * a stale observation resolves as 'stale'. Both are exercised below.
+     */
+    async function raceForeignResolution(
+      deviceId: string,
+      reporting: string[],
+      resolveRacer: (id: string, now: Date) => Promise<unknown>
+    ) {
+      const alert = await AlertV2.create(
+        createAlertInput({
+          device_id: deviceId,
+          status: 'firing',
+          last_observed_at: minutesAgo(60),
+        })
+      );
+
+      // Only Date is faked, so the real mongodb-memory-server connection's own
+      // timers are untouched. Same technique as evaluate.test.ts's collision
+      // tests — a same-millisecond collision cannot be expressed
+      // deterministically while `new Date()` returns unpredictable wall clock.
+      jest.useFakeTimers({
+        doNotFake: [
+          'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval',
+          'setImmediate', 'clearImmediate', 'nextTick', 'hrtime', 'performance',
+          'queueMicrotask',
+        ],
+      });
+      // Deliberately AFTER the seed, so `last_observed_at: minutesAgo(60)` is a
+      // real 60 minutes before the frozen `now` and the staleness cutoff bites.
+      const now = new Date();
+      jest.setSystemTime(now);
+
+      try {
+        const realBulkWrite = AlertV2.bulkWrite.bind(AlertV2);
+        const bulkWriteSpy = jest
+          .spyOn(AlertV2, 'bulkWrite')
+          .mockImplementationOnce(async (writes, options) => {
+            await resolveRacer(String(alert._id), now);
+            return realBulkWrite(writes, options);
+          });
+
+        const result = await sweepStaleAlerts(new Set(reporting));
+        bulkWriteSpy.mockRestore();
+        return { result, alert, now };
+      } finally {
+        jest.useRealTimers();
+      }
+    }
+
+    it("should not claim the evaluator's auto-resolve landing in the same millisecond", async () => {
+      monitoring.resetMetrics();
+
+      // Exactly what evaluateReadings' auto-resolve op writes, stamped with the
+      // same `now` this sweep will use.
+      const { result, alert } = await raceForeignResolution(
+        'device_gone',
+        ['device_001'],
+        async (id, now) => {
+          await AlertV2.updateOne(
+            { _id: id, is_open: true },
+            {
+              $set: {
+                status: 'resolved',
+                is_open: false,
+                'audit.updated_at': now,
+                'audit.updated_by': 'system',
+                'audit.resolved_at': now,
+                'audit.resolved_by': 'system',
+                'audit.resolution': 'auto',
+              },
+            }
+          );
+        }
+      );
+
+      // The sweep's own guarded updateOne matched nothing — is_open was already
+      // false. audit.resolved_at equals its `now` only because the EVALUATOR
+      // set it.
+      expect(result.resolved).toHaveLength(0);
+      expect(monitoring.getPrometheusMetrics()).not.toContain(
+        'alerts_resolved_total{resolution="device_inactive"}'
+      );
+
+      // History is not relabelled: the problem really did clear, and the
+      // timeline must not say the sensor merely went quiet.
+      const stored = await AlertV2.findOne({ _id: alert._id }).lean();
+      expect(stored!.audit.resolution).toBe('auto');
+    });
+
+    it('should not claim a manual resolution landing in the same millisecond', async () => {
+      monitoring.resetMetrics();
+
+      // The real static PATCH /api/v2/alerts/[id] calls. It stamps its own
+      // `new Date()`, which under the frozen clock IS the sweep's `now` — the
+      // collision arises naturally rather than being hand-constructed.
+      const { result, alert } = await raceForeignResolution(
+        'device_gone',
+        ['device_001'],
+        id => AlertV2.resolve(id, 'human@example.com', 'manual')
+      );
+
+      expect(result.resolved).toHaveLength(0);
+      expect(monitoring.getPrometheusMetrics()).not.toContain(
+        'alerts_resolved_total{resolution="device_inactive"}'
+      );
+
+      const stored = await AlertV2.findOne({ _id: alert._id }).lean();
+      expect(stored!.audit.resolution).toBe('manual');
+      expect(stored!.audit.resolved_by).toBe('human@example.com');
+    });
+
+    // The 'stale' branch takes a different filter from 'device_inactive' (it
+    // carries the last_observed_at cutoff), so it needs its own collision case
+    // rather than being assumed equivalent.
+    it("should not claim a foreign resolution on the 'stale' branch either", async () => {
+      monitoring.resetMetrics();
+
+      // device_001 IS reporting, but its observation is an hour old — the only
+      // way to reach the 'stale' branch.
+      const { result, alert } = await raceForeignResolution(
+        'device_001',
+        ['device_001'],
+        id => AlertV2.resolve(id, 'human@example.com', 'manual')
+      );
+
+      expect(result.resolved).toHaveLength(0);
+      expect(monitoring.getPrometheusMetrics()).not.toContain(
+        'alerts_resolved_total{resolution="stale"}'
+      );
+
+      const stored = await AlertV2.findOne({ _id: alert._id }).lean();
+      expect(stored!.audit.resolution).toBe('manual');
+    });
+
+    // Without this, a predicate tightened until it never matches would pass all
+    // three tests above while silently breaking the sweep entirely.
+    it('should still report its own resolutions under the same frozen clock', async () => {
+      monitoring.resetMetrics();
+
+      const { result, alert } = await raceForeignResolution(
+        'device_gone',
+        ['device_001'],
+        async () => {
+          /* no racer: the sweep's own op is the only writer */
+        }
+      );
+
+      expect(result.resolved).toHaveLength(1);
+      expect(result.resolved[0].resolution).toBe('device_inactive');
+      expect(monitoring.getPrometheusMetrics()).toContain(
+        'alerts_resolved_total{resolution="device_inactive"} 1'
+      );
+
+      const stored = await AlertV2.findOne({ _id: alert._id }).lean();
+      expect(stored!.audit.resolution).toBe('device_inactive');
+    });
+
+    // Both branches in ONE sweep, which is what makes a single blanket
+    // predicate insufficient: the grouped $or must confirm each candidate
+    // against the resolution ITS OWN op wrote, not against a shared value.
+    it('should confirm a mixed stale/device_inactive sweep per candidate', async () => {
+      monitoring.resetMetrics();
+
+      const inactive = await AlertV2.create(
+        createAlertInput({
+          device_id: 'device_gone',
+          status: 'firing',
+          last_observed_at: minutesAgo(1),
+        })
+      );
+      const stale = await AlertV2.create(
+        createAlertInput({
+          device_id: 'device_001',
+          status: 'firing',
+          last_observed_at: minutesAgo(60),
+        })
+      );
+
+      const result = await sweepStaleAlerts(new Set(['device_001']));
+
+      expect(result.resolved).toHaveLength(2);
+      const byId = new Map(result.resolved.map(a => [a._id, a.resolution]));
+      expect(byId.get(String(inactive._id))).toBe('device_inactive');
+      expect(byId.get(String(stale._id))).toBe('stale');
+
+      const prom = monitoring.getPrometheusMetrics();
+      expect(prom).toContain('alerts_resolved_total{resolution="device_inactive"} 1');
+      expect(prom).toContain('alerts_resolved_total{resolution="stale"} 1');
+    });
+  });
 });
 
 describe('safe wrappers', () => {

--- a/__tests__/unit/lib/alerting/sweep.test.ts
+++ b/__tests__/unit/lib/alerting/sweep.test.ts
@@ -122,28 +122,148 @@ describe('sweepStaleAlerts', () => {
     expect(result.resolved[0].resolution).toBe('device_inactive');
   });
 
-  it('should not delete a pending alert promoted to firing concurrently', async () => {
-    // Seed a pending alert whose device is absent from the reporting set.
+  it('should not delete a pending alert promoted to firing between the sweep read and its write', async () => {
+    // Seed a pending alert whose device is absent from the reporting set, so
+    // the sweep's OWN snapshot read sees it as 'pending' and queues it for
+    // deletion (toDelete), not resolution.
     const alert = await AlertV2.create(
       createAlertInput({ device_id: 'device_gone', status: 'pending', last_observed_at: minutesAgo(60) })
     );
 
-    // Simulate concurrent promotion: flip it to 'firing' before the sweep runs.
-    // This models the race where evaluateReadings commits a status-guarded
-    // updateOne from 'pending' to 'firing' inside the sweep's window.
-    await AlertV2.updateOne({ _id: alert._id }, { $set: { status: 'firing' } });
+    // The race has to land strictly between the snapshot read and the bulk
+    // write, or the guarded deleteMany is never even constructed (that was
+    // the bug in the test this replaces: promoting before calling
+    // sweepStaleAlerts made the sweep's own `find` see 'firing' already, so
+    // `toDelete` stayed empty and the guard was never exercised). Spying on
+    // bulkWrite is the only hook with the right timing.
+    const realBulkWrite = AlertV2.bulkWrite.bind(AlertV2);
+    const bulkWriteSpy = jest
+      .spyOn(AlertV2, 'bulkWrite')
+      .mockImplementationOnce(async (writes, options) => {
+        await AlertV2.updateOne({ _id: alert._id }, { $set: { status: 'firing' } });
+        return realBulkWrite(writes, options);
+      });
 
     const result = await sweepStaleAlerts(new Set(['device_001']));
 
-    // The document should NOT be deleted by our status-guarded deleteMany.
-    // Instead it should be resolved with device_inactive.
+    // The status-guarded deleteMany must not match a document that is no
+    // longer 'pending' by the time the write reaches the server.
     expect(result.deleted).toBe(0);
-    expect(result.resolved).toHaveLength(1);
-    expect(result.resolved[0].resolution).toBe('device_inactive');
+    expect(result.resolved).toHaveLength(0);
 
     const stored = await AlertV2.findOne({ _id: alert._id }).lean();
     expect(stored).not.toBeNull();
-    expect(stored!.status).toBe('resolved');
+    expect(stored!.status).toBe('firing');
+    expect(stored!.is_open).toBe(true);
+
+    bulkWriteSpy.mockRestore();
+  });
+
+  it('should not resolve a stale alert as stale once a fresh observation lands before the write', async () => {
+    // Stale AT SNAPSHOT TIME on a reporting device: deviceInactive is false,
+    // so this can only take the 'stale' branch, which is exactly the branch
+    // 1a guards.
+    const alert = await AlertV2.create(
+      createAlertInput({ device_id: 'device_001', status: 'firing', last_observed_at: minutesAgo(60) })
+    );
+
+    // Between the snapshot read and the write, a concurrent evaluateReadings()
+    // records a fresh breaching observation — the episode is breaching again
+    // and must not be closed out from under it.
+    const realBulkWrite = AlertV2.bulkWrite.bind(AlertV2);
+    const bulkWriteSpy = jest
+      .spyOn(AlertV2, 'bulkWrite')
+      .mockImplementationOnce(async (writes, options) => {
+        await AlertV2.updateOne({ _id: alert._id }, { $set: { last_observed_at: new Date() } });
+        return realBulkWrite(writes, options);
+      });
+
+    const result = await sweepStaleAlerts(new Set(['device_001']));
+
+    expect(result.resolved).toHaveLength(0);
+    expect(result.deleted).toBe(0);
+
+    const stored = await AlertV2.findOne({ _id: alert._id }).lean();
+    expect(stored!.status).toBe('firing');
+    expect(stored!.is_open).toBe(true);
+    expect(stored!.audit.resolution).toBeUndefined();
+
+    bulkWriteSpy.mockRestore();
+  });
+
+  it('should report deleted as the actual deletedCount, not the candidate count', async () => {
+    // Two pending alerts on non-reporting devices are both delete candidates
+    // at snapshot time; only one survives to the write untouched.
+    const untouched = await AlertV2.create(
+      createAlertInput({ device_id: 'device_gone_1', status: 'pending', last_observed_at: minutesAgo(60) })
+    );
+    const promoted = await AlertV2.create(
+      createAlertInput({ device_id: 'device_gone_2', status: 'pending', last_observed_at: minutesAgo(60) })
+    );
+
+    const realBulkWrite = AlertV2.bulkWrite.bind(AlertV2);
+    const bulkWriteSpy = jest
+      .spyOn(AlertV2, 'bulkWrite')
+      .mockImplementationOnce(async (writes, options) => {
+        // Only ONE of the two candidates races to 'firing' before the write.
+        await AlertV2.updateOne({ _id: promoted._id }, { $set: { status: 'firing' } });
+        return realBulkWrite(writes, options);
+      });
+
+    const result = await sweepStaleAlerts(new Set(['device_001']));
+
+    // toDelete had 2 candidates; only 1 delete actually landed.
+    expect(result.deleted).toBe(1);
+
+    expect(await AlertV2.findById(untouched._id).lean()).toBeNull();
+    expect((await AlertV2.findById(promoted._id).lean())!.status).toBe('firing');
+
+    bulkWriteSpy.mockRestore();
+  });
+
+  it('should exclude an alert a concurrent writer already resolved from resolved[]', async () => {
+    const alert = await AlertV2.create(
+      createAlertInput({ device_id: 'device_gone', status: 'firing', last_observed_at: minutesAgo(1) })
+    );
+
+    // A different writer (e.g. a human PATCHing the alert to 'resolved')
+    // closes this SAME episode first, with its own timestamp, between the
+    // sweep's snapshot read and its write. The timestamp is deliberately NOT
+    // `new Date()`: the reconciliation query keys on `audit.resolved_at ===
+    // now`, and a concurrent write racing in on the same tick can land in the
+    // same millisecond as the sweep's `now`, which would make this test pass
+    // for the wrong reason (coincidental timestamp equality) instead of
+    // proving the sweep's own guarded updateOne failed to match.
+    const realBulkWrite = AlertV2.bulkWrite.bind(AlertV2);
+    const bulkWriteSpy = jest
+      .spyOn(AlertV2, 'bulkWrite')
+      .mockImplementationOnce(async (writes, options) => {
+        await AlertV2.updateOne(
+          { _id: alert._id },
+          {
+            $set: {
+              status: 'resolved',
+              is_open: false,
+              'audit.resolved_at': minutesAgo(5),
+              'audit.resolved_by': 'human@example.com',
+              'audit.resolution': 'manual',
+            },
+          }
+        );
+        return realBulkWrite(writes, options);
+      });
+
+    const result = await sweepStaleAlerts(new Set(['device_001']));
+
+    // The sweep's own updateOne (filter: { is_open: true, ... }) cannot match
+    // a document the concurrent writer already closed, so this episode must
+    // not be reported as one the SWEEP resolved.
+    expect(result.resolved).toHaveLength(0);
+
+    const stored = await AlertV2.findOne({ _id: alert._id }).lean();
+    expect(stored!.audit.resolution).toBe('manual'); // untouched by the sweep
+
+    bulkWriteSpy.mockRestore();
   });
 });
 
@@ -186,10 +306,18 @@ describe('safe wrappers', () => {
     const spy = jest.spyOn(AlertV2, 'find').mockImplementationOnce(() => {
       throw new Error('database exploded');
     });
+    const errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => undefined);
 
     const result = await safeSweepStaleAlerts(new Set(['device_001']));
 
     expect(result).toEqual({ deleted: 0, resolved: [] });
+    // Proves the catch block actually executed, rather than the happy path
+    // returning an empty result for unrelated reasons (e.g. no open alerts) —
+    // { deleted: 0, resolved: [] } is byte-identical to that early return.
+    expect(spy).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+
     spy.mockRestore();
+    errorSpy.mockRestore();
   });
 });

--- a/__tests__/unit/lib/alerting/sweep.test.ts
+++ b/__tests__/unit/lib/alerting/sweep.test.ts
@@ -6,6 +6,7 @@ import AlertV2 from '@/models/v2/AlertV2';
 import AlertRuleV2 from '@/models/v2/AlertRuleV2';
 import { sweepStaleAlerts, STALE_AFTER_SECONDS } from '@/lib/alerting/sweep';
 import { safeEvaluateReadings, safeSweepStaleAlerts } from '@/lib/alerting';
+import * as notifyModule from '@/lib/alerting/notify';
 import * as monitoring from '@/lib/monitoring';
 import { createAlertInput, resetCounters, createAlertRuleInput } from '../../../setup/factories';
 
@@ -382,6 +383,78 @@ describe('safe wrappers', () => {
     spy.mockRestore();
     errorSpy.mockRestore();
     captureSpy.mockRestore();
+  });
+
+  // publishAlertEvents runs in its OWN nested try/catch inside safeEvaluateReadings
+  // and safeSweepStaleAlerts (lib/alerting/index.ts), separate from the try/catch
+  // around the DB call. Spying on '@/lib/alerting/notify' rather than the
+  // '@/lib/alerting' barrel is deliberate: index.ts imports publishAlertEvents
+  // from './notify' directly (a relative import, resolving to the same module as
+  // '@/lib/alerting/notify'), so a spy on the barrel's re-export would never
+  // intercept the call index.ts actually makes — the exact dead-spy hazard this
+  // suite was warned about for the PATCH route's own barrel import.
+  it('should return the real evaluation result, not the empty fallback, when publishAlertEvents throws', async () => {
+    await AlertRuleV2.create(
+      createAlertRuleInput({
+        metric: 'value',
+        comparison: 'gt',
+        threshold: 0,
+        selector: { types: ['temperature'] },
+      })
+    );
+    const publishSpy = jest
+      .spyOn(notifyModule, 'publishAlertEvents')
+      .mockRejectedValueOnce(new Error('pusher exploded'));
+
+    const result = await safeEvaluateReadings(
+      [{ metadata: { device_id: 'device_001', type: 'temperature', unit: 'celsius', source: 'sensor' }, timestamp: new Date(), value: 1 }] as never,
+      [{ _id: 'device_001', type: 'temperature', location: { building_id: 'HQ', floor: 1, room_name: 'X' }, metadata: { tags: [], department: 'x' } }] as never
+    );
+
+    // The evaluation itself succeeded and fired a real alert. If the broadcast
+    // failure reached the outer catch, this would come back
+    // emptyEvaluationResult() ({ fired: [], ... }) instead.
+    expect(result.fired).toHaveLength(1);
+    expect(await AlertV2.countDocuments({ status: 'firing' })).toBe(1);
+
+    // A broadcast fault must never be mislabeled as an evaluation_error — that
+    // counter is reserved for the DB call itself.
+    const snapshot = monitoring.getMetricsSnapshot();
+    const alerts = snapshot.alerts as Record<string, unknown>;
+    expect(alerts.evaluationErrors).toBe(0);
+
+    // Proves the mocked rejection was actually reached, not skipped.
+    expect(publishSpy).toHaveBeenCalledTimes(1);
+
+    publishSpy.mockRestore();
+  });
+
+  it('should return the real sweep result, not the empty fallback, when publishAlertEvents throws', async () => {
+    await AlertV2.create(
+      createAlertInput({ device_id: 'device_gone', status: 'firing', last_observed_at: minutesAgo(1) })
+    );
+    const publishSpy = jest
+      .spyOn(notifyModule, 'publishAlertEvents')
+      .mockRejectedValueOnce(new Error('pusher exploded'));
+
+    const result = await safeSweepStaleAlerts(new Set(['device_001']));
+
+    // The sweep itself succeeded and resolved a real alert. If the broadcast
+    // failure reached the outer catch, this would come back
+    // { deleted: 0, resolved: [] } instead — byte-identical to the DB-failure
+    // fallback, which is exactly why this needs its own assertion on the DB
+    // state, not just on the returned shape.
+    expect(result.resolved).toHaveLength(1);
+    expect(result.resolved[0].resolution).toBe('device_inactive');
+    expect((await AlertV2.findOne({}).lean())!.status).toBe('resolved');
+
+    const snapshot = monitoring.getMetricsSnapshot();
+    const alerts = snapshot.alerts as Record<string, unknown>;
+    expect(alerts.evaluationErrors).toBe(0);
+
+    expect(publishSpy).toHaveBeenCalledTimes(1);
+
+    publishSpy.mockRestore();
   });
 
   // The whole point of catching around captureException (see the doc comment

--- a/__tests__/unit/lib/cache.test.ts
+++ b/__tests__/unit/lib/cache.test.ts
@@ -37,6 +37,199 @@ jest.mock('@/lib/monitoring/logger', () => ({
   },
 }));
 
+// ============================================================================
+// A TINY LUA EVALUATOR FOR THE COMMIT SCRIPT
+// ============================================================================
+//
+// WHY THIS EXISTS. The cross-process guard is a Lua script (`lib/cache/cache.ts`,
+// COMMIT_IF_EPOCH_UNCHANGED) and CI runs no Redis, so nothing in the committed
+// suite used to EXECUTE it — the fake `eval` below reimplemented the
+// compare-and-set contract in JavaScript and threw the `_script` argument away.
+// That made every assertion about the guard an assertion about the fake. The
+// script's `~=` could be flipped to `==`, inverting the guard into "commit only
+// when the epoch HAS changed" — committing precisely the stale writes the guard
+// exists to prevent — and the whole suite stayed green.
+//
+// So the fake now runs the real script text. This is not a Lua implementation;
+// it is an interpreter for exactly the constructs COMMIT_IF_EPOCH_UNCHANGED
+// uses (local binding, `redis.call`, one-line `if ... then ... end`, `return
+// <int>`, `==`/`~=` on strings and booleans). Anything else throws rather than
+// being skipped or guessed at, so a future edit that outgrows it fails loudly
+// here instead of quietly reverting these tests to testing a fake again.
+//
+// Semantics that matter and are deliberately modelled:
+//   - a missing key makes `redis.call('GET', ...)` yield `false`, because Redis
+//     maps nil to false in Lua. That is what the script's `current == false`
+//     normalization exists to handle.
+//   - `==` does not coerce across types, so `'' == false` is false, as in Lua.
+
+/** The only value types this script ever produces. */
+type LuaValue = string | boolean | number;
+
+interface LuaRedis {
+  call(command: string, ...args: LuaValue[]): LuaValue;
+}
+
+function unsupportedLua(what: string, detail: string): never {
+  throw new Error(
+    `The commit script uses Lua this evaluator does not implement (${what}): ${detail}`
+  );
+}
+
+/** Splits a call's argument list on top-level commas. */
+function splitLuaArgs(argList: string): string[] {
+  const args: string[] = [];
+  let depth = 0;
+  let current = '';
+
+  for (const char of argList) {
+    if (char === '(') depth += 1;
+    if (char === ')') depth -= 1;
+    if (char === ',' && depth === 0) {
+      args.push(current);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  if (current.trim()) args.push(current);
+
+  return args;
+}
+
+/**
+ * Execute `script` with the given KEYS/ARGV against `redis`, returning the
+ * integer the script returns. Lua is 1-indexed; KEYS/ARGV are passed 0-indexed
+ * here and adjusted on lookup.
+ */
+function runLuaCommitScript(
+  script: string,
+  keys: string[],
+  argv: string[],
+  redis: LuaRedis
+): number {
+  const locals = new Map<string, LuaValue>();
+
+  const evaluate = (raw: string): LuaValue => {
+    const expression = raw.trim();
+
+    const argvIndex = /^ARGV\[(\d+)\]$/.exec(expression);
+    if (argvIndex) return argv[Number(argvIndex[1]) - 1] ?? false;
+
+    const keysIndex = /^KEYS\[(\d+)\]$/.exec(expression);
+    if (keysIndex) return keys[Number(keysIndex[1]) - 1] ?? false;
+
+    const stringLiteral = /^'([^']*)'$/.exec(expression);
+    if (stringLiteral) return stringLiteral[1];
+
+    if (expression === 'false') return false;
+    if (expression === 'true') return true;
+    if (/^-?\d+$/.test(expression)) return Number(expression);
+
+    const call = /^redis\.call\((.*)\)$/.exec(expression);
+    if (call) {
+      const [command, ...args] = splitLuaArgs(call[1]).map(evaluate);
+      if (typeof command !== 'string') unsupportedLua('redis.call command', expression);
+      return redis.call(command, ...args);
+    }
+
+    if (/^[A-Za-z_]\w*$/.test(expression)) {
+      if (!locals.has(expression)) unsupportedLua('unbound name', expression);
+      return locals.get(expression) as LuaValue;
+    }
+
+    return unsupportedLua('expression', expression);
+  };
+
+  const isTruthy = (raw: string): boolean => {
+    const comparison = /^(.+?)\s*(==|~=)\s*(.+)$/.exec(raw.trim());
+    if (!comparison) unsupportedLua('condition', raw);
+
+    // No cross-type coercion, exactly like Lua: '' does not equal false.
+    const equal = evaluate(comparison[1]) === evaluate(comparison[3]);
+    return comparison[2] === '==' ? equal : !equal;
+  };
+
+  /** Returns the script's return value, or undefined if the statement fell through. */
+  const execute = (raw: string): number | undefined => {
+    const statement = raw.trim();
+
+    const returned = /^return\s+(-?\d+)$/.exec(statement);
+    if (returned) return Number(returned[1]);
+
+    const declaration = /^local\s+([A-Za-z_]\w*)\s*=\s*(.+)$/.exec(statement);
+    if (declaration) {
+      locals.set(declaration[1], evaluate(declaration[2]));
+      return undefined;
+    }
+
+    if (/^redis\.call\(/.test(statement)) {
+      evaluate(statement);
+      return undefined;
+    }
+
+    const assignment = /^([A-Za-z_]\w*)\s*=\s*(.+)$/.exec(statement);
+    if (assignment) {
+      if (!locals.has(assignment[1]))
+        unsupportedLua('assignment to an undeclared name', statement);
+      locals.set(assignment[1], evaluate(assignment[2]));
+      return undefined;
+    }
+
+    return unsupportedLua('statement', statement);
+  };
+
+  const lines = script
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line && !line.startsWith('--'));
+
+  for (const line of lines) {
+    const conditional = /^if\s+(.+?)\s+then\s+(.+?)\s+end$/.exec(line);
+
+    if (conditional) {
+      if (!isTruthy(conditional[1])) continue;
+      const result = execute(conditional[2]);
+      if (result !== undefined) return result;
+      continue;
+    }
+
+    const result = execute(line);
+    if (result !== undefined) return result;
+  }
+
+  return unsupportedLua('control flow', 'the script ended without returning');
+}
+
+/** A `redis` table backed by a plain key/value map, for the evaluator to call into. */
+function createLuaRedis(store: Map<string, string>): LuaRedis {
+  return {
+    call(command: string, ...args: LuaValue[]): LuaValue {
+      const name = command.toUpperCase();
+
+      if (name === 'GET') {
+        const key = String(args[0]);
+        // Redis maps a missing key's nil to `false` in Lua.
+        return store.has(key) ? (store.get(key) as string) : false;
+      }
+
+      if (name === 'SETEX') {
+        const [key, , value] = args.map(String);
+        store.set(key, value);
+        return 'OK';
+      }
+
+      return unsupportedLua('redis command', name);
+    },
+  };
+}
+
+/** ioredis' `eval(script, numKeys, ...keysThenArgv)` calling convention. */
+function evalWithLua(store: Map<string, string>) {
+  return async (script: string, numKeys: number, ...args: string[]): Promise<number> =>
+    runLuaCommitScript(script, args.slice(0, numKeys), args.slice(numKeys), createLuaRedis(store));
+}
+
 describe('Cache Manager', () => {
   // Save original env and reset mocks before each test
   const originalEnv = process.env;
@@ -597,12 +790,20 @@ describe('Cache Manager', () => {
         readsEpoch: at(/redis\.call\(\s*'GET'\s*,\s*KEYS\[2\]\s*\)/),
         /** Normalizes a missing epoch key, so "never invalidated" compares equal to ''. */
         normalizesMissing: at(/==\s*false/),
-        /** Compares the two AND bails out. Both halves required on one line. */
+        /**
+         * Compares the two AND bails out. Both halves required on one line.
+         *
+         * The operator is pinned to `~=` on purpose. An earlier version of
+         * this matcher accepted `==` as well, which meant it passed against
+         * the exact inversion it was written to catch — "commit only when the
+         * epoch HAS changed" — a guard that refuses every legitimate write and
+         * admits every stale one. `guards` must mean "bails out on a
+         * MISMATCH", so only the inequality qualifies.
+         */
         guards: lines.findIndex(
           line =>
-            /\bcurrent\b\s*(~=|==)\s*\bobserved\b|\bobserved\b\s*(~=|==)\s*\bcurrent\b/.test(
-              line
-            ) && /\breturn\s+0\b/.test(line)
+            /\bcurrent\b\s*~=\s*\bobserved\b|\bobserved\b\s*~=\s*\bcurrent\b/.test(line) &&
+            /\breturn\s+0\b/.test(line)
         ),
         /** The one and only write. */
         writes: at(/redis\.call\(\s*'SETEX'\s*,\s*KEYS\[1\]\s*,\s*ARGV\[1\]\s*,\s*ARGV\[2\]\s*\)/),
@@ -664,6 +865,75 @@ describe('Cache Manager', () => {
       expect(script.lines.some(line => /\breturn\s+0\b/.test(line))).toBe(true);
       expect(script.lines.some(line => /\breturn\s+1\b/.test(line))).toBe(true);
     });
+
+    // ------------------------------------------------------------------
+    // ...and the same script, EXECUTED.
+    // ------------------------------------------------------------------
+    //
+    // The structural rows above describe the script's shape. These run it.
+    // Shape assertions can only ever check that some comparison is present;
+    // running it is what pins down which way round the comparison points. An
+    // inverted guard (`~=` flipped to `==`) satisfies "a comparison exists"
+    // and fails every row below.
+    describe('executed against the evaluator', () => {
+      const VALUE_KEY = 'exec:key';
+      const EPOCH_KEY = 'exec:key::epoch';
+      const TTL = '60';
+      const PAYLOAD = '{"fresh":true}';
+
+      /** Runs the module's real script over a store seeded with `epoch`. */
+      async function run(epoch: string | null, observedEpoch: string) {
+        const store = new Map<string, string>();
+        if (epoch !== null) store.set(EPOCH_KEY, epoch);
+
+        const result = await evalWithLua(store)(
+          await captureCommitScript(),
+          2,
+          VALUE_KEY,
+          EPOCH_KEY,
+          TTL,
+          PAYLOAD,
+          observedEpoch
+        );
+
+        return { result, store };
+      }
+
+      it('should commit when the epoch is unchanged since it was observed', async () => {
+        const { result, store } = await run('7', '7');
+
+        expect(result).toBe(1);
+        expect(store.get(VALUE_KEY)).toBe(PAYLOAD);
+      });
+
+      it('should REFUSE and write nothing when the epoch moved on', async () => {
+        // The C6 race itself: the fetch observed epoch 7, an invalidation in
+        // another process bumped it to 8, and this write is now stale.
+        const { result, store } = await run('8', '7');
+
+        expect(result).toBe(0);
+        expect(store.has(VALUE_KEY)).toBe(false);
+      });
+
+      it('should commit the first write to a key that was never invalidated', async () => {
+        // No epoch key at all: GET yields false, the script normalizes it to
+        // '', and '' is what readEpoch reported. Were this refused, caching
+        // would simply never happen.
+        const { result, store } = await run(null, '');
+
+        expect(result).toBe(1);
+        expect(store.get(VALUE_KEY)).toBe(PAYLOAD);
+      });
+
+      it('should refuse an unreadable epoch, which can never equal a real one', async () => {
+        // EPOCH_UNREADABLE contains a NUL byte precisely so it cannot collide
+        // with anything INCR produced. Fail closed.
+        const { result, store } = await run('3', '\u0000unreadable');
+
+        expect(result).toBe(0);
+        expect(store.has(VALUE_KEY)).toBe(false);
+      });
+    });
   });
 
   // ==========================================================================
@@ -678,11 +948,12 @@ describe('Cache Manager', () => {
   // registries, i.e. two independent generation counters — sharing one fake
   // Redis. Only the Redis-side epoch can pass them.
   //
-  // The fake's `eval` implements the compare-and-set contract the Lua script
-  // encodes (compare the epoch, SETEX only on a match) rather than
-  // interpreting Lua. The script text itself was verified against a real
-  // Redis 7 out of band; see the round-2 section of the P4 report for the
-  // exact command and its output.
+  // The fake's `eval` EXECUTES the module's real script text through
+  // `runLuaCommitScript` (see the evaluator at the top of this file), so these
+  // rows pass or fail on what the script actually says, not on a JavaScript
+  // restatement of what it is supposed to say. The script was additionally
+  // verified against a real Redis 7 out of band; see the round-2 section of
+  // the P4 report for the exact command and its output.
   describe('cross-process guard (Redis epoch)', () => {
     /** One shared "Redis server" that several isolated cache modules can talk to. */
     function createSharedRedis() {
@@ -725,24 +996,11 @@ describe('Cache Manager', () => {
           };
           return chain;
         }),
-        eval: jest.fn(
-          async (
-            _script: string,
-            _numKeys: number,
-            valueKey: string,
-            epochKey: string,
-            ttl: string,
-            value: string,
-            observedEpoch: string
-          ) => {
-            // Atomic by construction: one synchronous compare-and-set, which
-            // is exactly the property EVAL gives on a real server.
-            const current = store.get(epochKey) ?? '';
-            if (current !== observedEpoch) return 0;
-            store.set(valueKey, value);
-            return 1;
-          }
-        ),
+        // Runs the module's REAL script text through `runLuaCommitScript`
+        // rather than reimplementing the compare-and-set. Atomic by
+        // construction: the interpreter is synchronous from first line to
+        // return, which is the property EVAL gives on a real server.
+        eval: jest.fn(evalWithLua(store)),
       };
 
       return redis;

--- a/__tests__/unit/lib/cache.test.ts
+++ b/__tests__/unit/lib/cache.test.ts
@@ -17,6 +17,7 @@ import {
   isCacheEnabled,
   CACHE_TTL,
 } from '@/lib/cache/cache';
+import type * as CacheModule from '@/lib/cache/cache';
 import * as redisModule from '@/lib/redis/client';
 import { resetMetrics } from '@/lib/monitoring/metrics';
 
@@ -238,6 +239,53 @@ describe('Cache Manager', () => {
       expect(mockRedis.del).toHaveBeenCalledWith('device:device_001');
     });
 
+    // The cross-process half of the stale-write guard: an invalidation has to
+    // leave a mark another process can see, which is the per-key epoch.
+    it('should bump the key epoch before deleting', async () => {
+      const pipeline = {
+        incr: jest.fn().mockReturnThis(),
+        expire: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([]),
+      };
+      const mockRedis = {
+        pipeline: jest.fn().mockReturnValue(pipeline),
+        del: jest.fn().mockResolvedValue(1),
+      };
+      (redisModule.getRedisClient as jest.Mock).mockReturnValue(mockRedis);
+      (redisModule.isRedisAvailable as jest.Mock).mockReturnValue(true);
+
+      const result = await del('device:device_001');
+
+      expect(result).toBe(1);
+      expect(pipeline.incr).toHaveBeenCalledWith('device:device_001::epoch');
+      expect(pipeline.expire).toHaveBeenCalledWith('device:device_001::epoch', 3600);
+      // The epoch must be bumped BEFORE the DEL, so a getOrSet in another
+      // process that reads it from that moment on already sees the new value.
+      expect(pipeline.exec.mock.invocationCallOrder[0]).toBeLessThan(
+        mockRedis.del.mock.invocationCallOrder[0]
+      );
+    });
+
+    // Invalidation has always been best effort here (`del` already returns 0
+    // and warns on a Redis fault). A failed epoch bump must degrade the same
+    // way rather than stopping the DEL, which is the stronger of the two
+    // signals — and layer 1 still covers the instance.
+    it('should still delete when the epoch bump fails', async () => {
+      const mockRedis = {
+        pipeline: jest.fn(() => {
+          throw new Error('pipeline unavailable');
+        }),
+        del: jest.fn().mockResolvedValue(1),
+      };
+      (redisModule.getRedisClient as jest.Mock).mockReturnValue(mockRedis);
+      (redisModule.isRedisAvailable as jest.Mock).mockReturnValue(true);
+
+      const result = await del('device:device_001');
+
+      expect(result).toBe(1);
+      expect(mockRedis.del).toHaveBeenCalledWith('device:device_001');
+    });
+
     it('should delete multiple keys successfully', async () => {
       const mockRedis = { del: jest.fn().mockResolvedValue(3) };
       (redisModule.getRedisClient as jest.Mock).mockReturnValue(mockRedis);
@@ -293,6 +341,30 @@ describe('Cache Manager', () => {
 
       expect(result).toBe(2);
       expect(mockRedis.scan).toHaveBeenCalledWith('0', 'MATCH', 'device:*', 'COUNT', 100);
+    });
+
+    // Cross-process cover for the keys a pattern actually matched. It is
+    // strictly weaker than an exact-key del: a key ABSENT at scan time cannot
+    // be enumerated, and that is the very key a racing getOrSet missed on —
+    // only layer 1 covers that, and only within the instance.
+    it('should bump the epoch of every key the scan matched', async () => {
+      const pipeline = {
+        incr: jest.fn().mockReturnThis(),
+        expire: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([]),
+      };
+      const mockRedis = {
+        scan: jest.fn().mockResolvedValueOnce(['0', ['device:001', 'device:002']]),
+        pipeline: jest.fn().mockReturnValue(pipeline),
+        del: jest.fn().mockResolvedValue(2),
+      };
+      (redisModule.getRedisClient as jest.Mock).mockReturnValue(mockRedis);
+      (redisModule.isRedisAvailable as jest.Mock).mockReturnValue(true);
+
+      await delPattern('device:*');
+
+      expect(pipeline.incr).toHaveBeenCalledWith('device:001::epoch');
+      expect(pipeline.incr).toHaveBeenCalledWith('device:002::epoch');
     });
 
     it('should handle multiple scan iterations', async () => {
@@ -357,11 +429,15 @@ describe('Cache Manager', () => {
       expect(fetchFn).not.toHaveBeenCalled();
     });
 
+    // The write now commits through a Lua compare-and-set rather than a bare
+    // SETEX, so that an invalidation from ANOTHER process — which this
+    // process's in-memory generation counter cannot see — still cancels it.
+    // The SETEX happens inside the script, server-side.
     it('should fetch and cache when cache miss', async () => {
       const freshData = { id: 'device_001', name: 'Fresh Device' };
       const mockRedis = {
         get: jest.fn().mockResolvedValue(null),
-        setex: jest.fn().mockResolvedValue('OK'),
+        eval: jest.fn().mockResolvedValue(1),
       };
       (redisModule.getRedisClient as jest.Mock).mockReturnValue(mockRedis);
       (redisModule.isRedisAvailable as jest.Mock).mockReturnValue(true);
@@ -371,16 +447,46 @@ describe('Cache Manager', () => {
 
       expect(result).toEqual(freshData);
       expect(fetchFn).toHaveBeenCalled();
-      // set() is called asynchronously, wait a tick
+      // the commit is called asynchronously, wait a tick
       await new Promise(resolve => setImmediate(resolve));
-      expect(mockRedis.setex).toHaveBeenCalled();
+      expect(mockRedis.eval).toHaveBeenCalled();
+
+      // Shape only. What the script must SEMANTICALLY do is asserted in the
+      // 'commit script invariants' block below — a `toContain('SETEX')` here
+      // survives deletion of the epoch compare and would let the whole
+      // cross-process mechanism regress silently.
+      const [script, numKeys, valueKey, epochK, ttlArg, payload] = mockRedis.eval.mock.calls[0];
+      expect(script).toContain('SETEX');
+      expect(numKeys).toBe(2);
+      expect(valueKey).toBe('device:device_001');
+      expect(epochK).toBe('device:device_001::epoch');
+      expect(ttlArg).toBe('300');
+      expect(payload).toBe(JSON.stringify(freshData));
+    });
+
+    it('should snapshot the key epoch before fetching, not after', async () => {
+      const mockRedis = {
+        get: jest.fn().mockResolvedValue(null),
+        eval: jest.fn().mockResolvedValue(1),
+      };
+      (redisModule.getRedisClient as jest.Mock).mockReturnValue(mockRedis);
+      (redisModule.isRedisAvailable as jest.Mock).mockReturnValue(true);
+
+      const fetchFn = jest.fn().mockResolvedValue({ id: 'device_001' });
+      await getOrSet('device:device_001', fetchFn, { ttl: 300 });
+
+      // An epoch read after the fetch would be blind to exactly the
+      // invalidations this guard exists to catch.
+      expect(mockRedis.get).toHaveBeenCalledWith('device:device_001::epoch');
+      const epochRead = mockRedis.get.mock.invocationCallOrder[1];
+      expect(epochRead).toBeLessThan(fetchFn.mock.invocationCallOrder[0]);
     });
 
     it('should return fetched data even if cache set fails', async () => {
       const freshData = { id: 'device_001' };
       const mockRedis = {
         get: jest.fn().mockResolvedValue(null),
-        setex: jest.fn().mockRejectedValue(new Error('Set failed')),
+        eval: jest.fn().mockRejectedValue(new Error('Set failed')),
       };
       (redisModule.getRedisClient as jest.Mock).mockReturnValue(mockRedis);
       (redisModule.isRedisAvailable as jest.Mock).mockReturnValue(true);
@@ -389,6 +495,376 @@ describe('Cache Manager', () => {
       const result = await getOrSet('device:device_001', fetchFn, { ttl: 300 });
 
       expect(result).toEqual(freshData);
+    });
+
+    // Degradation must match the rest of this module: no cache, no throw. A
+    // cache that hard-failed with Redis down would be a worse regression than
+    // the race it is guarding against.
+    it('should return fetched data when Redis is unavailable', async () => {
+      (redisModule.getRedisClient as jest.Mock).mockReturnValue(null);
+
+      const freshData = { id: 'device_001' };
+      const fetchFn = jest.fn().mockResolvedValue(freshData);
+
+      await expect(getOrSet('device:device_001', fetchFn, { ttl: 300 })).resolves.toEqual(
+        freshData
+      );
+      expect(fetchFn).toHaveBeenCalled();
+    });
+
+    // An unreadable epoch is not the same as "never invalidated". It must fail
+    // CLOSED — skip the write — or a flapping Redis would reopen the race.
+    it('should skip the write when the epoch could not be read', async () => {
+      const mockRedis = {
+        get: jest
+          .fn()
+          // the value read: a miss
+          .mockResolvedValueOnce(null)
+          // the epoch read: a fault
+          .mockRejectedValueOnce(new Error('epoch read failed')),
+        eval: jest.fn().mockResolvedValue(0),
+      };
+      (redisModule.getRedisClient as jest.Mock).mockReturnValue(mockRedis);
+      (redisModule.isRedisAvailable as jest.Mock).mockReturnValue(true);
+
+      const freshData = { id: 'device_001' };
+      const result = await getOrSet('device:device_001', jest.fn().mockResolvedValue(freshData), {
+        ttl: 300,
+      });
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(result).toEqual(freshData);
+      // The observed epoch handed to the CAS cannot be a value INCR can
+      // produce, so the compare can only fail.
+      const observed = mockRedis.eval.mock.calls[0][6];
+      expect(observed).not.toBe('');
+      expect(observed).not.toMatch(/^\d+$/);
+    });
+  });
+
+  // ==========================================================================
+  // COMMIT SCRIPT INVARIANTS
+  // ==========================================================================
+  //
+  // The whole cross-process guard lives inside a Lua script, and no test that
+  // runs in CI executes Lua — the fakes elsewhere in this file implement the
+  // compare-and-set CONTRACT in JavaScript. Without this block, someone could
+  // delete the epoch comparison from the script and every test would stay
+  // green while production silently lost the guard.
+  //
+  // So these assert the script's SEMANTICS structurally, on the exact text the
+  // module hands to EVAL (captured from the call, so it cannot drift from what
+  // ships). They are deliberately behavioural rather than a whole-string
+  // snapshot: each one names a property the script must have, and says why.
+  //
+  // Executing the real thing is covered separately and opt-in, by
+  // `__tests__/integration/cache-commit-script.redis.test.ts`.
+  describe('commit script invariants', () => {
+    /** The script the module actually passes to EVAL. Ground truth, not file text. */
+    async function captureCommitScript(): Promise<string> {
+      const mockRedis = {
+        get: jest.fn().mockResolvedValue(null),
+        eval: jest.fn().mockResolvedValue(1),
+      };
+      (redisModule.getRedisClient as jest.Mock).mockReturnValue(mockRedis);
+      (redisModule.isRedisAvailable as jest.Mock).mockReturnValue(true);
+
+      await getOrSet('script:probe', async () => ({ probe: true }), { ttl: 60 });
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(mockRedis.eval).toHaveBeenCalled();
+      return mockRedis.eval.mock.calls[0][0] as string;
+    }
+
+    /**
+     * Locate each required step by line. The script is straight-line, so line
+     * ORDER is what encodes reachability: a `return 0` above the write means
+     * the write cannot run on the branch that returns.
+     */
+    function analyse(script: string) {
+      const lines = script
+        .split('\n')
+        .map(line => line.trim())
+        .filter(Boolean);
+
+      const at = (pattern: RegExp) => lines.findIndex(line => pattern.test(line));
+
+      return {
+        lines,
+        /** Binds the caller's observed epoch. */
+        bindsObserved: at(/=\s*ARGV\[3\]/),
+        /** Reads the CURRENT epoch from the epoch key. */
+        readsEpoch: at(/redis\.call\(\s*'GET'\s*,\s*KEYS\[2\]\s*\)/),
+        /** Normalizes a missing epoch key, so "never invalidated" compares equal to ''. */
+        normalizesMissing: at(/==\s*false/),
+        /** Compares the two AND bails out. Both halves required on one line. */
+        guards: lines.findIndex(
+          line =>
+            /\bcurrent\b\s*(~=|==)\s*\bobserved\b|\bobserved\b\s*(~=|==)\s*\bcurrent\b/.test(
+              line
+            ) && /\breturn\s+0\b/.test(line)
+        ),
+        /** The one and only write. */
+        writes: at(/redis\.call\(\s*'SETEX'\s*,\s*KEYS\[1\]\s*,\s*ARGV\[1\]\s*,\s*ARGV\[2\]\s*\)/),
+        writeCount: lines.filter(line => /redis\.call\(\s*'SETEX'/.test(line)).length,
+      };
+    }
+
+    it('should read the current epoch and bind the epoch the caller observed', async () => {
+      const script = analyse(await captureCommitScript());
+
+      expect(script.readsEpoch).toBeGreaterThanOrEqual(0);
+      expect(script.bindsObserved).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should treat a missing epoch key as the empty observation', async () => {
+      const script = analyse(await captureCommitScript());
+
+      // Without this, the very first write to a never-invalidated key would
+      // compare `false` against `''` and be refused forever — the guard would
+      // turn into "caching is off".
+      expect(script.normalizesMissing).toBeGreaterThanOrEqual(0);
+      expect(script.normalizesMissing).toBeGreaterThan(script.readsEpoch);
+    });
+
+    // THE assertion this block exists for. Deleting
+    // `if current ~= observed then return 0 end` makes `guards` -1 and fails
+    // here, which is exactly the regression that must not reach production.
+    it('should compare the observed epoch against the current one and return early when they differ', async () => {
+      const script = analyse(await captureCommitScript());
+
+      expect(script.guards).toBeGreaterThanOrEqual(0);
+      // You cannot compare what you have not read or bound yet.
+      expect(script.guards).toBeGreaterThan(script.readsEpoch);
+      expect(script.guards).toBeGreaterThan(script.bindsObserved);
+    });
+
+    it('should place the write after the guard, so a mismatch cannot reach it', async () => {
+      const script = analyse(await captureCommitScript());
+
+      expect(script.writes).toBeGreaterThanOrEqual(0);
+      expect(script.guards).toBeGreaterThanOrEqual(0);
+      // Straight-line script: the guard returns, so every line below it runs
+      // only on the matching branch. A write ABOVE the guard would be
+      // unconditional and the epoch would be decorative.
+      expect(script.writes).toBeGreaterThan(script.guards);
+    });
+
+    it('should contain exactly one write, so no path bypasses the guard', async () => {
+      const script = analyse(await captureCommitScript());
+
+      expect(script.writeCount).toBe(1);
+    });
+
+    it('should signal a refusal distinguishably from a commit', async () => {
+      const script = analyse(await captureCommitScript());
+
+      // commitIfEpochUnchanged treats anything other than 1 as "refused", so
+      // the script has to actually return both outcomes.
+      expect(script.lines.some(line => /\breturn\s+0\b/.test(line))).toBe(true);
+      expect(script.lines.some(line => /\breturn\s+1\b/.test(line))).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // CROSS-PROCESS STALE-WRITE GUARD
+  // ==========================================================================
+  //
+  // The in-process generation counter cannot see across a process boundary,
+  // and on serverless the two halves of this race normally land on different
+  // function instances: the PATCH that disables an alert rule runs in one, the
+  // ingest request that repopulates the rule cache runs in another. So these
+  // tests deliberately DEFEAT the in-process layer — two isolated module
+  // registries, i.e. two independent generation counters — sharing one fake
+  // Redis. Only the Redis-side epoch can pass them.
+  //
+  // The fake's `eval` implements the compare-and-set contract the Lua script
+  // encodes (compare the epoch, SETEX only on a match) rather than
+  // interpreting Lua. The script text itself was verified against a real
+  // Redis 7 out of band; see the round-2 section of the P4 report for the
+  // exact command and its output.
+  describe('cross-process guard (Redis epoch)', () => {
+    /** One shared "Redis server" that several isolated cache modules can talk to. */
+    function createSharedRedis() {
+      const store = new Map<string, string>();
+
+      const redis = {
+        store,
+        get: jest.fn(async (key: string) => store.get(key) ?? null),
+        setex: jest.fn(async (key: string, _ttl: number, value: string) => {
+          store.set(key, value);
+          return 'OK';
+        }),
+        del: jest.fn(async (...keys: string[]) => {
+          let deleted = 0;
+          for (const key of keys) if (store.delete(key)) deleted += 1;
+          return deleted;
+        }),
+        incr: jest.fn(async (key: string) => {
+          const next = Number(store.get(key) ?? '0') + 1;
+          store.set(key, String(next));
+          return next;
+        }),
+        expire: jest.fn(async (_key: string, _seconds: number) => 1),
+        pipeline: jest.fn(() => {
+          const queued: Array<() => Promise<unknown>> = [];
+          const chain = {
+            incr(key: string) {
+              queued.push(() => redis.incr(key));
+              return chain;
+            },
+            expire(key: string, seconds: number) {
+              queued.push(() => redis.expire(key, seconds));
+              return chain;
+            },
+            async exec() {
+              const results: Array<[null, unknown]> = [];
+              for (const op of queued) results.push([null, await op()]);
+              return results;
+            },
+          };
+          return chain;
+        }),
+        eval: jest.fn(
+          async (
+            _script: string,
+            _numKeys: number,
+            valueKey: string,
+            epochKey: string,
+            ttl: string,
+            value: string,
+            observedEpoch: string
+          ) => {
+            // Atomic by construction: one synchronous compare-and-set, which
+            // is exactly the property EVAL gives on a real server.
+            const current = store.get(epochKey) ?? '';
+            if (current !== observedEpoch) return 0;
+            store.set(valueKey, value);
+            return 1;
+          }
+        ),
+      };
+
+      return redis;
+    }
+
+    /**
+     * Load a FRESH copy of the cache module — its own module-level generation
+     * counter and invalidation log — bound to the shared Redis. This is what
+     * stands in for a separate serverless instance.
+     */
+    function loadCacheInstance(sharedRedis: unknown): typeof CacheModule {
+      let instance!: typeof CacheModule;
+
+      jest.isolateModules(() => {
+        const isolatedRedis = require('@/lib/redis/client') as typeof redisModule;
+        (isolatedRedis.getRedisClient as jest.Mock).mockReturnValue(sharedRedis);
+        (isolatedRedis.isRedisAvailable as jest.Mock).mockReturnValue(true);
+        instance = require('@/lib/cache/cache') as typeof CacheModule;
+      });
+
+      return instance;
+    }
+
+    function deferred() {
+      let resolve!: () => void;
+      const promise = new Promise<void>(r => {
+        resolve = r;
+      });
+      return { promise, resolve };
+    }
+
+    const RULES_KEY = 'alert:rules:active';
+
+    it('should not let one instance resurrect a value another instance invalidated', async () => {
+      const shared = createSharedRedis();
+      const instanceA = loadCacheInstance(shared);
+      const instanceB = loadCacheInstance(shared);
+
+      // Genuinely separate module state, or this test proves nothing.
+      expect(instanceA).not.toBe(instanceB);
+
+      const fetchStarted = deferred();
+      const release = deferred();
+
+      // A: the value read misses, A snapshots the epoch, A starts fetching the
+      // pre-mutation rule set.
+      const inFlight = instanceA.getOrSet(
+        RULES_KEY,
+        async () => {
+          fetchStarted.resolve();
+          await release.promise;
+          return [{ _id: 'rule_1', enabled: true }];
+        },
+        { ttl: 60 }
+      );
+      await fetchStarted.promise;
+
+      // B: a different instance disables the rule and invalidates.
+      await instanceB.del(RULES_KEY);
+
+      // A completes and tries to publish what it loaded.
+      release.resolve();
+      const stale = await inFlight;
+      expect(stale).toEqual([{ _id: 'rule_1', enabled: true }]);
+      await new Promise(resolve => setImmediate(resolve));
+
+      // THE assertion: the stale value never landed. Not "landed and then
+      // expired". Stated first so it is what fails if the guard regresses,
+      // rather than the corroborating detail below.
+      expect(shared.store.has(RULES_KEY)).toBe(false);
+
+      // Corroboration: A's own generation counter never saw B's invalidation,
+      // so A really did reach the commit and was refused there. Without this,
+      // a test that passed because layer 1 happened to fire would look
+      // identical, and the cross-process property would be untested.
+      expect(shared.eval).toHaveBeenCalledTimes(1);
+      await expect(shared.eval.mock.results[0].value).resolves.toBe(0);
+    });
+
+    it('should let an instance commit when no other instance invalidated', async () => {
+      const shared = createSharedRedis();
+      const instanceA = loadCacheInstance(shared);
+      loadCacheInstance(shared);
+
+      const value = await instanceA.getOrSet(RULES_KEY, async () => [{ _id: 'rule_1' }], {
+        ttl: 60,
+      });
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(value).toEqual([{ _id: 'rule_1' }]);
+      expect(shared.store.get(RULES_KEY)).toBe(JSON.stringify([{ _id: 'rule_1' }]));
+    });
+
+    it('should keep refusing across repeated invalidations, not just the first', async () => {
+      const shared = createSharedRedis();
+      const instanceA = loadCacheInstance(shared);
+      const instanceB = loadCacheInstance(shared);
+
+      for (let round = 0; round < 3; round += 1) {
+        const fetchStarted = deferred();
+        const release = deferred();
+
+        const inFlight = instanceA.getOrSet(
+          RULES_KEY,
+          async () => {
+            fetchStarted.resolve();
+            await release.promise;
+            return [{ round }];
+          },
+          { ttl: 60 }
+        );
+        await fetchStarted.promise;
+        await instanceB.del(RULES_KEY);
+        release.resolve();
+        await inFlight;
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(shared.store.has(RULES_KEY)).toBe(false);
+      }
+
+      // Three invalidations, three monotonically increasing epochs.
+      expect(shared.store.get(`${RULES_KEY}::epoch`)).toBe('3');
     });
   });
 

--- a/__tests__/unit/lib/cacheInvalidation.test.ts
+++ b/__tests__/unit/lib/cacheInvalidation.test.ts
@@ -13,6 +13,7 @@ import {
   invalidateHealthCache,
   invalidateMetadata,
   clearAllCaches,
+  invalidateAlertRules,
 } from '@/lib/cache/invalidation';
 import * as cacheModule from '@/lib/cache/cache';
 
@@ -31,6 +32,7 @@ jest.mock('@/lib/cache/keys', () => ({
   metadataPattern: jest.fn((orgId: string) => `org:${orgId}:metadata:*`),
   healthPattern: jest.fn((orgId: string) => `org:${orgId}:health:*`),
   readingsPattern: jest.fn((orgId: string) => `org:${orgId}:readings:latest:*`),
+  alertRulesKey: jest.fn(() => 'alert:rules:active'),
 }));
 
 // Mock logger to suppress output during tests
@@ -177,6 +179,24 @@ describe('Cache Invalidation', () => {
       (cacheModule.delPattern as jest.Mock).mockRejectedValueOnce(new Error('Redis error'));
 
       await expect(invalidateMetadata(TEST_ORG)).resolves.not.toThrow();
+    });
+  });
+
+  // ==========================================================================
+  // ALERT RULE INVALIDATION
+  // ==========================================================================
+
+  describe('invalidateAlertRules()', () => {
+    it('should invalidate the active alert rule cache', async () => {
+      await invalidateAlertRules();
+
+      expect(cacheModule.del).toHaveBeenCalledWith('alert:rules:active');
+    });
+
+    it('should handle errors gracefully', async () => {
+      (cacheModule.del as jest.Mock).mockRejectedValueOnce(new Error('Redis error'));
+
+      await expect(invalidateAlertRules()).resolves.not.toThrow();
     });
   });
 

--- a/__tests__/unit/lib/cacheKeys.test.ts
+++ b/__tests__/unit/lib/cacheKeys.test.ts
@@ -18,6 +18,7 @@ import {
   healthPattern,
   readingsPattern,
   analyticsPattern,
+  alertRulesKey,
 } from '@/lib/cache/keys';
 
 const TEST_ORG = 'org_test_123';
@@ -213,6 +214,23 @@ describe('Cache Keys', () => {
       const pattern2 = devicePattern('org_b');
 
       expect(pattern1).not.toBe(pattern2);
+    });
+  });
+
+  // ==========================================================================
+  // Alert Rules Key
+  // ==========================================================================
+
+  describe('alertRulesKey', () => {
+    it('should generate a global key with no org prefix', () => {
+      expect(alertRulesKey()).toBe('alert:rules:active');
+    });
+
+    it('should not accept or embed an org id', () => {
+      // The cron path authenticates with SEED_SECRET and has no Clerk context, so
+      // there is no orgId to compute. Deliberate departure from orgPrefix.
+      expect(alertRulesKey.length).toBe(0);
+      expect(alertRulesKey()).not.toContain('org:');
     });
   });
 });

--- a/__tests__/unit/lib/metrics.test.ts
+++ b/__tests__/unit/lib/metrics.test.ts
@@ -14,6 +14,8 @@ import {
   getMetricsSnapshot,
   getPrometheusMetrics,
   resetMetrics,
+  recordAlert,
+  recordAlertEvaluationDuration,
 } from '@/lib/monitoring/metrics';
 
 describe('Metrics Collection', () => {
@@ -462,6 +464,60 @@ describe('Metrics Collection', () => {
       expect(cache.misses).toBe(0);
       expect(ingestion.total).toBe(0);
       expect(database.queryCount).toBe(0);
+    });
+  });
+
+  // ==========================================================================
+  // ALERTING METRICS
+  // ==========================================================================
+
+  describe('recordAlert', () => {
+    beforeEach(() => {
+      resetMetrics();
+    });
+
+    it('should count fired alerts by severity', () => {
+      recordAlert('fired', { severity: 'critical' });
+      recordAlert('fired', { severity: 'critical' });
+      recordAlert('fired', { severity: 'warning' });
+
+      const prom = getPrometheusMetrics();
+
+      expect(prom).toContain('alerts_fired_total{severity="critical"} 2');
+      expect(prom).toContain('alerts_fired_total{severity="warning"} 1');
+    });
+
+    it('should count resolved alerts by resolution', () => {
+      recordAlert('resolved', { resolution: 'auto' });
+      recordAlert('resolved', { resolution: 'stale' });
+
+      const prom = getPrometheusMetrics();
+
+      expect(prom).toContain('alerts_resolved_total{resolution="auto"} 1');
+      expect(prom).toContain('alerts_resolved_total{resolution="stale"} 1');
+    });
+
+    it('should count evaluation errors', () => {
+      recordAlert('evaluation_error');
+
+      expect(getPrometheusMetrics()).toContain('alert_evaluation_errors_total 1');
+    });
+
+    it('should record evaluation duration as a histogram', () => {
+      recordAlertEvaluationDuration(12);
+      recordAlertEvaluationDuration(20);
+
+      const prom = getPrometheusMetrics();
+
+      expect(prom).toContain('alert_evaluation_duration_ms_count 2');
+      expect(prom).toContain('alert_evaluation_duration_ms_sum 32');
+    });
+
+    it('should be reset by resetMetrics', () => {
+      recordAlert('fired', { severity: 'info' });
+      resetMetrics();
+
+      expect(getPrometheusMetrics()).not.toContain('alerts_fired_total{severity="info"}');
     });
   });
 });

--- a/__tests__/unit/lib/metrics.test.ts
+++ b/__tests__/unit/lib/metrics.test.ts
@@ -16,6 +16,7 @@ import {
   resetMetrics,
   recordAlert,
   recordAlertEvaluationDuration,
+  recordAlertRuleSkipped,
 } from '@/lib/monitoring/metrics';
 
 describe('Metrics Collection', () => {
@@ -450,6 +451,7 @@ describe('Metrics Collection', () => {
       recordAlert('fired', { severity: 'critical' });
       recordAlert('evaluation_error');
       recordAlertEvaluationDuration(15);
+      recordAlertRuleSkipped('unknown_metric');
 
       // Reset
       resetMetrics();
@@ -471,6 +473,7 @@ describe('Metrics Collection', () => {
       expect(database.queryCount).toBe(0);
       expect(alerts.fired).toEqual({});
       expect(alerts.resolved).toEqual({});
+      expect(alerts.rulesSkipped).toEqual({});
       expect(alerts.evaluationErrors).toBe(0);
       expect(alerts.avgEvaluationDuration).toBe(0);
     });
@@ -559,6 +562,43 @@ describe('Metrics Collection', () => {
       expect(getPrometheusMetrics()).not.toContain('alerts_fired_total{severity="info"}');
       expect(alerts.evaluationErrors).toBe(0);
       expect(alerts.avgEvaluationDuration).toBe(0);
+    });
+  });
+
+  describe('recordAlertRuleSkipped', () => {
+    beforeEach(() => {
+      resetMetrics();
+    });
+
+    it('should count skipped rules by reason', () => {
+      recordAlertRuleSkipped('unknown_metric');
+      recordAlertRuleSkipped('unknown_metric');
+      recordAlertRuleSkipped('invalid_rule_id');
+
+      const prom = getPrometheusMetrics();
+
+      expect(prom).toContain('alert_rules_skipped_total{reason="unknown_metric"} 2');
+      expect(prom).toContain('alert_rules_skipped_total{reason="invalid_rule_id"} 1');
+    });
+
+    it('should expose skipped rule counts via getMetricsSnapshot()', () => {
+      recordAlertRuleSkipped('unexpected_error');
+
+      const snapshot = getMetricsSnapshot();
+      const alerts = snapshot.alerts as Record<string, unknown>;
+      const rulesSkipped = alerts.rulesSkipped as Record<string, number>;
+
+      expect(rulesSkipped.unexpected_error).toBe(1);
+    });
+
+    it('should be reset by resetMetrics', () => {
+      recordAlertRuleSkipped('invalid_rule_id');
+
+      resetMetrics();
+
+      expect(getPrometheusMetrics()).not.toContain(
+        'alert_rules_skipped_total{reason="invalid_rule_id"}'
+      );
     });
   });
 });

--- a/__tests__/unit/lib/metrics.test.ts
+++ b/__tests__/unit/lib/metrics.test.ts
@@ -304,6 +304,7 @@ describe('Metrics Collection', () => {
       expect(snapshot).toHaveProperty('cache');
       expect(snapshot).toHaveProperty('ingestion');
       expect(snapshot).toHaveProperty('database');
+      expect(snapshot).toHaveProperty('alerts');
       expect(snapshot).toHaveProperty('timestamp');
     });
 
@@ -446,6 +447,9 @@ describe('Metrics Collection', () => {
       recordCacheEvent('hit');
       recordIngestion(100, 0);
       recordDatabaseQuery(50);
+      recordAlert('fired', { severity: 'critical' });
+      recordAlert('evaluation_error');
+      recordAlertEvaluationDuration(15);
 
       // Reset
       resetMetrics();
@@ -456,6 +460,7 @@ describe('Metrics Collection', () => {
       const cache = snapshot.cache as Record<string, number | string>;
       const ingestion = snapshot.ingestion as Record<string, number | string>;
       const database = snapshot.database as Record<string, number>;
+      const alerts = snapshot.alerts as Record<string, unknown>;
 
       expect(requests.latency).toEqual({});
       expect(requests.counts).toEqual({});
@@ -464,6 +469,10 @@ describe('Metrics Collection', () => {
       expect(cache.misses).toBe(0);
       expect(ingestion.total).toBe(0);
       expect(database.queryCount).toBe(0);
+      expect(alerts.fired).toEqual({});
+      expect(alerts.resolved).toEqual({});
+      expect(alerts.evaluationErrors).toBe(0);
+      expect(alerts.avgEvaluationDuration).toBe(0);
     });
   });
 
@@ -513,11 +522,43 @@ describe('Metrics Collection', () => {
       expect(prom).toContain('alert_evaluation_duration_ms_sum 32');
     });
 
+    it('should expose fired/resolved counts and average duration via getMetricsSnapshot()', () => {
+      recordAlert('fired', { severity: 'critical' });
+      recordAlert('fired', { severity: 'critical' });
+      recordAlert('resolved', { resolution: 'auto' });
+      recordAlertEvaluationDuration(10);
+      recordAlertEvaluationDuration(30);
+
+      const snapshot = getMetricsSnapshot();
+      const alerts = snapshot.alerts as Record<string, unknown>;
+      const fired = alerts.fired as Record<string, number>;
+      const resolved = alerts.resolved as Record<string, number>;
+
+      expect(fired.critical).toBe(2);
+      expect(resolved.auto).toBe(1);
+      expect(alerts.avgEvaluationDuration).toBe(20); // (10 + 30) / 2
+    });
+
+    it('should return 0 average evaluation duration when none recorded', () => {
+      const snapshot = getMetricsSnapshot();
+      const alerts = snapshot.alerts as Record<string, unknown>;
+
+      expect(alerts.avgEvaluationDuration).toBe(0);
+    });
+
     it('should be reset by resetMetrics', () => {
       recordAlert('fired', { severity: 'info' });
+      recordAlert('evaluation_error');
+      recordAlertEvaluationDuration(42);
+
       resetMetrics();
 
+      const snapshot = getMetricsSnapshot();
+      const alerts = snapshot.alerts as Record<string, unknown>;
+
       expect(getPrometheusMetrics()).not.toContain('alerts_fired_total{severity="info"}');
+      expect(alerts.evaluationErrors).toBe(0);
+      expect(alerts.avgEvaluationDuration).toBe(0);
     });
   });
 });

--- a/__tests__/unit/lib/pusher-alerts.test.tsx
+++ b/__tests__/unit/lib/pusher-alerts.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * usePusherAlerts Tests
+ */
+
+import { render, act } from '@testing-library/react';
+import React from 'react';
+import { PusherProvider, usePusherAlerts } from '@/lib/pusher-context';
+import { getPusherClient } from '@/lib/pusher-client';
+import type { AlertEvent } from '@/types/v2/alert.types';
+
+const handlers = new Map<string, (data: unknown) => void>();
+const unbind = jest.fn();
+const unsubscribe = jest.fn();
+
+jest.mock('@/lib/pusher-client', () => ({
+  getPusherClient: jest.fn(() => ({
+    subscribe: jest.fn(() => ({
+      bind: (event: string, handler: (data: unknown) => void) => {
+        handlers.set(event, handler);
+      },
+      unbind: (event: string) => {
+        unbind(event);
+        handlers.delete(event);
+      },
+    })),
+    unsubscribe,
+  })),
+}));
+
+function Consumer({ onEvent }: { onEvent: (e: AlertEvent) => void }) {
+  usePusherAlerts(onEvent);
+  return null;
+}
+
+beforeEach(() => {
+  handlers.clear();
+  unbind.mockClear();
+  unsubscribe.mockClear();
+  (getPusherClient as jest.Mock).mockClear();
+});
+
+describe('usePusherAlerts', () => {
+  it('should bind the alert-event name', () => {
+    render(
+      <PusherProvider>
+        <Consumer onEvent={jest.fn()} />
+      </PusherProvider>
+    );
+
+    expect(handlers.has('alert-event')).toBe(true);
+  });
+
+  it('should deliver a fired envelope to subscribers', () => {
+    const onEvent = jest.fn();
+    render(
+      <PusherProvider>
+        <Consumer onEvent={onEvent} />
+      </PusherProvider>
+    );
+
+    const envelope: AlertEvent = { kind: 'fired', alerts: [] };
+    act(() => handlers.get('alert-event')!(envelope));
+
+    expect(onEvent).toHaveBeenCalledWith(envelope);
+  });
+
+  it('should deliver a storm envelope', () => {
+    const onEvent = jest.fn();
+    render(
+      <PusherProvider>
+        <Consumer onEvent={onEvent} />
+      </PusherProvider>
+    );
+
+    const envelope: AlertEvent = {
+      kind: 'storm',
+      of: 'fired',
+      count: 312,
+      by_severity: { info: 0, warning: 12, critical: 300 },
+      since: '2026-08-01T12:00:00.000Z',
+    };
+    act(() => handlers.get('alert-event')!(envelope));
+
+    expect(onEvent).toHaveBeenCalledWith(envelope);
+  });
+
+  it('should not break the readings subscription', () => {
+    render(
+      <PusherProvider>
+        <Consumer onEvent={jest.fn()} />
+      </PusherProvider>
+    );
+
+    expect(handlers.has('new-readings')).toBe(true);
+  });
+
+  it('should unbind both events on unmount', () => {
+    const { unmount } = render(
+      <PusherProvider>
+        <Consumer onEvent={jest.fn()} />
+      </PusherProvider>
+    );
+
+    unmount();
+
+    expect(unbind).toHaveBeenCalledWith('alert-event');
+    expect(unbind).toHaveBeenCalledWith('new-readings');
+    expect(unsubscribe).toHaveBeenCalledWith('InfraSight');
+  });
+
+  it('should stop delivering after a subscriber unmounts', () => {
+    const onEvent = jest.fn();
+    function Toggle({ show }: { show: boolean }) {
+      return (
+        <PusherProvider>{show ? <Consumer onEvent={onEvent} /> : null}</PusherProvider>
+      );
+    }
+
+    const { rerender } = render(<Toggle show />);
+    rerender(<Toggle show={false} />);
+
+    act(() => handlers.get('alert-event')?.({ kind: 'fired', alerts: [] }));
+
+    expect(onEvent).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/unit/lib/pusher-alerts.test.tsx
+++ b/__tests__/unit/lib/pusher-alerts.test.tsx
@@ -1,56 +1,151 @@
 /**
- * usePusherAlerts Tests
+ * PusherProvider realtime boundary tests.
+ *
+ * Two things are under test here and they are easy to confuse:
+ *
+ * 1. CHANNEL SPLIT. Readings stay on the public `InfraSight` channel (the
+ *    simulate route publishes there by that name and predates alerting);
+ *    alerts move to the `private-alerts` channel, whose `private-` prefix is
+ *    what forces pusher-js through /api/pusher/auth. A test that only checked
+ *    "alert-event is bound somewhere" would pass against the leaky
+ *    single-public-channel arrangement this replaced, so the assertions below
+ *    are about WHICH channel each event is bound to.
+ *
+ * 2. CONNECTION HEALTH. A dead socket and a quiet building look identical on
+ *    screen. The provider therefore has to distinguish connecting (normal, say
+ *    nothing) from unavailable/failed/unauthorized (degraded, say so), and a
+ *    terminal Pusher close code from a retryable blip.
  */
 
 import { render, act } from '@testing-library/react';
 import React from 'react';
-import { PusherProvider, usePusherAlerts } from '@/lib/pusher-context';
+import {
+  PusherProvider,
+  usePusherAlerts,
+  useRealtimeConnection,
+  type RealtimeConnection,
+} from '@/lib/pusher-context';
+import { ALERT_CHANNEL, READINGS_CHANNEL } from '@/lib/pusher-channels';
 import { getPusherClient } from '@/lib/pusher-client';
 import type { AlertEvent } from '@/types/v2/alert.types';
 
-const handlers = new Map<string, (data: unknown) => void>();
+type Handler = (data?: unknown) => void;
+
+/** Handlers keyed `channel:event`, so a test can assert WHERE a bind landed. */
+const handlers = new Map<string, Handler>();
+const connectionHandlers = new Map<string, Handler>();
 const unbind = jest.fn();
 const unsubscribe = jest.fn();
+let socketState = 'initialized';
 
 jest.mock('@/lib/pusher-client', () => ({
-  getPusherClient: jest.fn(() => ({
-    subscribe: jest.fn(() => ({
-      bind: (event: string, handler: (data: unknown) => void) => {
-        handlers.set(event, handler);
+  getPusherClient: jest.fn(),
+}));
+
+function makeClient() {
+  return {
+    subscribe: (channelName: string) => ({
+      subscribed: false,
+      bind: (event: string, handler: Handler) => {
+        handlers.set(`${channelName}:${event}`, handler);
       },
       unbind: (event: string) => {
-        unbind(event);
-        handlers.delete(event);
+        unbind(`${channelName}:${event}`);
+        handlers.delete(`${channelName}:${event}`);
       },
-    })),
+    }),
     unsubscribe,
-  })),
-}));
+    connection: {
+      get state() {
+        return socketState;
+      },
+      bind: (event: string, handler: Handler) => {
+        connectionHandlers.set(event, handler);
+      },
+      unbind: (event: string) => {
+        connectionHandlers.delete(event);
+      },
+    },
+  };
+}
 
 function Consumer({ onEvent }: { onEvent: (e: AlertEvent) => void }) {
   usePusherAlerts(onEvent);
   return null;
 }
 
+/**
+ * Publishes the live connection value so assertions can read it directly.
+ * Written from an effect rather than during render — assigning to a module
+ * variable mid-render is a side effect React makes no promises about.
+ */
+let latestConnection: RealtimeConnection | null = null;
+function ConnectionProbe() {
+  const connection = useRealtimeConnection();
+  React.useEffect(() => {
+    latestConnection = connection;
+  }, [connection]);
+  return null;
+}
+
+/** Drives the socket through pusher-js's own state_change event. */
+function moveSocketTo(state: string) {
+  socketState = state;
+  act(() => connectionHandlers.get('state_change')?.({ current: state }));
+}
+
+function renderProvider() {
+  return render(
+    <PusherProvider>
+      <Consumer onEvent={jest.fn()} />
+      <ConnectionProbe />
+    </PusherProvider>
+  );
+}
+
 beforeEach(() => {
   handlers.clear();
+  connectionHandlers.clear();
   unbind.mockClear();
   unsubscribe.mockClear();
-  (getPusherClient as jest.Mock).mockClear();
+  latestConnection = null;
+  socketState = 'initialized';
+  (getPusherClient as jest.Mock).mockReset();
+  (getPusherClient as jest.Mock).mockImplementation(() => makeClient());
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
 });
 
-describe('usePusherAlerts', () => {
-  it('should bind the alert-event name', () => {
-    render(
-      <PusherProvider>
-        <Consumer onEvent={jest.fn()} />
-      </PusherProvider>
-    );
+afterEach(() => {
+  jest.restoreAllMocks();
+});
 
-    expect(handlers.has('alert-event')).toBe(true);
+describe('channel split', () => {
+  it('keeps the alert channel private', () => {
+    // If this ever loses its prefix, pusher-js stops calling /api/pusher/auth
+    // and the whole authorization story silently evaporates.
+    expect(ALERT_CHANNEL.startsWith('private-')).toBe(true);
   });
 
-  it('should deliver a fired envelope to subscribers', () => {
+  it('leaves readings on the public channel the simulate route publishes to', () => {
+    expect(READINGS_CHANNEL).toBe('InfraSight');
+  });
+
+  it('binds alert-event on the PRIVATE channel, not the readings channel', () => {
+    renderProvider();
+
+    expect(handlers.has(`${ALERT_CHANNEL}:alert-event`)).toBe(true);
+    expect(handlers.has(`${READINGS_CHANNEL}:alert-event`)).toBe(false);
+  });
+
+  it('binds new-readings on the PUBLIC channel, not the alert channel', () => {
+    renderProvider();
+
+    expect(handlers.has(`${READINGS_CHANNEL}:new-readings`)).toBe(true);
+    expect(handlers.has(`${ALERT_CHANNEL}:new-readings`)).toBe(false);
+  });
+
+  it('delivers a fired envelope to subscribers', () => {
     const onEvent = jest.fn();
     render(
       <PusherProvider>
@@ -59,12 +154,12 @@ describe('usePusherAlerts', () => {
     );
 
     const envelope: AlertEvent = { kind: 'fired', alerts: [] };
-    act(() => handlers.get('alert-event')!(envelope));
+    act(() => handlers.get(`${ALERT_CHANNEL}:alert-event`)!(envelope));
 
     expect(onEvent).toHaveBeenCalledWith(envelope);
   });
 
-  it('should deliver a storm envelope', () => {
+  it('delivers a storm envelope', () => {
     const onEvent = jest.fn();
     render(
       <PusherProvider>
@@ -79,48 +174,160 @@ describe('usePusherAlerts', () => {
       by_severity: { info: 0, warning: 12, critical: 300 },
       since: '2026-08-01T12:00:00.000Z',
     };
-    act(() => handlers.get('alert-event')!(envelope));
+    act(() => handlers.get(`${ALERT_CHANNEL}:alert-event`)!(envelope));
 
     expect(onEvent).toHaveBeenCalledWith(envelope);
   });
 
-  it('should not break the readings subscription', () => {
-    render(
-      <PusherProvider>
-        <Consumer onEvent={jest.fn()} />
-      </PusherProvider>
-    );
-
-    expect(handlers.has('new-readings')).toBe(true);
-  });
-
-  it('should unbind both events on unmount', () => {
-    const { unmount } = render(
-      <PusherProvider>
-        <Consumer onEvent={jest.fn()} />
-      </PusherProvider>
-    );
+  it('unbinds both events and unsubscribes both channels on unmount', () => {
+    const { unmount } = renderProvider();
 
     unmount();
 
-    expect(unbind).toHaveBeenCalledWith('alert-event');
-    expect(unbind).toHaveBeenCalledWith('new-readings');
-    expect(unsubscribe).toHaveBeenCalledWith('InfraSight');
+    expect(unbind).toHaveBeenCalledWith(`${ALERT_CHANNEL}:alert-event`);
+    expect(unbind).toHaveBeenCalledWith(`${READINGS_CHANNEL}:new-readings`);
+    expect(unsubscribe).toHaveBeenCalledWith(READINGS_CHANNEL);
+    expect(unsubscribe).toHaveBeenCalledWith(ALERT_CHANNEL);
   });
 
-  it('should stop delivering after a subscriber unmounts', () => {
+  it('unbinds the connection handlers on unmount', () => {
+    const { unmount } = renderProvider();
+    expect(connectionHandlers.has('state_change')).toBe(true);
+
+    unmount();
+
+    expect(connectionHandlers.has('state_change')).toBe(false);
+    expect(connectionHandlers.has('error')).toBe(false);
+  });
+
+  it('stops delivering after a subscriber unmounts', () => {
     const onEvent = jest.fn();
     function Toggle({ show }: { show: boolean }) {
-      return (
-        <PusherProvider>{show ? <Consumer onEvent={onEvent} /> : null}</PusherProvider>
-      );
+      return <PusherProvider>{show ? <Consumer onEvent={onEvent} /> : null}</PusherProvider>;
     }
 
     const { rerender } = render(<Toggle show />);
     rerender(<Toggle show={false} />);
 
-    act(() => handlers.get('alert-event')?.({ kind: 'fired', alerts: [] }));
+    act(() => handlers.get(`${ALERT_CHANNEL}:alert-event`)?.({ kind: 'fired', alerts: [] }));
 
     expect(onEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('connection health', () => {
+  /** Socket up AND the private channel accepted us. */
+  function reachHealthy() {
+    moveSocketTo('connected');
+    act(() => handlers.get(`${ALERT_CHANNEL}:pusher:subscription_succeeded`)?.());
+  }
+
+  it('reports connected once the socket is up and the private channel accepted', () => {
+    renderProvider();
+
+    reachHealthy();
+
+    expect(latestConnection).toMatchObject({
+      connected: true,
+      state: 'connected',
+      degraded: false,
+    });
+  });
+
+  it('is not connected, but also not degraded, while still connecting', () => {
+    renderProvider();
+
+    moveSocketTo('connecting');
+
+    // Nothing is wrong yet — a banner here would fire on every cold page load.
+    expect(latestConnection).toMatchObject({ connected: false, degraded: false });
+  });
+
+  it('goes degraded and retryable when the socket becomes unavailable', () => {
+    renderProvider();
+    reachHealthy();
+
+    moveSocketTo('unavailable');
+
+    expect(latestConnection).toMatchObject({
+      connected: false,
+      state: 'reconnecting',
+      degraded: true,
+      terminal: false,
+    });
+    expect(latestConnection!.message).toEqual(expect.any(String));
+  });
+
+  it('marks a terminal Pusher close code as failed and not self-healing', () => {
+    renderProvider();
+    reachHealthy();
+
+    // 4004 = quota exceeded. pusher-js will not retry a 4000-4099 close, so
+    // without this the app looks connected forever while receiving nothing.
+    act(() =>
+      connectionHandlers.get('error')?.({
+        error: { data: { code: 4004, message: 'over quota' } },
+      })
+    );
+
+    expect(latestConnection).toMatchObject({
+      connected: false,
+      state: 'failed',
+      degraded: true,
+      terminal: true,
+    });
+    expect(latestConnection!.message).toContain('4004');
+  });
+
+  it('treats a retryable close code as a blip, not a failure', () => {
+    renderProvider();
+    reachHealthy();
+
+    // 4100+ means "reconnect after a backoff" — pusher-js handles it itself.
+    act(() => connectionHandlers.get('error')?.({ error: { data: { code: 4200 } } }));
+
+    expect(latestConnection).toMatchObject({ connected: true, terminal: false });
+  });
+
+  it('goes unauthorized when the private alert channel refuses the subscription', () => {
+    renderProvider();
+    moveSocketTo('connected');
+
+    act(() =>
+      handlers.get(`${ALERT_CHANNEL}:pusher:subscription_error`)?.({ status: 403 })
+    );
+
+    // The socket itself is fine — readings keep flowing — but alerts are dead,
+    // which is precisely the case that must still drive the poll fallback.
+    expect(latestConnection).toMatchObject({
+      connected: false,
+      state: 'unauthorized',
+      degraded: true,
+    });
+  });
+
+  it('surfaces missing Pusher env vars as a degraded state, not just a console warning', () => {
+    (getPusherClient as jest.Mock).mockImplementation(() => {
+      throw new Error('Missing required Pusher environment variables.');
+    });
+
+    render(
+      <PusherProvider>
+        <ConnectionProbe />
+      </PusherProvider>
+    );
+
+    expect(latestConnection).toMatchObject({
+      connected: false,
+      state: 'not-configured',
+      degraded: true,
+      terminal: true,
+    });
+  });
+
+  it('reports not-connected with no provider in the tree', () => {
+    render(<ConnectionProbe />);
+
+    expect(latestConnection).toMatchObject({ connected: false, state: 'no-provider' });
   });
 });

--- a/__tests__/unit/lib/queryClient-alert-keys.test.ts
+++ b/__tests__/unit/lib/queryClient-alert-keys.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Alert / alert-rule query key invalidation coverage
+ *
+ * Guards a coupling that is load-bearing and completely invisible at the call
+ * site.
+ *
+ * Every alert and alert-rule mutation hook invalidates TWO keys — the specific
+ * `.detail(id)` and the broad `.all`:
+ *
+ *   onSuccess: (_, variables) => {
+ *     queryClient.invalidateQueries({ queryKey: queryKeys.alerts.detail(variables.id) });
+ *     queryClient.invalidateQueries({ queryKey: queryKeys.alerts.all });
+ *   }
+ *
+ * Today the second line makes the first redundant. `queryKeys.alerts.all` is
+ * `['alerts']`, `queryKeys.alerts.detail(id)` is `['alerts','detail',id]`, and
+ * React Query matches `invalidateQueries` by key PREFIX (`exact: false` is the
+ * default) — so invalidating `.all` already reaches every detail query. This
+ * was verified by mutation testing: deleting either `.detail(...)` line on its
+ * own leaves the whole alerting suite green, because its sibling covers it.
+ *
+ * The redundancy is not a property of the hooks. It is a property of the SHAPE
+ * OF THE KEYS in `lib/query/queryClient.ts`. Namespace them, or make `.all`
+ * something like `['alerts','root']`, and the relation silently inverts: `.all`
+ * stops covering `.detail`, the `.detail` lines become the only thing keeping
+ * an open detail pane honest, and nothing anywhere would say so. A subsystem
+ * that cannot tell you when it has stopped working is the failure mode this
+ * whole review is about, so it is pinned here rather than left implicit.
+ *
+ * Deliberately NOT a `jest.spyOn(queryClient, 'invalidateQueries')` assertion.
+ * Spying on the call and comparing it to the same constant the hook reads is
+ * tautological — it passes whether or not invalidating that key achieves
+ * anything. These tests assert the key relation itself and then exercise React
+ * Query's real matcher against it. The behavioural side (that the mutations
+ * actually refetch mounted queries) lives in `useAlerts.test.tsx` and
+ * `useAlertRules.test.tsx`.
+ */
+
+import { QueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/query/queryClient';
+
+/**
+ * Returns 'ok', or an explanation of what broke and what it now costs.
+ *
+ * A string rather than a boolean so the failure output carries its own
+ * briefing — `expect(covers).toBe(true)` would print "expected true, received
+ * false", which tells the next person nothing about which production lines
+ * just became load-bearing.
+ */
+function prefixCoverageDiagnosis(
+  namespace: string,
+  allKey: readonly unknown[],
+  detailKey: readonly unknown[]
+): string {
+  const covers =
+    allKey.length <= detailKey.length &&
+    allKey.every((segment, index) => Object.is(segment, detailKey[index]));
+
+  if (covers) return 'ok';
+
+  return (
+    `queryKeys.${namespace}.all (${JSON.stringify(allKey)}) is no longer a prefix of ` +
+    `queryKeys.${namespace}.detail(id) (${JSON.stringify(detailKey)}). ` +
+    'React Query matches invalidateQueries by key PREFIX, so the paired ' +
+    `invalidateQueries({ queryKey: queryKeys.${namespace}.all }) call in the mutation hooks NO ` +
+    'LONGER REACHES the detail query. The explicit ' +
+    `invalidateQueries({ queryKey: queryKeys.${namespace}.detail(...) }) calls in those hooks are ` +
+    'therefore now LOAD-BEARING — they were redundant only because of this prefix relation. ' +
+    'Do NOT remove them. Add a behavioural test that a mounted detail query refetches after ' +
+    'each mutation, then update this guard.'
+  );
+}
+
+/** Seeds a detail query, invalidates via `.all`, and reports whether it landed. */
+async function allInvalidationReachesDetail(
+  allKey: readonly unknown[],
+  detailKey: readonly unknown[]
+): Promise<boolean> {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  await client.fetchQuery({ queryKey: detailKey as unknown[], queryFn: async () => 'seeded' });
+  await client.invalidateQueries({ queryKey: allKey as unknown[] });
+
+  const detail = client.getQueryCache().find({ queryKey: detailKey as unknown[] });
+  return detail?.state.isInvalidated === true;
+}
+
+describe('queryKeys.alerts invalidation coverage', () => {
+  it('should keep alerts.all a prefix of alerts.detail(id)', () => {
+    expect(
+      prefixCoverageDiagnosis('alerts', queryKeys.alerts.all, queryKeys.alerts.detail('alert_1'))
+    ).toBe('ok');
+  });
+
+  /**
+   * The prefix check explains WHY; this asserts the property itself, through
+   * React Query's own matcher. It also fails if a React Query release changes
+   * how `invalidateQueries` matches — which a structural check would miss.
+   */
+  it('should have an alerts.all invalidation actually reach an alerts.detail query', async () => {
+    await expect(
+      allInvalidationReachesDetail(queryKeys.alerts.all, queryKeys.alerts.detail('alert_1'))
+    ).resolves.toBe(true);
+  });
+});
+
+describe('queryKeys.alertRules invalidation coverage', () => {
+  it('should keep alertRules.all a prefix of alertRules.detail(id)', () => {
+    expect(
+      prefixCoverageDiagnosis(
+        'alertRules',
+        queryKeys.alertRules.all,
+        queryKeys.alertRules.detail('rule_1')
+      )
+    ).toBe('ok');
+  });
+
+  it('should have an alertRules.all invalidation actually reach an alertRules.detail query', async () => {
+    await expect(
+      allInvalidationReachesDetail(
+        queryKeys.alertRules.all,
+        queryKeys.alertRules.detail('rule_1')
+      )
+    ).resolves.toBe(true);
+  });
+});

--- a/__tests__/unit/lib/realtime-polling.test.tsx
+++ b/__tests__/unit/lib/realtime-polling.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * Connection-state-aware poll fallback for the alert queries.
+ *
+ * The bug this covers is a screen that lies. When the Pusher socket dies —
+ * especially on a terminal close code (4004 quota, 4001 bad key) that never
+ * auto-reconnects — nothing refetches, `refetchOnWindowFocus` is false, and a
+ * wall display sits on "No open alerts." indefinitely while the building is on
+ * fire.
+ *
+ * The fix is deliberately NOT an unconditional interval, and both halves of
+ * that matter, so both are asserted here:
+ *   - socket down  -> poll, or the screen goes stale forever;
+ *   - socket up    -> do NOT poll, or every alert surface adds a request per
+ *                     30s that can only ever return what the socket already
+ *                     delivered.
+ *
+ * `useRealtimeConnection` is mocked because the point under test is the wiring
+ * between connection state and React Query, not how the state is computed —
+ * that lives in pusher-alerts.test.tsx.
+ */
+
+import React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  useAlertsList,
+  useOpenAlertCount,
+  REALTIME_FALLBACK_POLL_MS,
+} from '@/lib/query/hooks/useAlerts';
+import { useRealtimeConnection } from '@/lib/pusher-context';
+import { v2Api } from '@/lib/api/v2-client';
+
+jest.mock('@/lib/api/v2-client', () => ({
+  v2Api: {
+    alerts: { list: jest.fn() },
+  },
+}));
+
+jest.mock('@/lib/pusher-context', () => ({
+  useRealtimeConnection: jest.fn(),
+}));
+
+const mockConnection = useRealtimeConnection as jest.Mock;
+
+function setConnected(connected: boolean) {
+  mockConnection.mockReturnValue({
+    connected,
+    state: connected ? 'connected' : 'reconnecting',
+    degraded: !connected,
+    message: connected ? null : 'Lost the real-time connection.',
+    terminal: false,
+  });
+}
+
+/** Fresh client per render so cached data never leaks between rows. */
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client }, children);
+  return { client, wrapper };
+}
+
+/** The refetchInterval React Query actually resolved for the only live query. */
+function resolvedInterval(client: QueryClient): number | false | undefined {
+  const query = client.getQueryCache().getAll()[0];
+  return query?.observers[0]?.options.refetchInterval as number | false | undefined;
+}
+
+beforeEach(() => {
+  (v2Api.alerts.list as jest.Mock).mockResolvedValue({
+    data: [{ _id: 'a1' }],
+    pagination: { total: 1 },
+  });
+});
+
+describe('useAlertsList poll fallback', () => {
+  it('polls while the realtime connection is DOWN', async () => {
+    setConnected(false);
+    const { client, wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useAlertsList(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(resolvedInterval(client)).toBe(REALTIME_FALLBACK_POLL_MS);
+  });
+
+  it('does NOT poll while the realtime connection is UP', async () => {
+    setConnected(true);
+    const { client, wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useAlertsList(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(resolvedInterval(client)).toBe(false);
+  });
+
+  it('starts polling when a live connection drops', async () => {
+    setConnected(true);
+    const { client, wrapper } = makeWrapper();
+
+    const { result, rerender } = renderHook(() => useAlertsList(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(resolvedInterval(client)).toBe(false);
+
+    setConnected(false);
+    rerender();
+
+    expect(resolvedInterval(client)).toBe(REALTIME_FALLBACK_POLL_MS);
+  });
+
+  it('lets a caller override the interval, because config spreads last', async () => {
+    setConnected(false);
+    const { client, wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useAlertsList({}, { refetchInterval: 1234 }), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(resolvedInterval(client)).toBe(1234);
+  });
+});
+
+describe('useOpenAlertCount poll fallback', () => {
+  it('polls while the realtime connection is DOWN', async () => {
+    setConnected(false);
+    const { client, wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useOpenAlertCount(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(resolvedInterval(client)).toBe(REALTIME_FALLBACK_POLL_MS);
+  });
+
+  it('does NOT poll while the realtime connection is UP', async () => {
+    setConnected(true);
+    const { client, wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useOpenAlertCount(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(resolvedInterval(client)).toBe(false);
+  });
+});
+
+/**
+ * The rows above read the option React Query resolved; this one proves the
+ * option is actually wired to a timer that fires. A configuration assertion
+ * alone would pass against a `refetchInterval` React Query ignored.
+ */
+describe('poll fallback actually refetches', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('refetches after the interval elapses while disconnected', async () => {
+    setConnected(false);
+    const { wrapper } = makeWrapper();
+
+    renderHook(() => useAlertsList(), { wrapper });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(v2Api.alerts.list).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(REALTIME_FALLBACK_POLL_MS + 100);
+      await Promise.resolve();
+    });
+
+    expect((v2Api.alerts.list as jest.Mock).mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it('does not refetch on a timer while connected', async () => {
+    setConnected(true);
+    const { wrapper } = makeWrapper();
+
+    renderHook(() => useAlertsList(), { wrapper });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(v2Api.alerts.list).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(REALTIME_FALLBACK_POLL_MS * 4);
+      await Promise.resolve();
+    });
+
+    expect(v2Api.alerts.list).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/unit/lib/seed-alert-rules.test.ts
+++ b/__tests__/unit/lib/seed-alert-rules.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Seed Alert Rule Tests
+ *
+ * The seeded rule set is what makes Phase 4 visible on a fresh database, and it
+ * is also the fixture that proves optional selector.types is load-bearing.
+ */
+
+import AlertRuleV2 from '@/models/v2/AlertRuleV2';
+import { buildAlertRuleSeeds } from '@/scripts/v2/alert-rule-seeds';
+
+describe('buildAlertRuleSeeds', () => {
+  it('should produce four rules', () => {
+    expect(buildAlertRuleSeeds()).toHaveLength(4);
+  });
+
+  it('should include a duration-gated temperature rule', () => {
+    const rule = buildAlertRuleSeeds().find(r => r.selector.types?.includes('temperature'));
+
+    expect(rule).toBeDefined();
+    expect(rule!.metric).toBe('value');
+    expect(rule!.for_duration_seconds).toBe(300);
+  });
+
+  it('should include a fleet-wide low-battery rule with no selector.types', () => {
+    const rule = buildAlertRuleSeeds().find(r => r.metric === 'battery_level');
+
+    expect(rule).toBeDefined();
+    expect(rule!.selector.types).toBeUndefined();
+    expect(rule!.comparison).toBe('lt');
+  });
+
+  it('should include an anomaly_score rule bounded to 0-1', () => {
+    const rule = buildAlertRuleSeeds().find(r => r.metric === 'anomaly_score');
+
+    expect(rule).toBeDefined();
+    expect(rule!.threshold).toBeGreaterThanOrEqual(0);
+    expect(rule!.threshold).toBeLessThanOrEqual(1);
+  });
+
+  it('should give every value-metric rule a non-empty selector.types', () => {
+    for (const rule of buildAlertRuleSeeds())
+      if (rule.metric === 'value') expect(rule.selector.types!.length).toBeGreaterThan(0);
+  });
+
+  it('should produce rules the model accepts', async () => {
+    await AlertRuleV2.insertMany(buildAlertRuleSeeds());
+
+    expect(await AlertRuleV2.countDocuments({})).toBe(4);
+  });
+
+  // The test above proves little on its own: if Mongoose's insertMany silently
+  // dropped an invalid document instead of throwing, countDocuments could still
+  // read back something other than 4 and fail for an unrelated reason, or -
+  // worse - a partial insert could coincidentally still total 4 someday if the
+  // seed count changes. This test pins down the actual contract: insertMany is
+  // called with its default options (no `ordered: false`) everywhere in this
+  // module and in scripts/v2/seed-v2.ts, and under that default a single
+  // schema-violating document rejects the WHOLE batch, inserting nothing.
+  // Verified empirically against this repo's Mongoose version (see task report):
+  // with `{ ordered: false }` the same corrupted batch instead inserts the 3
+  // valid docs and silently drops the bad one - which is the exact failure mode
+  // this test exists to rule out for the real seed set.
+  it('should reject the whole batch, inserting nothing, if a seed violated the schema', async () => {
+    const corrupted: unknown[] = [
+      ...buildAlertRuleSeeds().slice(1),
+      { ...buildAlertRuleSeeds()[0], metric: 'not_a_real_metric' },
+    ];
+
+    await expect(AlertRuleV2.insertMany(corrupted)).rejects.toThrow(/validation failed/i);
+    expect(await AlertRuleV2.countDocuments({})).toBe(0);
+  });
+
+  // The "no selector.types" assertion above runs against the plain object
+  // buildAlertRuleSeeds() returns, which trivially has no `types` key - it
+  // proves nothing about what Mongoose does with it. AlertRuleV2 gives its
+  // selector array paths `default: undefined` specifically so persisting
+  // `selector: {}` does not silently turn into `selector: { types: [] }` (see
+  // models/v2/AlertRuleV2.ts). Only a real round trip through MongoDB, read
+  // back the same way the rule cache reads it (lib/alerting/rule-cache.ts uses
+  // `.lean()`), proves that override still holds for these exact seeds.
+  it('should keep a fleet-wide seed selector.types genuinely absent (not []) after a lean round trip', async () => {
+    await AlertRuleV2.insertMany(buildAlertRuleSeeds());
+
+    const persisted = await AlertRuleV2.findOne({ metric: 'battery_level' }).lean();
+
+    expect(persisted).not.toBeNull();
+    expect(persisted!.selector?.types).toBeUndefined();
+    expect(Array.isArray(persisted!.selector?.types)).toBe(false);
+  });
+
+  // Same claim, but through a hydrated (non-lean) document, which is the one
+  // read path where Mongoose actually reconstructs the `selector` subdocument
+  // via its schema default and would reveal an unguarded array path defaulting
+  // to `[]`. This is the version of the check that goes red if AlertRuleV2's
+  // `default: undefined` override on `types` is ever removed.
+  it('should keep selector.types undefined on a hydrated re-read of a fleet-wide seed too', async () => {
+    const [, , lowBattery] = buildAlertRuleSeeds();
+    expect(lowBattery.metric).toBe('battery_level');
+
+    await AlertRuleV2.insertMany([lowBattery]);
+    const rehydrated = await AlertRuleV2.findOne({ metric: 'battery_level' });
+
+    expect(rehydrated).not.toBeNull();
+    expect(rehydrated!.selector.types).toBeUndefined();
+    expect(Array.isArray(rehydrated!.selector.types)).toBe(false);
+  });
+});

--- a/__tests__/unit/lib/seed-alert-rules.test.ts
+++ b/__tests__/unit/lib/seed-alert-rules.test.ts
@@ -101,7 +101,7 @@ describe('buildAlertRuleSeeds', () => {
     const rehydrated = await AlertRuleV2.findOne({ metric: 'battery_level' });
 
     expect(rehydrated).not.toBeNull();
-    expect(rehydrated!.selector.types).toBeUndefined();
-    expect(Array.isArray(rehydrated!.selector.types)).toBe(false);
+    expect(rehydrated!.selector?.types).toBeUndefined();
+    expect(Array.isArray(rehydrated!.selector?.types)).toBe(false);
   });
 });

--- a/__tests__/unit/lib/sentry.test.ts
+++ b/__tests__/unit/lib/sentry.test.ts
@@ -1,16 +1,30 @@
 /**
  * Sentry Integration Tests
  *
- * Tests for optional Sentry error tracking and performance monitoring.
+ * These tests exist to catch one specific class of regression, so read the
+ * setup before adding to them.
+ *
+ * `lib/monitoring/sentry.ts` once gated every capture helper on a module-local
+ * flag that only `initSentry()` set. Production never calls `initSentry()` —
+ * Next.js initializes Sentry through `instrumentation.ts` ->
+ * `sentry.server.config.ts` — so every escalation in the app was dead code.
+ * The bug survived review because the tests here called `initSentry()`
+ * themselves before asserting, performing setup production never performs.
+ *
+ * So: the escalation tests below deliberately do NOT call `initSentry()`, and
+ * several of them assert `init` was never called, which is what makes them fail
+ * if the module-local gate is ever reintroduced. Do not "fix" a failing test in
+ * this file by adding an `initSentry()` call.
  */
 
-import {
-  isSentryConfigured,
-  initSentry,
-  withSentryErrorHandling,
-} from '@/lib/monitoring/sentry';
+// Type-only, so it is erased at compile time: the shim itself is loaded through
+// `loadShim()` below, which gives each test a module instance with pristine
+// internal state.
+import type * as SentryShimModule from '@/lib/monitoring/sentry';
 
-// Mock Sentry
+// Mock the real client. Every assertion below is against THIS module — the
+// singleton the Next.js config files initialize — not against any state
+// private to the shim.
 jest.mock('@sentry/nextjs', () => ({
   init: jest.fn(),
   captureException: jest.fn().mockReturnValue('event-id-123'),
@@ -24,12 +38,45 @@ jest.mock('@sentry/nextjs', () => ({
   }),
 }));
 
+type SentryShim = typeof SentryShimModule;
+
+interface SentryClientMock {
+  init: jest.Mock;
+  captureException: jest.Mock;
+  captureMessage: jest.Mock;
+  addBreadcrumb: jest.Mock;
+  setUser: jest.Mock;
+  setTag: jest.Mock;
+  setExtra: jest.Mock;
+  startInactiveSpan: jest.Mock;
+}
+
+/**
+ * Load a pristine copy of the shim plus the client instance it bound to.
+ *
+ * `jest.resetModules()` guarantees the shim's module-local state starts at its
+ * cold-boot value, so no earlier test in this file can leave it "initialized"
+ * and mask a reintroduced gate. The client must be required AFTER the shim so
+ * both resolve to the same freshly-built mock.
+ */
+function loadShim(): { shim: SentryShim; client: SentryClientMock } {
+  jest.resetModules();
+  const shim = require('@/lib/monitoring/sentry') as SentryShim;
+  const client = require('@sentry/nextjs') as unknown as SentryClientMock;
+  return { shim, client };
+}
+
+const DSN = 'https://key@sentry.io/project';
+
 describe('Sentry Integration', () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
     jest.clearAllMocks();
     process.env = { ...originalEnv };
+    // Explicit: a developer machine with a real DSN exported must not turn the
+    // "not configured" cases into false passes.
+    delete process.env.SENTRY_DSN;
   });
 
   afterAll(() => {
@@ -42,156 +89,199 @@ describe('Sentry Integration', () => {
 
   describe('isSentryConfigured()', () => {
     it('should return false when SENTRY_DSN is not set', () => {
-      delete process.env.SENTRY_DSN;
+      const { shim } = loadShim();
 
-      expect(isSentryConfigured()).toBe(false);
+      expect(shim.isSentryConfigured()).toBe(false);
     });
 
     it('should return true when SENTRY_DSN is set', () => {
-      process.env.SENTRY_DSN = 'https://key@sentry.io/project';
+      process.env.SENTRY_DSN = DSN;
+      const { shim } = loadShim();
 
-      expect(isSentryConfigured()).toBe(true);
+      expect(shim.isSentryConfigured()).toBe(true);
     });
 
     it('should return false for empty string', () => {
       process.env.SENTRY_DSN = '';
+      const { shim } = loadShim();
 
-      expect(isSentryConfigured()).toBe(false);
+      expect(shim.isSentryConfigured()).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // captureException() — THE ESCALATION PATH
+  //
+  // The load-bearing block. Every test here runs with a DSN configured and
+  // initSentry() never called, mirroring production exactly.
+  // ==========================================================================
+
+  describe('captureException() escalation', () => {
+    it('reaches the real @sentry/nextjs client with only a DSN set — initSentry() is not a precondition', () => {
+      process.env.SENTRY_DSN = DSN;
+      const { shim, client } = loadShim();
+
+      const error = new Error('evaluator exploded');
+      const result = shim.captureException(error);
+
+      // The two assertions have to hold together. `init` never being called is
+      // what proves the forward below did not depend on setup production skips:
+      // drop this and the test degrades into the one that shipped the bug.
+      expect(client.init).not.toHaveBeenCalled();
+      expect(client.captureException).toHaveBeenCalledTimes(1);
+      expect(client.captureException).toHaveBeenCalledWith(error, { extra: undefined });
+      expect(result).toBe('event-id-123');
+    });
+
+    it('forwards context as extra without any initialization of its own', () => {
+      process.env.SENTRY_DSN = DSN;
+      const { shim, client } = loadShim();
+
+      const error = new Error('Test error');
+      const context = { userId: '123', action: 'test' };
+      const result = shim.captureException(error, context);
+
+      expect(client.init).not.toHaveBeenCalled();
+      expect(client.captureException).toHaveBeenCalledWith(error, { extra: context });
+      expect(result).toBe('event-id-123');
+    });
+
+    it('forwards tags as a distinct top-level field, not folded into context', () => {
+      process.env.SENTRY_DSN = DSN;
+      const { shim, client } = loadShim();
+
+      const error = new Error('Test error');
+      const context = { readingsCount: 5 };
+      const tags = { subsystem: 'alerting' };
+      const result = shim.captureException(error, context, tags);
+
+      expect(result).toBe('event-id-123');
+      expect(client.init).not.toHaveBeenCalled();
+      // Full-shape match, not objectContaining: `tags` must be its own
+      // top-level key alongside `extra`. Sentry only indexes a top-level `tags`
+      // key as a filterable facet — nesting it under `extra` (the bug this test
+      // guards) silently downgrades it to unfilterable "Additional Data".
+      expect(client.captureException).toHaveBeenCalledWith(error, {
+        extra: context,
+        tags,
+      });
+
+      // Stated the other way round too, so a `{ extra: { ...context, tags } }`
+      // regression fails on the specific thing that is wrong with it rather
+      // than on a whole-object diff.
+      const [, options] = client.captureException.mock.calls[0];
+      expect(options.tags).toEqual(tags);
+      expect(options.extra).toEqual(context);
+      expect(Object.prototype.hasOwnProperty.call(options.extra, 'tags')).toBe(false);
+    });
+
+    it('omits the tags key entirely when no tags are passed', () => {
+      process.env.SENTRY_DSN = DSN;
+      const { shim, client } = loadShim();
+
+      shim.captureException(new Error('Test error'), { userId: '123' });
+
+      const [, options] = client.captureException.mock.calls[0];
+      expect(Object.prototype.hasOwnProperty.call(options, 'tags')).toBe(false);
+    });
+
+    it('reads the DSN gate per call, not once at module load', () => {
+      // The shim is loaded with no DSN, then the DSN appears. Nothing may be
+      // cached at import time: serverless cold starts and test harnesses both
+      // populate env after modules resolve.
+      const { shim, client } = loadShim();
+      expect(shim.captureException(new Error('too early'))).toBeUndefined();
+
+      process.env.SENTRY_DSN = DSN;
+
+      expect(shim.captureException(new Error('now configured'))).toBe('event-id-123');
+      expect(client.captureException).toHaveBeenCalledTimes(1);
+    });
+
+    it('is a no-op that returns undefined when no DSN is configured', () => {
+      const { shim, client } = loadShim();
+
+      const result = shim.captureException(new Error('Test error'), { userId: '123' });
+
+      expect(result).toBeUndefined();
+      expect(client.captureException).not.toHaveBeenCalled();
     });
   });
 
   // ==========================================================================
   // initSentry()
+  //
+  // Still exported (and re-exported from lib/monitoring/index.ts) for entry
+  // points that are not Next.js request handlers. It is no longer a
+  // precondition for anything above.
   // ==========================================================================
 
   describe('initSentry()', () => {
     it('should return false when SENTRY_DSN is not set', async () => {
-      delete process.env.SENTRY_DSN;
+      const { shim, client } = loadShim();
 
-      const result = await initSentry();
-
-      expect(result).toBe(false);
+      await expect(shim.initSentry()).resolves.toBe(false);
+      expect(client.init).not.toHaveBeenCalled();
     });
 
     it('should initialize Sentry when DSN is configured', async () => {
-      process.env.SENTRY_DSN = 'https://key@sentry.io/project';
+      process.env.SENTRY_DSN = DSN;
+      const { shim, client } = loadShim();
 
-      const result = await initSentry();
-
-      expect(result).toBe(true);
-      const Sentry = require('@sentry/nextjs');
-      expect(Sentry.init).toHaveBeenCalledWith(
+      await expect(shim.initSentry()).resolves.toBe(true);
+      expect(client.init).toHaveBeenCalledWith(
         expect.objectContaining({
-          dsn: 'https://key@sentry.io/project',
+          dsn: DSN,
         })
       );
     });
 
-    it('should return true on subsequent calls (already initialized)', async () => {
-      process.env.SENTRY_DSN = 'https://key@sentry.io/project';
+    it('should be idempotent — a second call does not re-init', async () => {
+      process.env.SENTRY_DSN = DSN;
+      const { shim, client } = loadShim();
 
-      await initSentry();
-      const result = await initSentry();
+      await shim.initSentry();
+      await expect(shim.initSentry()).resolves.toBe(true);
 
-      expect(result).toBe(true);
+      expect(client.init).toHaveBeenCalledTimes(1);
     });
 
     it('should use production sample rate in production', async () => {
-      process.env.SENTRY_DSN = 'https://key@sentry.io/project';
+      process.env.SENTRY_DSN = DSN;
       (process.env as Record<string, string | undefined>).NODE_ENV = 'production';
+      const { shim, client } = loadShim();
 
-      // Reset module to get fresh initialization
-      jest.resetModules();
-      const { initSentry: init } = require('@/lib/monitoring/sentry');
+      await shim.initSentry();
 
-      await init();
-
-      const Sentry = require('@sentry/nextjs');
-      expect(Sentry.init).toHaveBeenCalledWith(
+      expect(client.init).toHaveBeenCalledWith(
         expect.objectContaining({
           tracesSampleRate: 0.1,
         })
       );
     });
-  });
 
-  // ==========================================================================
-  // captureException()
-  // ==========================================================================
-
-  describe('captureException()', () => {
-    it('should return undefined when Sentry not initialized', () => {
-      // Reset module state - Sentry not initialized
-      jest.resetModules();
-      const { captureException: capture } = require('@/lib/monitoring/sentry');
-
-      const result = capture(new Error('Test error'));
-
-      expect(result).toBeUndefined();
-    });
-
-    it('should capture exception with context after initialization', async () => {
-      process.env.SENTRY_DSN = 'https://key@sentry.io/project';
-
-      // Re-import to get fresh module
-      jest.resetModules();
-      const { initSentry: init, captureException: capture } = require('@/lib/monitoring/sentry');
-
-      await init();
-
-      const error = new Error('Test error');
-      const context = { userId: '123', action: 'test' };
-      const result = capture(error, context);
-
-      expect(result).toBe('event-id-123');
-      const Sentry = require('@sentry/nextjs');
-      expect(Sentry.captureException).toHaveBeenCalledWith(error, {
-        extra: context,
+    it('should return false rather than throw when the SDK fails to initialize', async () => {
+      process.env.SENTRY_DSN = DSN;
+      const { shim, client } = loadShim();
+      client.init.mockImplementationOnce(() => {
+        throw new Error('bad DSN');
       });
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await expect(shim.initSentry()).resolves.toBe(false);
+
+      warn.mockRestore();
     });
 
-    it('should forward tags as a distinct field from context, not folded into it', async () => {
-      process.env.SENTRY_DSN = 'https://key@sentry.io/project';
+    it('does not gate captureException — capture works before and after it runs', async () => {
+      process.env.SENTRY_DSN = DSN;
+      const { shim, client } = loadShim();
 
-      jest.resetModules();
-      const { initSentry: init, captureException: capture } =
-        await import('@/lib/monitoring/sentry');
+      expect(shim.captureException(new Error('before'))).toBe('event-id-123');
+      await shim.initSentry();
+      expect(shim.captureException(new Error('after'))).toBe('event-id-123');
 
-      await init();
-
-      const error = new Error('Test error');
-      const context = { readingsCount: 5 };
-      const tags = { subsystem: 'alerting' };
-      const result = capture(error, context, tags);
-
-      expect(result).toBe('event-id-123');
-      const Sentry = await import('@sentry/nextjs');
-      // Full-shape match, not objectContaining: `tags` must be its own top-level
-      // key alongside `extra`, not nested inside it. Sentry only treats a
-      // top-level `tags` key as an indexed/filterable tag facet — nesting it
-      // under `extra` (the bug this test guards) silently downgrades it to
-      // unfilterable "Additional Data" instead.
-      expect(Sentry.captureException).toHaveBeenCalledWith(error, {
-        extra: context,
-        tags,
-      });
-    });
-
-    it('should omit the tags key entirely when no tags are passed', async () => {
-      process.env.SENTRY_DSN = 'https://key@sentry.io/project';
-
-      jest.resetModules();
-      const { initSentry: init, captureException: capture } =
-        await import('@/lib/monitoring/sentry');
-
-      await init();
-
-      const error = new Error('Test error');
-      capture(error, { userId: '123' });
-
-      const Sentry = await import('@sentry/nextjs');
-      const [, options] = (Sentry.captureException as jest.Mock).mock.calls[0];
-      expect(Object.prototype.hasOwnProperty.call(options, 'tags')).toBe(false);
+      expect(client.captureException).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -200,28 +290,22 @@ describe('Sentry Integration', () => {
   // ==========================================================================
 
   describe('captureMessage()', () => {
-    it('should return undefined when Sentry not initialized', () => {
-      jest.resetModules();
-      const { captureMessage: capture } = require('@/lib/monitoring/sentry');
+    it('should return undefined when Sentry is not configured', () => {
+      const { shim, client } = loadShim();
 
-      const result = capture('Test message');
-
-      expect(result).toBeUndefined();
+      expect(shim.captureMessage('Test message')).toBeUndefined();
+      expect(client.captureMessage).not.toHaveBeenCalled();
     });
 
-    it('should capture message with level and context', async () => {
-      process.env.SENTRY_DSN = 'https://key@sentry.io/project';
+    it('should capture message with level and context, without initSentry()', () => {
+      process.env.SENTRY_DSN = DSN;
+      const { shim, client } = loadShim();
 
-      jest.resetModules();
-      const { initSentry: init, captureMessage: capture } = require('@/lib/monitoring/sentry');
-
-      await init();
-
-      const result = capture('Test message', 'warning', { key: 'value' });
+      const result = shim.captureMessage('Test message', 'warning', { key: 'value' });
 
       expect(result).toBe('message-id-456');
-      const Sentry = require('@sentry/nextjs');
-      expect(Sentry.captureMessage).toHaveBeenCalledWith('Test message', {
+      expect(client.init).not.toHaveBeenCalled();
+      expect(client.captureMessage).toHaveBeenCalledWith('Test message', {
         level: 'warning',
         extra: { key: 'value' },
       });
@@ -233,28 +317,22 @@ describe('Sentry Integration', () => {
   // ==========================================================================
 
   describe('addBreadcrumb()', () => {
-    it('should do nothing when Sentry not initialized', () => {
-      jest.resetModules();
-      const { addBreadcrumb: add } = require('@/lib/monitoring/sentry');
+    it('should do nothing when Sentry is not configured', () => {
+      const { shim, client } = loadShim();
 
-      // Should not throw
-      add('Test breadcrumb', 'test');
+      shim.addBreadcrumb('Test breadcrumb', 'test');
 
-      const Sentry = require('@sentry/nextjs');
-      expect(Sentry.addBreadcrumb).not.toHaveBeenCalled();
+      expect(client.addBreadcrumb).not.toHaveBeenCalled();
     });
 
-    it('should add breadcrumb when initialized', async () => {
-      process.env.SENTRY_DSN = 'https://key@sentry.io/project';
+    it('should add breadcrumb without initSentry()', () => {
+      process.env.SENTRY_DSN = DSN;
+      const { shim, client } = loadShim();
 
-      jest.resetModules();
-      const { initSentry: init, addBreadcrumb: add } = require('@/lib/monitoring/sentry');
+      shim.addBreadcrumb('Test breadcrumb', 'navigation', { page: '/home' }, 'info');
 
-      await init();
-      add('Test breadcrumb', 'navigation', { page: '/home' }, 'info');
-
-      const Sentry = require('@sentry/nextjs');
-      expect(Sentry.addBreadcrumb).toHaveBeenCalledWith({
+      expect(client.init).not.toHaveBeenCalled();
+      expect(client.addBreadcrumb).toHaveBeenCalledWith({
         message: 'Test breadcrumb',
         category: 'navigation',
         data: { page: '/home' },
@@ -268,41 +346,31 @@ describe('Sentry Integration', () => {
   // ==========================================================================
 
   describe('setUser()', () => {
-    it('should do nothing when Sentry not initialized', () => {
-      jest.resetModules();
-      const { setUser: set } = require('@/lib/monitoring/sentry');
+    it('should do nothing when Sentry is not configured', () => {
+      const { shim, client } = loadShim();
 
-      set({ id: '123', email: 'test@example.com' });
+      shim.setUser({ id: '123', email: 'test@example.com' });
 
-      const Sentry = require('@sentry/nextjs');
-      expect(Sentry.setUser).not.toHaveBeenCalled();
+      expect(client.setUser).not.toHaveBeenCalled();
     });
 
-    it('should set user when initialized', async () => {
-      process.env.SENTRY_DSN = 'https://key@sentry.io/project';
+    it('should set user when configured', () => {
+      process.env.SENTRY_DSN = DSN;
+      const { shim, client } = loadShim();
 
-      jest.resetModules();
-      const { initSentry: init, setUser: set } = require('@/lib/monitoring/sentry');
-
-      await init();
       const user = { id: '123', email: 'test@example.com' };
-      set(user);
+      shim.setUser(user);
 
-      const Sentry = require('@sentry/nextjs');
-      expect(Sentry.setUser).toHaveBeenCalledWith(user);
+      expect(client.setUser).toHaveBeenCalledWith(user);
     });
 
-    it('should clear user when null is passed', async () => {
-      process.env.SENTRY_DSN = 'https://key@sentry.io/project';
+    it('should clear user when null is passed', () => {
+      process.env.SENTRY_DSN = DSN;
+      const { shim, client } = loadShim();
 
-      jest.resetModules();
-      const { initSentry: init, setUser: set } = require('@/lib/monitoring/sentry');
+      shim.setUser(null);
 
-      await init();
-      set(null);
-
-      const Sentry = require('@sentry/nextjs');
-      expect(Sentry.setUser).toHaveBeenCalledWith(null);
+      expect(client.setUser).toHaveBeenCalledWith(null);
     });
   });
 
@@ -311,27 +379,21 @@ describe('Sentry Integration', () => {
   // ==========================================================================
 
   describe('setTag()', () => {
-    it('should do nothing when Sentry not initialized', () => {
-      jest.resetModules();
-      const { setTag: set } = require('@/lib/monitoring/sentry');
+    it('should do nothing when Sentry is not configured', () => {
+      const { shim, client } = loadShim();
 
-      set('version', '1.0.0');
+      shim.setTag('version', '1.0.0');
 
-      const Sentry = require('@sentry/nextjs');
-      expect(Sentry.setTag).not.toHaveBeenCalled();
+      expect(client.setTag).not.toHaveBeenCalled();
     });
 
-    it('should set tag when initialized', async () => {
-      process.env.SENTRY_DSN = 'https://key@sentry.io/project';
+    it('should set tag when configured', () => {
+      process.env.SENTRY_DSN = DSN;
+      const { shim, client } = loadShim();
 
-      jest.resetModules();
-      const { initSentry: init, setTag: set } = require('@/lib/monitoring/sentry');
+      shim.setTag('version', '1.0.0');
 
-      await init();
-      set('version', '1.0.0');
-
-      const Sentry = require('@sentry/nextjs');
-      expect(Sentry.setTag).toHaveBeenCalledWith('version', '1.0.0');
+      expect(client.setTag).toHaveBeenCalledWith('version', '1.0.0');
     });
   });
 
@@ -340,27 +402,21 @@ describe('Sentry Integration', () => {
   // ==========================================================================
 
   describe('setExtra()', () => {
-    it('should do nothing when Sentry not initialized', () => {
-      jest.resetModules();
-      const { setExtra: set } = require('@/lib/monitoring/sentry');
+    it('should do nothing when Sentry is not configured', () => {
+      const { shim, client } = loadShim();
 
-      set('metadata', { key: 'value' });
+      shim.setExtra('metadata', { key: 'value' });
 
-      const Sentry = require('@sentry/nextjs');
-      expect(Sentry.setExtra).not.toHaveBeenCalled();
+      expect(client.setExtra).not.toHaveBeenCalled();
     });
 
-    it('should set extra when initialized', async () => {
-      process.env.SENTRY_DSN = 'https://key@sentry.io/project';
+    it('should set extra when configured', () => {
+      process.env.SENTRY_DSN = DSN;
+      const { shim, client } = loadShim();
 
-      jest.resetModules();
-      const { initSentry: init, setExtra: set } = require('@/lib/monitoring/sentry');
+      shim.setExtra('metadata', { key: 'value' });
 
-      await init();
-      set('metadata', { key: 'value' });
-
-      const Sentry = require('@sentry/nextjs');
-      expect(Sentry.setExtra).toHaveBeenCalledWith('metadata', { key: 'value' });
+      expect(client.setExtra).toHaveBeenCalledWith('metadata', { key: 'value' });
     });
   });
 
@@ -369,48 +425,35 @@ describe('Sentry Integration', () => {
   // ==========================================================================
 
   describe('startTransaction()', () => {
-    it('should return undefined when Sentry not initialized', () => {
-      jest.resetModules();
-      const { startTransaction: start } = require('@/lib/monitoring/sentry');
+    it('should return undefined when Sentry is not configured', () => {
+      const { shim, client } = loadShim();
 
-      const result = start('test-transaction', 'http.request');
-
-      expect(result).toBeUndefined();
+      expect(shim.startTransaction('test-transaction', 'http.request')).toBeUndefined();
+      expect(client.startInactiveSpan).not.toHaveBeenCalled();
     });
 
-    it('should start transaction when initialized', async () => {
-      process.env.SENTRY_DSN = 'https://key@sentry.io/project';
+    it('should start transaction when configured', () => {
+      process.env.SENTRY_DSN = DSN;
+      const { shim, client } = loadShim();
 
-      jest.resetModules();
-      const { initSentry: init, startTransaction: start } = require('@/lib/monitoring/sentry');
-
-      await init();
-      const transaction = start('test-transaction', 'http.request');
+      const transaction = shim.startTransaction('test-transaction', 'http.request');
 
       expect(transaction).toBeDefined();
       expect(transaction?.finish).toBeDefined();
-
-      const Sentry = require('@sentry/nextjs');
-      expect(Sentry.startInactiveSpan).toHaveBeenCalledWith({
+      expect(client.startInactiveSpan).toHaveBeenCalledWith({
         name: 'test-transaction',
         op: 'http.request',
       });
     });
 
-    it('should allow finishing the transaction', async () => {
-      process.env.SENTRY_DSN = 'https://key@sentry.io/project';
+    it('should allow finishing the transaction', () => {
+      process.env.SENTRY_DSN = DSN;
+      const { shim, client } = loadShim();
 
-      jest.resetModules();
-      const { initSentry: init, startTransaction: start } = require('@/lib/monitoring/sentry');
-
-      await init();
-      const transaction = start('test-transaction', 'http.request');
-
-      // Should not throw
+      const transaction = shim.startTransaction('test-transaction', 'http.request');
       transaction?.finish();
 
-      const Sentry = require('@sentry/nextjs');
-      const mockSpan = Sentry.startInactiveSpan.mock.results[0].value;
+      const mockSpan = client.startInactiveSpan.mock.results[0].value;
       expect(mockSpan.end).toHaveBeenCalled();
     });
   });
@@ -421,8 +464,9 @@ describe('Sentry Integration', () => {
 
   describe('withSentryErrorHandling()', () => {
     it('should execute function and return result', async () => {
+      const { shim } = loadShim();
       const fn = jest.fn().mockResolvedValue('result');
-      const wrapped = withSentryErrorHandling(fn);
+      const wrapped = shim.withSentryErrorHandling(fn);
 
       const result = await wrapped('arg1', 'arg2');
 
@@ -430,22 +474,18 @@ describe('Sentry Integration', () => {
       expect(fn).toHaveBeenCalledWith('arg1', 'arg2');
     });
 
-    it('should capture exception and rethrow on error', async () => {
-      process.env.SENTRY_DSN = 'https://key@sentry.io/project';
-
-      jest.resetModules();
-      const { initSentry: init, withSentryErrorHandling: wrap } = require('@/lib/monitoring/sentry');
-
-      await init();
+    it('should capture exception and rethrow on error, without initSentry()', async () => {
+      process.env.SENTRY_DSN = DSN;
+      const { shim, client } = loadShim();
 
       const error = new Error('Test error');
       const fn = jest.fn().mockRejectedValue(error);
-      const wrapped = wrap(fn, { action: 'test' });
+      const wrapped = shim.withSentryErrorHandling(fn, { action: 'test' });
 
       await expect(wrapped()).rejects.toThrow('Test error');
 
-      const Sentry = require('@sentry/nextjs');
-      expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+      expect(client.init).not.toHaveBeenCalled();
+      expect(client.captureException).toHaveBeenCalledWith(error, {
         extra: { action: 'test', args: [] },
       });
     });

--- a/__tests__/unit/lib/sentry.test.ts
+++ b/__tests__/unit/lib/sentry.test.ts
@@ -161,7 +161,8 @@ describe('Sentry Integration', () => {
       process.env.SENTRY_DSN = 'https://key@sentry.io/project';
 
       jest.resetModules();
-      const { initSentry: init, captureException: capture } = require('@/lib/monitoring/sentry');
+      const { initSentry: init, captureException: capture } =
+        await import('@/lib/monitoring/sentry');
 
       await init();
 
@@ -171,7 +172,7 @@ describe('Sentry Integration', () => {
       const result = capture(error, context, tags);
 
       expect(result).toBe('event-id-123');
-      const Sentry = require('@sentry/nextjs');
+      const Sentry = await import('@sentry/nextjs');
       // Full-shape match, not objectContaining: `tags` must be its own top-level
       // key alongside `extra`, not nested inside it. Sentry only treats a
       // top-level `tags` key as an indexed/filterable tag facet — nesting it
@@ -187,14 +188,15 @@ describe('Sentry Integration', () => {
       process.env.SENTRY_DSN = 'https://key@sentry.io/project';
 
       jest.resetModules();
-      const { initSentry: init, captureException: capture } = require('@/lib/monitoring/sentry');
+      const { initSentry: init, captureException: capture } =
+        await import('@/lib/monitoring/sentry');
 
       await init();
 
       const error = new Error('Test error');
       capture(error, { userId: '123' });
 
-      const Sentry = require('@sentry/nextjs');
+      const Sentry = await import('@sentry/nextjs');
       const [, options] = (Sentry.captureException as jest.Mock).mock.calls[0];
       expect(Object.prototype.hasOwnProperty.call(options, 'tags')).toBe(false);
     });

--- a/__tests__/unit/lib/sentry.test.ts
+++ b/__tests__/unit/lib/sentry.test.ts
@@ -156,6 +156,48 @@ describe('Sentry Integration', () => {
         extra: context,
       });
     });
+
+    it('should forward tags as a distinct field from context, not folded into it', async () => {
+      process.env.SENTRY_DSN = 'https://key@sentry.io/project';
+
+      jest.resetModules();
+      const { initSentry: init, captureException: capture } = require('@/lib/monitoring/sentry');
+
+      await init();
+
+      const error = new Error('Test error');
+      const context = { readingsCount: 5 };
+      const tags = { subsystem: 'alerting' };
+      const result = capture(error, context, tags);
+
+      expect(result).toBe('event-id-123');
+      const Sentry = require('@sentry/nextjs');
+      // Full-shape match, not objectContaining: `tags` must be its own top-level
+      // key alongside `extra`, not nested inside it. Sentry only treats a
+      // top-level `tags` key as an indexed/filterable tag facet — nesting it
+      // under `extra` (the bug this test guards) silently downgrades it to
+      // unfilterable "Additional Data" instead.
+      expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+        extra: context,
+        tags,
+      });
+    });
+
+    it('should omit the tags key entirely when no tags are passed', async () => {
+      process.env.SENTRY_DSN = 'https://key@sentry.io/project';
+
+      jest.resetModules();
+      const { initSentry: init, captureException: capture } = require('@/lib/monitoring/sentry');
+
+      await init();
+
+      const error = new Error('Test error');
+      capture(error, { userId: '123' });
+
+      const Sentry = require('@sentry/nextjs');
+      const [, options] = (Sentry.captureException as jest.Mock).mock.calls[0];
+      expect(Object.prototype.hasOwnProperty.call(options, 'tags')).toBe(false);
+    });
   });
 
   // ==========================================================================

--- a/__tests__/unit/lib/useAlertRules.test.tsx
+++ b/__tests__/unit/lib/useAlertRules.test.tsx
@@ -32,6 +32,7 @@ import {
   useUpdateAlertRule,
   useDeleteAlertRule,
 } from '@/lib/query/hooks/useAlertRules';
+import { useAlertsList } from '@/lib/query/hooks/useAlerts';
 import { v2Api } from '@/lib/api/v2-client';
 import type { CreateAlertRuleBody } from '@/types/v2';
 
@@ -44,7 +45,27 @@ jest.mock('@/lib/api/v2-client', () => ({
       update: jest.fn(),
       delete: jest.fn(),
     },
+    alerts: {
+      list: jest.fn(),
+      getById: jest.fn(),
+    },
   },
+}));
+
+/**
+ * Connected => `useRealtimeFallbackInterval()` returns false, so `useAlertsList`
+ * resolves `refetchInterval: false`. Any alert-list refetch the block at the
+ * bottom of this file observes can only have come from an invalidation, never
+ * from the poll fallback.
+ */
+jest.mock('@/lib/pusher-context', () => ({
+  useRealtimeConnection: () => ({
+    connected: true,
+    state: 'connected',
+    degraded: false,
+    message: null,
+    terminal: false,
+  }),
 }));
 
 function wrapper({ children }: { children: React.ReactNode }) {
@@ -363,5 +384,143 @@ describe('mutations refresh the mounted rule surfaces', () => {
 
     await waitFor(() => expect(result.current.detail.isError).toBe(true));
     expect(detailCalls()).toBeGreaterThan(before);
+  });
+});
+
+// ============================================================================
+// Editing a rule's condition closes alerts, so the ALERT surfaces must refresh
+// ============================================================================
+//
+// `PATCH /api/v2/alert-rules/[id]` does not only edit the rule. When
+// metric/comparison/threshold change, every open episode carrying the now-false
+// snapshot is closed in the database
+// (`closeEpisodesOrphanedByConditionChange`). Nothing patches alert rows into
+// this cache, `refetchOnWindowFocus` is off, and `useAlertsList` has no
+// unconditional `refetchInterval` — so an admin who raises a threshold and
+// closes twelve episodes keeps watching all twelve render as firing until
+// something else invalidates them. Hence `queryKeys.alerts.all` in
+// `useUpdateAlertRule`.
+//
+// Built to the same bar as the block above and for the same reason: asserting
+// `invalidateQueries` was called with `queryKeys.alerts.all` would be
+// tautological, since the hook and the test would be reading the same constant
+// and the assertion would pass even if invalidating that key refetched nothing.
+// So a real QueryClient holds a real, mounted, observed ALERTS list; the fake
+// alerts API is backed by mutable server state that the rule update mutates the
+// way the route does; and the assertion is that the rendered alerts changed.
+
+type FakeAlert = { _id: string; rule_id: string; status: 'firing' | 'resolved' };
+
+/**
+ * A stand-in alerts API over mutable state. `list` serves only OPEN episodes,
+ * which is what `GET /api/v2/alerts` defaults to — so an episode the rule edit
+ * closed disappears from the list exactly as it would in the app.
+ */
+function seedAlertServer(initial: FakeAlert[]) {
+  const server = { alerts: initial };
+
+  (v2Api.alerts.list as jest.Mock).mockImplementation(async () => {
+    const open = server.alerts.filter(alert => alert.status !== 'resolved');
+    return { data: open, pagination: { total: open.length } };
+  });
+
+  return server;
+}
+
+/**
+ * The rule edit as the server actually performs it: the rule changes AND every
+ * open episode of that rule closes. Wiring only the rule half would make the
+ * alerts list unable to change, and the test would prove nothing.
+ */
+function seedConditionChangingUpdate(ruleServer: { rules: FakeRule[] }, alertServer: { alerts: FakeAlert[] }) {
+  (v2Api.alertRules.update as jest.Mock).mockImplementation(
+    async (id: string, data: Record<string, unknown>) => {
+      ruleServer.rules = ruleServer.rules.map(rule =>
+        rule._id === id ? { ...rule, ...data } : rule
+      );
+      alertServer.alerts = alertServer.alerts.map(alert =>
+        alert.rule_id === id && alert.status !== 'resolved'
+          ? { ...alert, status: 'resolved' as const }
+          : alert
+      );
+      return { data: ruleServer.rules.find(rule => rule._id === id) };
+    }
+  );
+}
+
+function useAlertAndRuleSurfaces() {
+  return {
+    alerts: useAlertsList(),
+    rules: useAlertRulesList(),
+    update: useUpdateAlertRule(),
+  };
+}
+
+function alertListCalls() {
+  return (v2Api.alerts.list as jest.Mock).mock.calls.length;
+}
+
+describe('updating a rule refreshes the mounted alert surfaces', () => {
+  const OPEN_EPISODES: FakeAlert[] = [
+    { _id: 'a1', rule_id: 'r1', status: 'firing' },
+    { _id: 'a2', rule_id: 'r1', status: 'firing' },
+  ];
+
+  async function mountSettled() {
+    const { wrapper: sharedWrapper } = makeSharedWrapper();
+    const { result } = renderHook(() => useAlertAndRuleSurfaces(), { wrapper: sharedWrapper });
+
+    await waitFor(() => {
+      expect(result.current.rules.isSuccess).toBe(true);
+      expect(result.current.alerts.isSuccess).toBe(true);
+    });
+
+    return result;
+  }
+
+  /**
+   * The control. `useAlertsList` has a 30s staleTime and, with the socket
+   * mocked as connected, no `refetchInterval` — so without this an increased
+   * call count below could just be React Query refetching on its own.
+   */
+  it('should not refetch the alerts list on its own while nothing invalidates it', async () => {
+    seedRuleServer([{ ...RULE_ONE }]);
+    seedAlertServer(OPEN_EPISODES.map(alert => ({ ...alert })));
+
+    const result = await mountSettled();
+    const before = alertListCalls();
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+
+    expect(alertListCalls()).toBe(before);
+    expect(result.current.alerts.data).toHaveLength(2);
+  });
+
+  it('should refetch the alerts list after a rule update, dropping the episodes it closed', async () => {
+    const ruleServer = seedRuleServer([{ ...RULE_ONE }]);
+    const alertServer = seedAlertServer(OPEN_EPISODES.map(alert => ({ ...alert })));
+    seedConditionChangingUpdate(ruleServer, alertServer);
+
+    const result = await mountSettled();
+    const before = alertListCalls();
+    expect(result.current.alerts.data).toHaveLength(2);
+
+    await act(async () => {
+      result.current.update.mutate({
+        id: 'r1',
+        data: {
+          metric: 'value',
+          comparison: 'gt',
+          threshold: 99,
+          selector: { types: ['temperature'] },
+        },
+      });
+    });
+    await waitFor(() => expect(result.current.update.isSuccess).toBe(true));
+
+    await waitFor(() => expect(result.current.alerts.data).toEqual([]));
+    expect(alertListCalls()).toBeGreaterThan(before);
   });
 });

--- a/__tests__/unit/lib/useAlertRules.test.tsx
+++ b/__tests__/unit/lib/useAlertRules.test.tsx
@@ -2,9 +2,27 @@
  * useAlertRules Hook Tests
  *
  * @jest-environment jsdom
+ *
+ * The `mutations refresh the mounted rule surfaces` block below protects the
+ * `invalidateQueries` calls in the three rule mutations. Nothing patches the
+ * rule list into the cache — create/update/delete change the server and the
+ * invalidation is the only reason the open rules table re-reads it. Delete one
+ * and a just-created rule does not appear until a full remount.
+ *
+ * These tests deliberately do NOT spy on `queryClient.invalidateQueries` and
+ * assert the key. That assertion is tautological: the hook and the test read
+ * the same `queryKeys.alertRules.all` constant, so it passes even if
+ * invalidating that key refetches nothing. Instead a real `QueryClient` holds a
+ * real, mounted, observed list query, the fake API is backed by mutable server
+ * state, and the assertion is that the rendered rules actually changed.
+ *
+ * `useAlertRulesList` has a 5-minute `staleTime` and no `refetchInterval`, so a
+ * refetch inside a sub-second test cannot come from anywhere else. The control
+ * test (`does not refetch on its own...`) pins that down rather than assuming
+ * it.
  */
 
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import {
@@ -116,5 +134,234 @@ describe('mutations', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(v2Api.alertRules.delete).toHaveBeenCalledWith('r1');
+  });
+});
+
+// ============================================================================
+// D1 — the invalidations are load-bearing
+// ============================================================================
+
+type FakeRule = { _id: string; name: string; enabled: boolean };
+
+/**
+ * A stand-in alert-rules API backed by mutable state, so a test can act out
+ * "the server now says something different" — the only way to tell a real
+ * refetch from a cache read.
+ *
+ * `getById` REJECTS for an id that is no longer there, mirroring the 404 a
+ * soft-deleted rule returns. That makes "the detail pane refetched" observable
+ * as `isError` rather than as a silently stale success.
+ */
+function seedRuleServer(initial: FakeRule[]) {
+  const server = { rules: initial };
+
+  (v2Api.alertRules.list as jest.Mock).mockImplementation(async () => ({
+    data: server.rules,
+  }));
+  (v2Api.alertRules.getById as jest.Mock).mockImplementation(async (id: string) => {
+    const rule = server.rules.find(candidate => candidate._id === id);
+    if (!rule) throw new Error('Alert rule not found');
+    return { data: rule };
+  });
+
+  return server;
+}
+
+/** One real QueryClient shared by every hook in the render, as in the app. */
+function makeSharedWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const sharedWrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client }, children);
+  return { client, wrapper: sharedWrapper };
+}
+
+/**
+ * The rules admin screen: the table, the detail pane, and the three actions.
+ * Mounted together because React Query only refetches queries that have a live
+ * observer — a test that mounts a mutation alone can never see the
+ * invalidation do anything at all.
+ */
+function useRuleSurfaces() {
+  return {
+    list: useAlertRulesList(),
+    detail: useAlertRuleDetail('r1'),
+    create: useCreateAlertRule(),
+    update: useUpdateAlertRule(),
+    remove: useDeleteAlertRule(),
+  };
+}
+
+function listCalls() {
+  return (v2Api.alertRules.list as jest.Mock).mock.calls.length;
+}
+
+function detailCalls() {
+  return (v2Api.alertRules.getById as jest.Mock).mock.calls.length;
+}
+
+const RULE_ONE: FakeRule = { _id: 'r1', name: 'High temp', enabled: true };
+
+describe('mutations refresh the mounted rule surfaces', () => {
+  async function mountSettled() {
+    const { wrapper: sharedWrapper } = makeSharedWrapper();
+    const { result } = renderHook(() => useRuleSurfaces(), { wrapper: sharedWrapper });
+
+    await waitFor(() => {
+      expect(result.current.list.isSuccess).toBe(true);
+      expect(result.current.detail.isSuccess).toBe(true);
+    });
+
+    return result;
+  }
+
+  /**
+   * The control. Without it, an increased call count elsewhere in this block
+   * could just be React Query refetching on its own, and every assertion below
+   * would be measuring nothing.
+   */
+  it('should not refetch on its own while nothing invalidates it', async () => {
+    seedRuleServer([{ ...RULE_ONE }]);
+
+    const result = await mountSettled();
+    const before = listCalls();
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+
+    expect(listCalls()).toBe(before);
+    expect(result.current.list.data).toEqual([RULE_ONE]);
+  });
+
+  it('should refetch the rules list after creating, showing the new rule', async () => {
+    const server = seedRuleServer([{ ...RULE_ONE }]);
+    (v2Api.alertRules.create as jest.Mock).mockImplementation(async (body: CreateAlertRuleBody) => {
+      const created = { _id: 'r2', name: body.name, enabled: body.enabled !== false };
+      server.rules = [...server.rules, created];
+      return { data: created };
+    });
+
+    const result = await mountSettled();
+    const before = listCalls();
+    expect(result.current.list.data).toEqual([RULE_ONE]);
+
+    await act(async () => {
+      result.current.create.mutate({
+        name: 'Low battery',
+        metric: 'battery_level',
+        comparison: 'lt',
+        threshold: 15,
+        severity: 'warning',
+      });
+    });
+    await waitFor(() => expect(result.current.create.isSuccess).toBe(true));
+
+    await waitFor(() =>
+      expect(result.current.list.data).toEqual([
+        RULE_ONE,
+        { _id: 'r2', name: 'Low battery', enabled: true },
+      ])
+    );
+    expect(listCalls()).toBeGreaterThan(before);
+  });
+
+  it('should refetch the rules list after updating, showing the new name', async () => {
+    const server = seedRuleServer([{ ...RULE_ONE }]);
+    (v2Api.alertRules.update as jest.Mock).mockImplementation(
+      async (id: string, data: { name?: string }) => {
+        server.rules = server.rules.map(rule =>
+          rule._id === id ? { ...rule, ...data } : rule
+        );
+        return { data: server.rules.find(rule => rule._id === id) };
+      }
+    );
+
+    const result = await mountSettled();
+    const before = listCalls();
+    expect(result.current.list.data).toEqual([RULE_ONE]);
+
+    await act(async () => {
+      result.current.update.mutate({ id: 'r1', data: { name: 'Very high temp' } });
+    });
+    await waitFor(() => expect(result.current.update.isSuccess).toBe(true));
+
+    await waitFor(() =>
+      expect(result.current.list.data).toEqual([
+        { _id: 'r1', name: 'Very high temp', enabled: true },
+      ])
+    );
+    expect(listCalls()).toBeGreaterThan(before);
+  });
+
+  it('should refetch the rule detail after updating, showing the new name', async () => {
+    const server = seedRuleServer([{ ...RULE_ONE }]);
+    (v2Api.alertRules.update as jest.Mock).mockImplementation(
+      async (id: string, data: { name?: string }) => {
+        server.rules = server.rules.map(rule =>
+          rule._id === id ? { ...rule, ...data } : rule
+        );
+        return { data: server.rules.find(rule => rule._id === id) };
+      }
+    );
+
+    const result = await mountSettled();
+    const before = detailCalls();
+    expect(result.current.detail.data).toEqual(RULE_ONE);
+
+    await act(async () => {
+      result.current.update.mutate({ id: 'r1', data: { name: 'Very high temp' } });
+    });
+    await waitFor(() => expect(result.current.update.isSuccess).toBe(true));
+
+    await waitFor(() =>
+      expect(result.current.detail.data).toEqual({
+        _id: 'r1',
+        name: 'Very high temp',
+        enabled: true,
+      })
+    );
+    expect(detailCalls()).toBeGreaterThan(before);
+  });
+
+  it('should refetch the rules list after deleting, dropping the deleted rule', async () => {
+    const server = seedRuleServer([{ ...RULE_ONE }, { _id: 'r2', name: 'CO2', enabled: true }]);
+    (v2Api.alertRules.delete as jest.Mock).mockImplementation(async (id: string) => {
+      server.rules = server.rules.filter(rule => rule._id !== id);
+      return { data: { _id: id, deleted: true } };
+    });
+
+    const result = await mountSettled();
+    const before = listCalls();
+    expect(result.current.list.data).toHaveLength(2);
+
+    await act(async () => {
+      result.current.remove.mutate('r2');
+    });
+    await waitFor(() => expect(result.current.remove.isSuccess).toBe(true));
+
+    await waitFor(() => expect(result.current.list.data).toEqual([RULE_ONE]));
+    expect(listCalls()).toBeGreaterThan(before);
+  });
+
+  it('should refetch the rule detail after deleting, so it stops showing a gone rule', async () => {
+    const server = seedRuleServer([{ ...RULE_ONE }]);
+    (v2Api.alertRules.delete as jest.Mock).mockImplementation(async (id: string) => {
+      server.rules = server.rules.filter(rule => rule._id !== id);
+      return { data: { _id: id, deleted: true } };
+    });
+
+    const result = await mountSettled();
+    const before = detailCalls();
+    expect(result.current.detail.data).toEqual(RULE_ONE);
+
+    await act(async () => {
+      result.current.remove.mutate('r1');
+    });
+    await waitFor(() => expect(result.current.remove.isSuccess).toBe(true));
+
+    await waitFor(() => expect(result.current.detail.isError).toBe(true));
+    expect(detailCalls()).toBeGreaterThan(before);
   });
 });

--- a/__tests__/unit/lib/useAlertRules.test.tsx
+++ b/__tests__/unit/lib/useAlertRules.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * useAlertRules Hook Tests
+ *
+ * @jest-environment jsdom
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import {
+  useAlertRulesList,
+  useAlertRuleDetail,
+  useCreateAlertRule,
+  useUpdateAlertRule,
+  useDeleteAlertRule,
+} from '@/lib/query/hooks/useAlertRules';
+import { v2Api } from '@/lib/api/v2-client';
+import type { CreateAlertRuleBody } from '@/types/v2';
+
+jest.mock('@/lib/api/v2-client', () => ({
+  v2Api: {
+    alertRules: {
+      list: jest.fn(),
+      getById: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+  },
+}));
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return React.createElement(QueryClientProvider, { client }, children);
+}
+
+describe('useAlertRulesList', () => {
+  it('should return the rules array', async () => {
+    (v2Api.alertRules.list as jest.Mock).mockResolvedValue({
+      data: [{ _id: 'r1', name: 'High temp' }],
+    });
+
+    const { result } = renderHook(() => useAlertRulesList({ enabled: true }), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ _id: 'r1', name: 'High temp' }]);
+    expect(v2Api.alertRules.list).toHaveBeenCalledWith({ enabled: true });
+  });
+
+  it('should surface an error', async () => {
+    (v2Api.alertRules.list as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useAlertRulesList(), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe('useAlertRuleDetail', () => {
+  it('should be disabled without an id', () => {
+    const { result } = renderHook(() => useAlertRuleDetail(''), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(v2Api.alertRules.getById).not.toHaveBeenCalled();
+  });
+
+  it('should load a rule by id', async () => {
+    (v2Api.alertRules.getById as jest.Mock).mockResolvedValue({
+      data: { _id: 'r1', name: 'High temp' },
+    });
+
+    const { result } = renderHook(() => useAlertRuleDetail('r1'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ _id: 'r1', name: 'High temp' });
+    expect(v2Api.alertRules.getById).toHaveBeenCalledWith('r1');
+  });
+});
+
+describe('mutations', () => {
+  it('should create a rule', async () => {
+    (v2Api.alertRules.create as jest.Mock).mockResolvedValue({ data: { _id: 'r2' } });
+
+    const { result } = renderHook(() => useCreateAlertRule(), { wrapper });
+    const body: CreateAlertRuleBody = {
+      name: 'R',
+      metric: 'value',
+      comparison: 'gt',
+      threshold: 30,
+      severity: 'warning',
+      selector: { types: ['temperature'] },
+    };
+    result.current.mutate(body);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(v2Api.alertRules.create).toHaveBeenCalledWith(body);
+  });
+
+  it('should update a rule with {id, data}', async () => {
+    (v2Api.alertRules.update as jest.Mock).mockResolvedValue({ data: { _id: 'r1', name: 'New' } });
+
+    const { result } = renderHook(() => useUpdateAlertRule(), { wrapper });
+    result.current.mutate({ id: 'r1', data: { name: 'New' } });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(v2Api.alertRules.update).toHaveBeenCalledWith('r1', { name: 'New' });
+  });
+
+  it('should delete a rule by bare id, not an object', async () => {
+    (v2Api.alertRules.delete as jest.Mock).mockResolvedValue({
+      data: { _id: 'r1', deleted: true },
+    });
+
+    const { result } = renderHook(() => useDeleteAlertRule(), { wrapper });
+    result.current.mutate('r1');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(v2Api.alertRules.delete).toHaveBeenCalledWith('r1');
+  });
+});

--- a/__tests__/unit/lib/useAlerts.test.tsx
+++ b/__tests__/unit/lib/useAlerts.test.tsx
@@ -2,9 +2,37 @@
  * useAlerts Hook Tests
  *
  * @jest-environment jsdom
+ *
+ * The `mutations refresh the mounted alert surfaces` block below exists because
+ * the invalidations in `useAcknowledgeAlert` / `useResolveAlert` are the ONLY
+ * thing that moves a new row onto the screen. Nothing in this subsystem calls
+ * `setQueryData`; the Pusher `alert-event` carries a notification, never the
+ * row. Delete an `invalidateQueries` line and the acknowledged alert keeps
+ * rendering as "firing" until something unrelated happens to refetch.
+ *
+ * Those tests deliberately do NOT spy on `queryClient.invalidateQueries` and
+ * assert it was called with `queryKeys.alerts.all`. That assertion is
+ * tautological — the test and the hook read the same constant, so it passes
+ * whether or not invalidating that key achieves anything. Instead a real
+ * `QueryClient` holds a real, mounted, observed list query; the fake API is
+ * backed by mutable server state; and the assertion is that the rendered rows
+ * and the nav-badge count actually changed to what the server now returns.
+ *
+ * Two things are pinned so an observed refetch cannot be an accident:
+ *  - `useRealtimeConnection` is mocked as connected, which resolves
+ *    `refetchInterval` to `false` — no timer can refetch anything here.
+ *  - `does not refetch on its own while nothing invalidates it` is the control:
+ *    it proves the call-count increases in the other tests are caused by the
+ *    mutation and not by React Query refetching in the background.
+ *
+ * Note that each mutation hook invalidates `alerts.detail(id)` AND
+ * `alerts.all`, and today the second makes the first redundant — `alerts.all`
+ * is a key PREFIX of `alerts.detail(id)`. That coupling lives in
+ * `lib/query/queryClient.ts` and is guarded by
+ * `__tests__/unit/lib/queryClient-alert-keys.test.ts`, not here.
  */
 
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import {
@@ -25,6 +53,21 @@ jest.mock('@/lib/api/v2-client', () => ({
       resolve: jest.fn(),
     },
   },
+}));
+
+/**
+ * Connected => `useRealtimeFallbackInterval()` returns false, so every alert
+ * query resolves `refetchInterval: false`. Any refetch these tests observe can
+ * only have come from an explicit invalidation, never from the poll fallback.
+ */
+jest.mock('@/lib/pusher-context', () => ({
+  useRealtimeConnection: () => ({
+    connected: true,
+    state: 'connected',
+    degraded: false,
+    message: null,
+    terminal: false,
+  }),
 }));
 
 function wrapper({ children }: { children: React.ReactNode }) {
@@ -106,5 +149,234 @@ describe('useOpenAlertCount', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(v2Api.alerts.list).toHaveBeenCalledWith({ limit: 1 });
+  });
+});
+
+// ============================================================================
+// D1 — the invalidations are load-bearing
+// ============================================================================
+
+type FakeAlert = { _id: string; status: string };
+
+/**
+ * A stand-in alerts API backed by mutable state, so a test can act out "the
+ * server now says something different" — which is the only way to tell a real
+ * refetch from a cache read.
+ *
+ * `open` is what `GET /api/v2/alerts` returns (firing + acknowledged) and backs
+ * both the list and the nav badge, exactly as the real endpoint does. `store`
+ * is separate because a resolved alert leaves the open list while remaining
+ * perfectly fetchable by id — that asymmetry is the whole point of the
+ * "dropping the resolved row" test.
+ */
+function seedAlertServer(initial: { open: FakeAlert[]; total: number }) {
+  const store: Record<string, FakeAlert> = {};
+  for (const row of initial.open) store[row._id] = row;
+
+  const server = { open: initial.open, total: initial.total, store };
+
+  (v2Api.alerts.list as jest.Mock).mockImplementation(async (params?: { limit?: number }) => ({
+    data: params?.limit === 1 ? server.open.slice(0, 1) : server.open,
+    pagination: { total: server.total },
+  }));
+  (v2Api.alerts.getById as jest.Mock).mockImplementation(async (id: string) => ({
+    data: server.store[id],
+  }));
+
+  return server;
+}
+
+/** One real QueryClient shared by every hook in the render, as in the app. */
+function makeSharedWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const sharedWrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client }, children);
+  return { client, wrapper: sharedWrapper };
+}
+
+/**
+ * Every alert surface a user has open at once: the list, the nav badge, the
+ * detail pane, and the two action buttons. Mounting them together is the point
+ * — React Query only refetches queries that have a live observer, so a test
+ * that mounts the mutation alone can never see the invalidation do anything.
+ */
+function useAlertSurfaces() {
+  return {
+    list: useAlertsList({ status: 'firing' }),
+    count: useOpenAlertCount(),
+    detail: useAlertDetail('a1'),
+    acknowledge: useAcknowledgeAlert(),
+    resolve: useResolveAlert(),
+  };
+}
+
+function listCalls() {
+  return (v2Api.alerts.list as jest.Mock).mock.calls.length;
+}
+
+function detailCalls() {
+  return (v2Api.alerts.getById as jest.Mock).mock.calls.length;
+}
+
+describe('mutations refresh the mounted alert surfaces', () => {
+  async function mountSettled() {
+    const { wrapper: sharedWrapper } = makeSharedWrapper();
+    const { result } = renderHook(() => useAlertSurfaces(), { wrapper: sharedWrapper });
+
+    await waitFor(() => {
+      expect(result.current.list.isSuccess).toBe(true);
+      expect(result.current.count.isSuccess).toBe(true);
+      expect(result.current.detail.isSuccess).toBe(true);
+    });
+
+    return result;
+  }
+
+  /**
+   * The control. Without it, an increased call count elsewhere in this block
+   * could just be React Query refetching on its own, and every assertion below
+   * would be measuring nothing.
+   */
+  it('should not refetch on its own while nothing invalidates it', async () => {
+    seedAlertServer({ open: [{ _id: 'a1', status: 'firing' }], total: 3 });
+
+    const result = await mountSettled();
+    const before = listCalls();
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
+
+    expect(listCalls()).toBe(before);
+    expect(result.current.list.data).toEqual([{ _id: 'a1', status: 'firing' }]);
+  });
+
+  it('should refetch the alert list after acknowledging, showing the new server rows', async () => {
+    const server = seedAlertServer({ open: [{ _id: 'a1', status: 'firing' }], total: 3 });
+    (v2Api.alerts.acknowledge as jest.Mock).mockImplementation(async (id: string) => {
+      server.open = [{ _id: id, status: 'acknowledged' }];
+      server.store[id] = server.open[0];
+      server.total = 2;
+      return { data: server.open[0] };
+    });
+
+    const result = await mountSettled();
+    const before = listCalls();
+    expect(result.current.list.data).toEqual([{ _id: 'a1', status: 'firing' }]);
+
+    await act(async () => {
+      result.current.acknowledge.mutate({ id: 'a1' });
+    });
+    await waitFor(() => expect(result.current.acknowledge.isSuccess).toBe(true));
+
+    await waitFor(() =>
+      expect(result.current.list.data).toEqual([{ _id: 'a1', status: 'acknowledged' }])
+    );
+    expect(listCalls()).toBeGreaterThan(before);
+  });
+
+  it('should refetch the open-alert badge count after acknowledging', async () => {
+    const server = seedAlertServer({ open: [{ _id: 'a1', status: 'firing' }], total: 3 });
+    (v2Api.alerts.acknowledge as jest.Mock).mockImplementation(async (id: string) => {
+      server.total = 2;
+      return { data: { _id: id, status: 'acknowledged' } };
+    });
+
+    const result = await mountSettled();
+    expect(result.current.count.data).toBe(3);
+
+    await act(async () => {
+      result.current.acknowledge.mutate({ id: 'a1' });
+    });
+    await waitFor(() => expect(result.current.acknowledge.isSuccess).toBe(true));
+
+    await waitFor(() => expect(result.current.count.data).toBe(2));
+  });
+
+  it('should refetch the open alert detail after acknowledging', async () => {
+    const server = seedAlertServer({ open: [{ _id: 'a1', status: 'firing' }], total: 3 });
+    (v2Api.alerts.acknowledge as jest.Mock).mockImplementation(async (id: string) => {
+      server.store[id] = { _id: id, status: 'acknowledged' };
+      return { data: server.store[id] };
+    });
+
+    const result = await mountSettled();
+    const before = detailCalls();
+    expect(result.current.detail.data).toEqual({ _id: 'a1', status: 'firing' });
+
+    await act(async () => {
+      result.current.acknowledge.mutate({ id: 'a1' });
+    });
+    await waitFor(() => expect(result.current.acknowledge.isSuccess).toBe(true));
+
+    await waitFor(() =>
+      expect(result.current.detail.data).toEqual({ _id: 'a1', status: 'acknowledged' })
+    );
+    expect(detailCalls()).toBeGreaterThan(before);
+  });
+
+  it('should refetch the alert list after resolving, dropping the resolved row', async () => {
+    const server = seedAlertServer({ open: [{ _id: 'a1', status: 'firing' }], total: 3 });
+    (v2Api.alerts.resolve as jest.Mock).mockImplementation(async (id: string) => {
+      // Resolved alerts leave the default (open) list entirely.
+      server.open = [];
+      server.store[id] = { _id: id, status: 'resolved' };
+      server.total = 2;
+      return { data: server.store[id] };
+    });
+
+    const result = await mountSettled();
+    const before = listCalls();
+    expect(result.current.list.data).toEqual([{ _id: 'a1', status: 'firing' }]);
+
+    await act(async () => {
+      result.current.resolve.mutate({ id: 'a1', note: 'fixed' });
+    });
+    await waitFor(() => expect(result.current.resolve.isSuccess).toBe(true));
+
+    await waitFor(() => expect(result.current.list.data).toEqual([]));
+    expect(listCalls()).toBeGreaterThan(before);
+  });
+
+  it('should refetch the open-alert badge count after resolving', async () => {
+    const server = seedAlertServer({ open: [{ _id: 'a1', status: 'firing' }], total: 3 });
+    (v2Api.alerts.resolve as jest.Mock).mockImplementation(async (id: string) => {
+      server.total = 2;
+      return { data: { _id: id, status: 'resolved' } };
+    });
+
+    const result = await mountSettled();
+    expect(result.current.count.data).toBe(3);
+
+    await act(async () => {
+      result.current.resolve.mutate({ id: 'a1' });
+    });
+    await waitFor(() => expect(result.current.resolve.isSuccess).toBe(true));
+
+    await waitFor(() => expect(result.current.count.data).toBe(2));
+  });
+
+  it('should refetch the open alert detail after resolving', async () => {
+    const server = seedAlertServer({ open: [{ _id: 'a1', status: 'firing' }], total: 3 });
+    (v2Api.alerts.resolve as jest.Mock).mockImplementation(async (id: string) => {
+      server.store[id] = { _id: id, status: 'resolved' };
+      return { data: server.store[id] };
+    });
+
+    const result = await mountSettled();
+    const before = detailCalls();
+    expect(result.current.detail.data).toEqual({ _id: 'a1', status: 'firing' });
+
+    await act(async () => {
+      result.current.resolve.mutate({ id: 'a1' });
+    });
+    await waitFor(() => expect(result.current.resolve.isSuccess).toBe(true));
+
+    await waitFor(() =>
+      expect(result.current.detail.data).toEqual({ _id: 'a1', status: 'resolved' })
+    );
+    expect(detailCalls()).toBeGreaterThan(before);
   });
 });

--- a/__tests__/unit/lib/useAlerts.test.tsx
+++ b/__tests__/unit/lib/useAlerts.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * useAlerts Hook Tests
+ *
+ * @jest-environment jsdom
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import {
+  useAlertsList,
+  useAlertDetail,
+  useAcknowledgeAlert,
+  useResolveAlert,
+  useOpenAlertCount,
+} from '@/lib/query/hooks/useAlerts';
+import { v2Api } from '@/lib/api/v2-client';
+
+jest.mock('@/lib/api/v2-client', () => ({
+  v2Api: {
+    alerts: {
+      list: jest.fn(),
+      getById: jest.fn(),
+      acknowledge: jest.fn(),
+      resolve: jest.fn(),
+    },
+  },
+}));
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return React.createElement(QueryClientProvider, { client }, children);
+}
+
+describe('useAlertsList', () => {
+  it('should return the alerts array', async () => {
+    (v2Api.alerts.list as jest.Mock).mockResolvedValue({ data: [{ _id: 'a1', status: 'firing' }] });
+
+    const { result } = renderHook(() => useAlertsList({ status: 'firing' }), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ _id: 'a1', status: 'firing' }]);
+    expect(v2Api.alerts.list).toHaveBeenCalledWith({ status: 'firing' });
+  });
+
+  it('should surface an error', async () => {
+    (v2Api.alerts.list as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useAlertsList(), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe('useAlertDetail', () => {
+  it('should be disabled without an id', () => {
+    const { result } = renderHook(() => useAlertDetail(''), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(v2Api.alerts.getById).not.toHaveBeenCalled();
+  });
+});
+
+describe('mutations', () => {
+  it('should acknowledge', async () => {
+    (v2Api.alerts.acknowledge as jest.Mock).mockResolvedValue({ data: { _id: 'a1', status: 'acknowledged' } });
+
+    const { result } = renderHook(() => useAcknowledgeAlert(), { wrapper });
+    result.current.mutate({ id: 'a1' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(v2Api.alerts.acknowledge).toHaveBeenCalledWith('a1', undefined);
+  });
+
+  it('should resolve with a note', async () => {
+    (v2Api.alerts.resolve as jest.Mock).mockResolvedValue({ data: { _id: 'a1', status: 'resolved' } });
+
+    const { result } = renderHook(() => useResolveAlert(), { wrapper });
+    result.current.mutate({ id: 'a1', note: 'fixed' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(v2Api.alerts.resolve).toHaveBeenCalledWith('a1', 'fixed');
+  });
+});
+
+describe('useOpenAlertCount', () => {
+  it('should read pagination.total, not the row count', async () => {
+    (v2Api.alerts.list as jest.Mock).mockResolvedValue({
+      data: [{ _id: 'a1' }],     // one row...
+      pagination: { total: 143 }, // ...but 143 open alerts
+    });
+
+    const { result } = renderHook(() => useOpenAlertCount(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(143);
+  });
+
+  it('should request a single row rather than a full page', async () => {
+    (v2Api.alerts.list as jest.Mock).mockResolvedValue({
+      data: [],
+      pagination: { total: 0 },
+    });
+
+    const { result } = renderHook(() => useOpenAlertCount(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(v2Api.alerts.list).toHaveBeenCalledWith({ limit: 1 });
+  });
+});

--- a/__tests__/unit/lib/v2-client-alerts.test.ts
+++ b/__tests__/unit/lib/v2-client-alerts.test.ts
@@ -1,0 +1,90 @@
+/**
+ * V2 API Client — Alerts and Alert Rules
+ */
+
+import { alertsApi, alertRulesApi } from '@/lib/api/v2-client';
+
+const originalFetch = global.fetch;
+
+function mockJson(data: unknown, status = 200) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: status < 400,
+    status,
+    json: async () => ({ success: status < 400, data, timestamp: new Date().toISOString() }),
+  }) as unknown as typeof fetch;
+}
+
+function calledUrl(): string {
+  return (global.fetch as jest.Mock).mock.calls[0][0] as string;
+}
+
+function calledInit(): RequestInit {
+  return (global.fetch as jest.Mock).mock.calls[0][1] as RequestInit;
+}
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe('alertsApi', () => {
+  it('should build the list URL with filters', async () => {
+    mockJson([]);
+    await alertsApi.list({ status: 'firing', severity: 'critical', limit: 10 });
+
+    const url = calledUrl();
+    expect(url).toContain('/api/v2/alerts?');
+    expect(url).toContain('status=firing');
+    expect(url).toContain('severity=critical');
+    expect(url).toContain('limit=10');
+  });
+
+  it('should request a single alert with include_device', async () => {
+    mockJson({});
+    await alertsApi.getById('507f1f77bcf86cd799439011', { include_device: true });
+
+    expect(calledUrl()).toBe('/api/v2/alerts/507f1f77bcf86cd799439011?include_device=true');
+  });
+
+  it('should PATCH acknowledged', async () => {
+    mockJson({});
+    await alertsApi.acknowledge('507f1f77bcf86cd799439011');
+
+    expect(calledInit().method).toBe('PATCH');
+    expect(JSON.parse(calledInit().body as string)).toEqual({ status: 'acknowledged' });
+  });
+
+  it('should PATCH resolved with a note', async () => {
+    mockJson({});
+    await alertsApi.resolve('507f1f77bcf86cd799439011', 'Swapped sensor');
+
+    expect(JSON.parse(calledInit().body as string)).toEqual({
+      status: 'resolved',
+      note: 'Swapped sensor',
+    });
+  });
+});
+
+describe('alertRulesApi', () => {
+  it('should POST a new rule', async () => {
+    mockJson({});
+    await alertRulesApi.create({
+      name: 'R',
+      metric: 'value',
+      comparison: 'gt',
+      threshold: 30,
+      severity: 'warning',
+      selector: { types: ['temperature'] },
+    });
+
+    expect(calledUrl()).toBe('/api/v2/alert-rules');
+    expect(calledInit().method).toBe('POST');
+  });
+
+  it('should DELETE a rule', async () => {
+    mockJson({});
+    await alertRulesApi.delete('507f1f77bcf86cd799439011');
+
+    expect(calledUrl()).toBe('/api/v2/alert-rules/507f1f77bcf86cd799439011');
+    expect(calledInit().method).toBe('DELETE');
+  });
+});

--- a/__tests__/unit/models/AlertRuleV2.test.ts
+++ b/__tests__/unit/models/AlertRuleV2.test.ts
@@ -26,7 +26,7 @@ describe('AlertRuleV2 Model', () => {
       expect(rule.enabled).toBe(true);
       expect(rule.for_duration_seconds).toBe(0);
       expect(rule.cooldown_seconds).toBe(300);
-      expect(rule.selector.types).toEqual(['temperature']);
+      expect(rule.selector?.types).toEqual(['temperature']);
       expect(rule.audit.created_at).toBeInstanceOf(Date);
       expect(rule.audit.deleted_at).toBeUndefined();
     });
@@ -36,7 +36,7 @@ describe('AlertRuleV2 Model', () => {
         createAlertRuleInput({ metric: 'battery_level', comparison: 'lt', threshold: 20, selector: {} })
       );
 
-      expect(rule.selector.types).toBeUndefined();
+      expect(rule.selector?.types).toBeUndefined();
     });
 
     it('should reject an unknown metric', async () => {

--- a/__tests__/unit/models/AlertRuleV2.test.ts
+++ b/__tests__/unit/models/AlertRuleV2.test.ts
@@ -1,0 +1,109 @@
+/**
+ * AlertRuleV2 Model Unit Tests
+ */
+
+import AlertRuleV2, { READING_TYPES } from '@/models/v2/AlertRuleV2';
+import { createAlertRuleInput, resetCounters } from '../../setup/factories';
+
+describe('AlertRuleV2 Model', () => {
+  beforeEach(() => {
+    resetCounters();
+  });
+
+  describe('document creation', () => {
+    it('should create a rule with defaults applied', async () => {
+      const rule = await AlertRuleV2.create(
+        createAlertRuleInput({
+          name: 'High temperature',
+          metric: 'value',
+          comparison: 'gt',
+          threshold: 30,
+          severity: 'critical',
+          selector: { types: ['temperature'] },
+        })
+      );
+
+      expect(rule.enabled).toBe(true);
+      expect(rule.for_duration_seconds).toBe(0);
+      expect(rule.cooldown_seconds).toBe(300);
+      expect(rule.selector.types).toEqual(['temperature']);
+      expect(rule.audit.created_at).toBeInstanceOf(Date);
+      expect(rule.audit.deleted_at).toBeUndefined();
+    });
+
+    it('should allow a rule with no selector types (fleet-wide)', async () => {
+      const rule = await AlertRuleV2.create(
+        createAlertRuleInput({ metric: 'battery_level', comparison: 'lt', threshold: 20, selector: {} })
+      );
+
+      expect(rule.selector.types).toBeUndefined();
+    });
+
+    it('should reject an unknown metric', async () => {
+      await expect(
+        AlertRuleV2.create(createAlertRuleInput({ metric: 'humidity_delta' as never }))
+      ).rejects.toThrow();
+    });
+
+    it('should expose all 15 reading types', () => {
+      expect(READING_TYPES).toHaveLength(15);
+      expect(READING_TYPES).toContain('temperature');
+      expect(READING_TYPES).toContain('energy');
+    });
+  });
+
+  describe('findActive', () => {
+    it('should exclude soft-deleted rules', async () => {
+      const kept = await AlertRuleV2.create(createAlertRuleInput({ name: 'Kept' }));
+      const gone = await AlertRuleV2.create(createAlertRuleInput({ name: 'Gone' }));
+      await AlertRuleV2.softDelete(String(gone._id), 'admin@example.com');
+
+      const active = await AlertRuleV2.findActive().lean();
+
+      expect(active).toHaveLength(1);
+      expect(String(active[0]._id)).toBe(String(kept._id));
+    });
+
+    it('should accept an additional filter', async () => {
+      await AlertRuleV2.create(createAlertRuleInput({ name: 'On', enabled: true }));
+      await AlertRuleV2.create(createAlertRuleInput({ name: 'Off', enabled: false }));
+
+      const active = await AlertRuleV2.findActive({ enabled: true }).lean();
+
+      expect(active).toHaveLength(1);
+      expect(active[0].name).toBe('On');
+    });
+  });
+
+  describe('softDelete', () => {
+    it('should stamp deleted_at and deleted_by', async () => {
+      const rule = await AlertRuleV2.create(createAlertRuleInput());
+
+      const deleted = await AlertRuleV2.softDelete(String(rule._id), 'admin@example.com');
+
+      expect(deleted?.audit.deleted_at).toBeInstanceOf(Date);
+      expect(deleted?.audit.deleted_by).toBe('admin@example.com');
+    });
+
+    it('should return null for an unknown id', async () => {
+      const missing = await AlertRuleV2.softDelete('507f1f77bcf86cd799439011', 'admin@example.com');
+      expect(missing).toBeNull();
+    });
+  });
+
+  describe('middleware', () => {
+    it('should bump audit.updated_at on findOneAndUpdate', async () => {
+      const rule = await AlertRuleV2.create(createAlertRuleInput());
+      const before = rule.audit.updated_at;
+
+      await new Promise(r => setTimeout(r, 5));
+      const updated = await AlertRuleV2.findByIdAndUpdate(
+        rule._id,
+        { $set: { threshold: 99 } },
+        { new: true }
+      );
+
+      expect(updated!.audit.updated_at.getTime()).toBeGreaterThan(before.getTime());
+    });
+  });
+});

--- a/__tests__/unit/models/AlertRuleV2.test.ts
+++ b/__tests__/unit/models/AlertRuleV2.test.ts
@@ -2,8 +2,34 @@
  * AlertRuleV2 Model Unit Tests
  */
 
+import type { Schema } from 'mongoose';
 import AlertRuleV2, { READING_TYPES } from '@/models/v2/AlertRuleV2';
+import ReadingV2 from '@/models/v2/ReadingV2';
+import DeviceV2 from '@/models/v2/DeviceV2';
+import { readingTypeSchema } from '@/lib/validations/v2/reading.validation';
+import { deviceTypeSchema } from '@/lib/validations/v2/device.validation';
 import { createAlertRuleInput, resetCounters } from '../../setup/factories';
+
+/**
+ * Read an `enum` off a compiled Mongoose path. Deliberately goes through the
+ * live schema rather than re-importing a constant: the enum literal in
+ * ReadingV2.ts / DeviceV2.ts is a SEPARATE hand-maintained copy of the reading
+ * type list, and reading it back out of the schema is the only way to compare
+ * against it without simply restating it here.
+ */
+function schemaEnum(schema: Schema, path: string): string[] {
+  const options = schema.path(path)?.options as { enum?: string[] } | undefined;
+  const values = options?.enum;
+  if (!values) throw new Error(`No enum on schema path "${path}"`);
+  return values;
+}
+
+/** The `metadata` sub-schema of the readings timeseries collection. */
+function readingMetadataSchema(): Schema {
+  return (ReadingV2.schema.path('metadata') as unknown as { schema: Schema }).schema;
+}
+
+const sorted = (values: readonly string[]) => [...values].sort();
 
 describe('AlertRuleV2 Model', () => {
   beforeEach(() => {
@@ -45,10 +71,45 @@ describe('AlertRuleV2 Model', () => {
       ).rejects.toThrow();
     });
 
-    it('should expose all 15 reading types', () => {
-      expect(READING_TYPES).toHaveLength(15);
-      expect(READING_TYPES).toContain('temperature');
-      expect(READING_TYPES).toContain('energy');
+  });
+
+  /**
+   * READING_TYPES is one of several hand-maintained copies of the reading type
+   * list (see "Adding a New Device / Reading Type" in CLAUDE.md). A count
+   * assertion — which is what used to live here — passes as soon as somebody
+   * adds a 16th type to one copy and a 16th type to this one, even if they are
+   * different types. These compare the actual SETS.
+   *
+   * The compile-time guard in models/v2/AlertRuleV2.ts covers the copies that
+   * are TypeScript unions; `tsc` cannot see a Mongoose `enum` array or a Zod
+   * `z.enum`, so those are covered here at runtime. Between the two, every copy
+   * outside the UI layer is checked.
+   *
+   * Why it matters that this is not a count: an omitted type gets NO rule
+   * bucket in lib/alerting/rule-cache.ts, `evaluateReadings` then evaluates
+   * every reading of that type against zero rules, and fleet-wide rules (no
+   * `selector.types` at all) stop applying to it too. Nothing throws, nothing
+   * is counted, and every affected rule still reads as Enabled.
+   */
+  describe('READING_TYPES conformance', () => {
+    it('should match the ReadingV2 timeseries metadata.type enum', () => {
+      expect(sorted(READING_TYPES)).toEqual(sorted(schemaEnum(readingMetadataSchema(), 'type')));
+    });
+
+    it('should match the DeviceV2 type enum', () => {
+      expect(sorted(READING_TYPES)).toEqual(sorted(schemaEnum(DeviceV2.schema, 'type')));
+    });
+
+    it('should match the reading validation Zod enum', () => {
+      expect(sorted(READING_TYPES)).toEqual(sorted(readingTypeSchema.options));
+    });
+
+    it('should match the device validation Zod enum', () => {
+      expect(sorted(READING_TYPES)).toEqual(sorted(deviceTypeSchema.options));
+    });
+
+    it('should have no duplicate entries', () => {
+      expect(new Set(READING_TYPES).size).toBe(READING_TYPES.length);
     });
   });
 

--- a/__tests__/unit/models/AlertV2.test.ts
+++ b/__tests__/unit/models/AlertV2.test.ts
@@ -6,7 +6,11 @@
  */
 
 import { Types } from 'mongoose';
-import AlertV2, { AlertTransitionError } from '@/models/v2/AlertV2';
+import AlertV2, {
+  AlertInvariantError,
+  AlertTransitionError,
+  isOpenForStatus,
+} from '@/models/v2/AlertV2';
 import { createAlertInput, resetCounters } from '../../setup/factories';
 
 /** The one invariant that keeps the partial unique index correct. */
@@ -167,6 +171,239 @@ describe('AlertV2 Model', () => {
     it('should return null for an unknown id', async () => {
       const result = await AlertV2.resolve('507f1f77bcf86cd799439011', 'user_admin');
       expect(result).toBeNull();
+    });
+  });
+
+  // ==========================================================================
+  // status / is_open INVARIANT ENFORCEMENT
+  // ==========================================================================
+  //
+  // The invariant used to live only in a comment. The damage a drifted document
+  // does is entirely invisible: a `resolved` document that kept `is_open: true`
+  // stays in the partial unique dedup index forever, so the evaluator — which
+  // loads open episodes purely on `is_open` — can never open another episode for
+  // that (rule, device) pair, and never resolves the stuck one either. Nothing
+  // logs, nothing counts, and the type system cannot help because the
+  // evaluator's bulk insert reaches the driver through a cast.
+  //
+  // These tests therefore assert on the DOCUMENT that lands, and — where the
+  // consequence is what matters — on the dedup index's behavior afterwards,
+  // not merely on which error type came back.
+  describe('status/is_open invariant', () => {
+    describe('isOpenForStatus', () => {
+      it('should map every status to its open state', () => {
+        expect(isOpenForStatus('pending')).toBe(true);
+        expect(isOpenForStatus('firing')).toBe(true);
+        expect(isOpenForStatus('acknowledged')).toBe(true);
+        expect(isOpenForStatus('resolved')).toBe(false);
+      });
+    });
+
+    describe('document writes', () => {
+      it('should reject a resolved document that keeps is_open true', async () => {
+        await expect(
+          AlertV2.create(createAlertInput({ status: 'resolved', is_open: true }))
+        ).rejects.toThrow(/is_open/);
+
+        expect(await AlertV2.countDocuments({})).toBe(0);
+      });
+
+      it('should reject an open document written with is_open false', async () => {
+        await expect(
+          AlertV2.create(createAlertInput({ status: 'firing', is_open: false }))
+        ).rejects.toThrow(/is_open/);
+
+        expect(await AlertV2.countDocuments({})).toBe(0);
+      });
+
+      it('should reject an inconsistent document on insertMany too', async () => {
+        await expect(
+          AlertV2.insertMany([createAlertInput({ status: 'resolved', is_open: true })])
+        ).rejects.toThrow(/is_open/);
+      });
+    });
+
+    describe('update writes', () => {
+      it('should derive is_open when an update sets status alone', async () => {
+        const alert = await AlertV2.create(createAlertInput({ status: 'firing', is_open: true }));
+
+        await AlertV2.updateOne({ _id: alert._id }, { $set: { status: 'resolved' } });
+
+        const stored = await AlertV2.findById(alert._id).lean();
+        expect(stored!.status).toBe('resolved');
+        expect(stored!.is_open).toBe(false);
+      });
+
+      it('should derive is_open for an operator-free update document', async () => {
+        const alert = await AlertV2.create(createAlertInput({ status: 'firing', is_open: true }));
+
+        // Mongoose casts a bare update into $set AFTER middleware runs, so this
+        // shape genuinely reaches the guard in its uncast form.
+        await AlertV2.updateOne({ _id: alert._id }, { status: 'resolved' });
+
+        const stored = await AlertV2.findById(alert._id).lean();
+        expect(stored!.is_open).toBe(false);
+      });
+
+      it('should reject an update that sets status and is_open in contradiction', async () => {
+        const alert = await AlertV2.create(createAlertInput({ status: 'firing', is_open: true }));
+
+        await expect(
+          AlertV2.updateOne(
+            { _id: alert._id },
+            { $set: { status: 'resolved', is_open: true } }
+          )
+        ).rejects.toBeInstanceOf(AlertInvariantError);
+
+        const stored = await AlertV2.findById(alert._id).lean();
+        expect(stored!.status).toBe('firing'); // nothing was written
+        expect(stored!.is_open).toBe(true);
+      });
+
+      it('should reject an update that sets is_open without status', async () => {
+        const alert = await AlertV2.create(createAlertInput({ status: 'firing', is_open: true }));
+
+        await expect(
+          AlertV2.updateOne({ _id: alert._id }, { $set: { is_open: false } })
+        ).rejects.toBeInstanceOf(AlertInvariantError);
+
+        const stored = await AlertV2.findById(alert._id).lean();
+        expect(stored!.is_open).toBe(true);
+      });
+
+      it('should leave an update that touches neither field alone', async () => {
+        const alert = await AlertV2.create(createAlertInput({ status: 'firing', is_open: true }));
+
+        await AlertV2.updateOne({ _id: alert._id }, { $set: { last_value: 99 } });
+
+        const stored = await AlertV2.findById(alert._id).lean();
+        expect(stored!.last_value).toBe(99);
+        expect(stored!.status).toBe('firing');
+        expect(stored!.is_open).toBe(true);
+      });
+
+      it('should reject a contradictory findOneAndUpdate', async () => {
+        const alert = await AlertV2.create(createAlertInput({ status: 'firing', is_open: true }));
+
+        await expect(
+          AlertV2.findOneAndUpdate(
+            { _id: alert._id },
+            { $set: { status: 'resolved', is_open: true } }
+          )
+        ).rejects.toBeInstanceOf(AlertInvariantError);
+      });
+    });
+
+    // bulkWrite bypasses query middleware entirely, and it is how BOTH
+    // production writers that resolve an episode reach the database (the
+    // evaluator's auto-resolve and the staleness sweep). An enforcement that
+    // only covered updateOne/findOneAndUpdate would miss them both.
+    describe('bulkWrite writes', () => {
+      it('should derive is_open for a bulk update that sets status alone, freeing the dedup index', async () => {
+        await AlertV2.init(); // the partial unique index must exist to be exercised
+
+        const rule_id = new Types.ObjectId();
+        const alert = await AlertV2.create(
+          createAlertInput({ rule_id, device_id: 'device_bulk', status: 'firing', is_open: true })
+        );
+
+        await AlertV2.bulkWrite([
+          { updateOne: { filter: { _id: alert._id }, update: { $set: { status: 'resolved' } } } },
+        ]);
+
+        const stored = await AlertV2.findById(alert._id).lean();
+        expect(stored!.status).toBe('resolved');
+        expect(stored!.is_open).toBe(false);
+
+        // The consequence, not just the field: with is_open correctly false the
+        // pair has left the partial unique index, so a NEW episode can open. If
+        // is_open had stayed true this insert would throw E11000 and the pair
+        // would be wedged forever.
+        await expect(
+          AlertV2.create(
+            createAlertInput({ rule_id, device_id: 'device_bulk', status: 'firing' })
+          )
+        ).resolves.toBeDefined();
+      });
+
+      it('should reject a bulk update that sets status and is_open in contradiction', async () => {
+        const alert = await AlertV2.create(createAlertInput({ status: 'firing', is_open: true }));
+
+        await expect(
+          AlertV2.bulkWrite([
+            {
+              updateOne: {
+                filter: { _id: alert._id },
+                update: { $set: { status: 'resolved', is_open: true } },
+              },
+            },
+          ])
+        ).rejects.toBeInstanceOf(AlertInvariantError);
+
+        const stored = await AlertV2.findById(alert._id).lean();
+        expect(stored!.status).toBe('firing');
+      });
+
+      // With `{ ordered: false }` — which both production callers use — a
+      // document that merely fails validation is DROPPED from the batch and
+      // decorated onto the result rather than thrown. That is exactly the
+      // silence the finding is about, so the insert path is guarded before the
+      // cast, where it can still fail the call.
+      it('should reject an inconsistent bulk insert instead of silently dropping it', async () => {
+        await expect(
+          AlertV2.bulkWrite(
+            [
+              {
+                insertOne: {
+                  document: createAlertInput({ status: 'resolved', is_open: true }) as never,
+                },
+              },
+            ],
+            { ordered: false }
+          )
+        ).rejects.toBeInstanceOf(AlertInvariantError);
+
+        expect(await AlertV2.countDocuments({})).toBe(0);
+      });
+
+      it('should leave a bulk update that touches neither field alone', async () => {
+        const alert = await AlertV2.create(createAlertInput({ status: 'firing', is_open: true }));
+
+        await AlertV2.bulkWrite([
+          {
+            updateOne: {
+              filter: { _id: alert._id },
+              update: { $set: { last_value: 77 }, $max: { last_observed_at: new Date() } },
+            },
+          },
+        ]);
+
+        const stored = await AlertV2.findById(alert._id).lean();
+        expect(stored!.last_value).toBe(77);
+        expect(stored!.is_open).toBe(true);
+      });
+    });
+
+    // The five writers that existed before this guard, each re-verified to
+    // still land a consistent document THROUGH the guard rather than around it.
+    describe('the existing writers still work', () => {
+      it('acknowledge() leaves an open, consistent document', async () => {
+        const alert = await AlertV2.create(createAlertInput({ status: 'firing', is_open: true }));
+
+        const acked = await AlertV2.acknowledge(String(alert._id), 'user_admin');
+
+        expect(acked!.status).toBe('acknowledged');
+        expect(acked!.is_open).toBe(true);
+      });
+
+      it('resolve() leaves a closed, consistent document', async () => {
+        const alert = await AlertV2.create(createAlertInput({ status: 'firing', is_open: true }));
+
+        const resolved = await AlertV2.resolve(String(alert._id), 'user_admin');
+
+        expect(resolved!.status).toBe('resolved');
+        expect(resolved!.is_open).toBe(false);
+      });
     });
   });
 });

--- a/__tests__/unit/models/AlertV2.test.ts
+++ b/__tests__/unit/models/AlertV2.test.ts
@@ -1,0 +1,172 @@
+/**
+ * AlertV2 Model Unit Tests
+ *
+ * Covers every legal transition, every illegal transition throwing the correct
+ * typed code, and the is_open === (status !== 'resolved') invariant after each.
+ */
+
+import { Types } from 'mongoose';
+import AlertV2, { AlertTransitionError } from '@/models/v2/AlertV2';
+import { createAlertInput, resetCounters } from '../../setup/factories';
+
+/** The one invariant that keeps the partial unique index correct. */
+function assertIsOpenInvariant(doc: { status: string; is_open: boolean }) {
+  expect(doc.is_open).toBe(doc.status !== 'resolved');
+}
+
+describe('AlertV2 Model', () => {
+  beforeEach(() => {
+    resetCounters();
+  });
+
+  describe('AlertTransitionError', () => {
+    it('should carry name and code', () => {
+      const error = new AlertTransitionError('ALREADY_RESOLVED', 'Already resolved');
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.name).toBe('AlertTransitionError');
+      expect(error.code).toBe('ALREADY_RESOLVED');
+    });
+  });
+
+  describe('document creation', () => {
+    it('should create a firing alert satisfying the is_open invariant', async () => {
+      const alert = await AlertV2.create(createAlertInput({ status: 'firing', is_open: true }));
+
+      assertIsOpenInvariant(alert);
+      expect(alert.audit.created_by).toBe('system');
+    });
+
+    it('should reject an unknown status', async () => {
+      await expect(
+        AlertV2.create(createAlertInput({ status: 'exploded' as never }))
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('deduplication index', () => {
+    it('should reject a second open episode for the same rule and device', async () => {
+      await AlertV2.init(); // ensure indexes are built before asserting on them
+
+      const rule_id = new Types.ObjectId();
+      await AlertV2.create(createAlertInput({ rule_id, device_id: 'device_001', is_open: true }));
+
+      await expect(
+        AlertV2.create(createAlertInput({ rule_id, device_id: 'device_001', is_open: true }))
+      ).rejects.toMatchObject({ code: 11000 });
+    });
+
+    it('should allow unlimited resolved episodes for the same rule and device', async () => {
+      await AlertV2.init();
+
+      const rule_id = new Types.ObjectId();
+      await AlertV2.create(
+        createAlertInput({ rule_id, device_id: 'device_002', status: 'resolved', is_open: false })
+      );
+      await AlertV2.create(
+        createAlertInput({ rule_id, device_id: 'device_002', status: 'resolved', is_open: false })
+      );
+
+      const count = await AlertV2.countDocuments({ rule_id, device_id: 'device_002' });
+      expect(count).toBe(2);
+    });
+  });
+
+  describe('acknowledge', () => {
+    it('should move firing to acknowledged and leave is_open true', async () => {
+      const alert = await AlertV2.create(createAlertInput({ status: 'firing', is_open: true }));
+
+      const acked = await AlertV2.acknowledge(String(alert._id), 'user_admin');
+
+      expect(acked!.status).toBe('acknowledged');
+      expect(acked!.audit.acknowledged_by).toBe('user_admin');
+      expect(acked!.audit.acknowledged_at).toBeInstanceOf(Date);
+      assertIsOpenInvariant(acked!);
+    });
+
+    it('should throw ALREADY_ACKNOWLEDGED when already acknowledged', async () => {
+      const alert = await AlertV2.create(
+        createAlertInput({ status: 'acknowledged', is_open: true })
+      );
+
+      await expect(AlertV2.acknowledge(String(alert._id), 'user_admin')).rejects.toMatchObject({
+        name: 'AlertTransitionError',
+        code: 'ALREADY_ACKNOWLEDGED',
+      });
+    });
+
+    it('should throw ALREADY_RESOLVED when resolved', async () => {
+      const alert = await AlertV2.create(createAlertInput({ status: 'resolved', is_open: false }));
+
+      await expect(AlertV2.acknowledge(String(alert._id), 'user_admin')).rejects.toMatchObject({
+        code: 'ALREADY_RESOLVED',
+      });
+    });
+
+    it('should throw NOT_YET_FIRING when pending', async () => {
+      const alert = await AlertV2.create(createAlertInput({ status: 'pending', is_open: true }));
+
+      await expect(AlertV2.acknowledge(String(alert._id), 'user_admin')).rejects.toMatchObject({
+        code: 'NOT_YET_FIRING',
+      });
+    });
+
+    it('should return null for an unknown id', async () => {
+      const result = await AlertV2.acknowledge('507f1f77bcf86cd799439011', 'user_admin');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('resolve', () => {
+    it('should resolve a firing alert and flip is_open to false', async () => {
+      const alert = await AlertV2.create(createAlertInput({ status: 'firing', is_open: true }));
+
+      const resolved = await AlertV2.resolve(String(alert._id), 'user_admin');
+
+      expect(resolved!.status).toBe('resolved');
+      expect(resolved!.audit.resolution).toBe('manual');
+      expect(resolved!.audit.resolved_by).toBe('user_admin');
+      assertIsOpenInvariant(resolved!);
+    });
+
+    it('should resolve an acknowledged alert', async () => {
+      const alert = await AlertV2.create(
+        createAlertInput({ status: 'acknowledged', is_open: true })
+      );
+
+      const resolved = await AlertV2.resolve(String(alert._id), 'user_admin');
+
+      expect(resolved!.status).toBe('resolved');
+      assertIsOpenInvariant(resolved!);
+    });
+
+    it('should record a non-default resolution', async () => {
+      const alert = await AlertV2.create(createAlertInput({ status: 'firing', is_open: true }));
+
+      const resolved = await AlertV2.resolve(String(alert._id), 'system', 'stale');
+
+      expect(resolved!.audit.resolution).toBe('stale');
+    });
+
+    it('should throw ALREADY_RESOLVED when already resolved', async () => {
+      const alert = await AlertV2.create(createAlertInput({ status: 'resolved', is_open: false }));
+
+      await expect(AlertV2.resolve(String(alert._id), 'user_admin')).rejects.toMatchObject({
+        code: 'ALREADY_RESOLVED',
+      });
+    });
+
+    it('should throw NOT_YET_FIRING when pending', async () => {
+      const alert = await AlertV2.create(createAlertInput({ status: 'pending', is_open: true }));
+
+      await expect(AlertV2.resolve(String(alert._id), 'user_admin')).rejects.toMatchObject({
+        code: 'NOT_YET_FIRING',
+      });
+    });
+
+    it('should return null for an unknown id', async () => {
+      const result = await AlertV2.resolve('507f1f77bcf86cd799439011', 'user_admin');
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/__tests__/unit/models/DeviceV2.test.ts
+++ b/__tests__/unit/models/DeviceV2.test.ts
@@ -19,6 +19,35 @@ import {
   VALID_DEVICE_STATUSES,
 } from '../../setup/factories';
 
+/**
+ * Runs `fn` with a clock that advances a millisecond on every `new Date()`.
+ *
+ * `audit.created_at` and `audit.updated_at` are populated by two independent clock
+ * reads, so on a loaded machine they can land in different milliseconds. This forces
+ * that interleaving deterministically instead of waiting for it to happen by chance.
+ */
+async function withDivergentClock<T>(fn: () => Promise<T>): Promise<T> {
+  const RealDate = global.Date;
+  let tick = 0;
+
+  class DivergentDate extends RealDate {
+    constructor(...args: unknown[]) {
+      if (args.length === 0) {
+        super(RealDate.now() + tick);
+        tick += 1;
+        // Spread forwards every argument at runtime; the cast just picks an overload.
+      } else super(...(args as [number]));
+    }
+  }
+
+  global.Date = DivergentDate as DateConstructor;
+  try {
+    return await fn();
+  } finally {
+    global.Date = RealDate;
+  }
+}
+
 describe('DeviceV2 Model', () => {
   beforeEach(() => {
     resetCounters();
@@ -408,6 +437,29 @@ describe('DeviceV2 Model', () => {
           -2
         );
         expect(device.audit.created_at.getTime()).toBeGreaterThanOrEqual(beforeCreate.getTime());
+      });
+
+      it('should keep updated_at exactly equal to created_at when the clock advances mid-create', async () => {
+        const device = await withDivergentClock(() =>
+          DeviceV2.create(createDeviceInput({ _id: 'device_divergent_clock' }))
+        );
+
+        // Exact equality matters: the history and audit endpoints treat any difference
+        // between these two as a real edit, so a millisecond of drift invents an
+        // "updated" entry for a device nobody has touched.
+        expect(device.audit.updated_at.getTime()).toBe(device.audit.created_at.getTime());
+      });
+
+      it('should preserve an explicitly supplied updated_at', async () => {
+        const created_at = new Date('2020-01-01T00:00:00.000Z');
+        const updated_at = new Date('2021-06-06T00:00:00.000Z');
+
+        const device = await DeviceV2.create({
+          ...createDeviceInput({ _id: 'device_explicit_audit' }),
+          audit: { created_at, created_by: 'seed', updated_at, updated_by: 'seed' },
+        });
+
+        expect(device.audit.updated_at.getTime()).toBe(updated_at.getTime());
       });
     });
 

--- a/__tests__/unit/scripts/index-shape.test.ts
+++ b/__tests__/unit/scripts/index-shape.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Index Shape Comparison Tests
+ *
+ * `verify-indexes.ts`'s dedup check historically compared only key fields (as a
+ * SUBSET match — extra fields on the live index were ignored) and the `unique`
+ * flag. It never looked at `partialFilterExpression`. That let a plain unique
+ * index on `{rule_id, device_id}` pass verification as though it were the partial
+ * dedup index defined in AlertV2.ts:167-170.
+ *
+ * That confusion is catastrophic, not cosmetic: a plain (non-partial) unique index
+ * permits exactly one alert document EVER per (rule, device) pair, instead of one
+ * *open* one. The first resolved episode then permanently blocks every later
+ * episode for that device, and the evaluator absorbs the resulting E11000 as a
+ * benign race (see the duplicate-key handling in lib/alerting/evaluate.ts) — so
+ * alerting goes silent with no error, no log, and no metric movement. The verifier
+ * is the only thing standing between that state and production.
+ *
+ * These tests pin the fixed comparison logic in scripts/v2/index-shape.ts. No live
+ * database is involved — that is the point of extracting the comparison functions
+ * out of verify-indexes.ts and create-indexes-v2.ts, both of which connect to
+ * MongoDB and run unconditionally at import time.
+ */
+
+import {
+  checkIndexExists,
+  indexShapeMatches,
+  keysMatch,
+  partialFilterExpressionsMatch,
+  type IndexInfo,
+} from '@/scripts/v2/index-shape';
+
+// The real expectation declared in verify-indexes.ts for AlertV2's dedup index.
+// Reproduced here (rather than imported) so these tests pin behavior against a
+// value that cannot silently drift out of sync with the actual comparison inputs.
+const RULE_DEVICE_OPEN_UNIQUE_EXPECTATION = {
+  fields: { rule_id: 1, device_id: 1 },
+  unique: true,
+  partialFilterExpression: { is_open: true },
+};
+
+describe('checkIndexExists — AlertV2 dedup index', () => {
+  it('REJECTS a plain unique index on {rule_id, device_id} when the expectation declares a partialFilterExpression', () => {
+    // This is the catastrophic case from the task brief: an index that is unique
+    // and has the right keys, but is missing the partial filter entirely.
+    const plainUniqueIndex: IndexInfo[] = [
+      { name: 'rule_device_open_unique', key: { rule_id: 1, device_id: 1 }, unique: true },
+    ];
+
+    expect(checkIndexExists(plainUniqueIndex, RULE_DEVICE_OPEN_UNIQUE_EXPECTATION)).toBe(false);
+  });
+
+  it('ACCEPTS the correct partial unique index', () => {
+    const correctIndex: IndexInfo[] = [
+      {
+        name: 'rule_device_open_unique',
+        key: { rule_id: 1, device_id: 1 },
+        unique: true,
+        partialFilterExpression: { is_open: true },
+      },
+    ];
+
+    expect(checkIndexExists(correctIndex, RULE_DEVICE_OPEN_UNIQUE_EXPECTATION)).toBe(true);
+  });
+
+  it('REJECTS an index with the right filter but unique: false', () => {
+    const nonUniqueIndex: IndexInfo[] = [
+      {
+        name: 'rule_device_open_unique',
+        key: { rule_id: 1, device_id: 1 },
+        unique: false,
+        partialFilterExpression: { is_open: true },
+      },
+    ];
+
+    expect(checkIndexExists(nonUniqueIndex, RULE_DEVICE_OPEN_UNIQUE_EXPECTATION)).toBe(false);
+  });
+
+  it('does not let rule_device_resolved_at (as actually defined in AlertV2.ts) satisfy rule_device_open_unique', () => {
+    // The real, adjacent index: same first two fields, plus a third, and NOT
+    // unique. Note this case is already rejected today by the `unique` check
+    // alone (expected.unique: true vs. this index's unique: undefined) — see the
+    // isolating test directly below for the case that pins the field-exactness
+    // fix (item 3) specifically, independent of `unique`.
+    const resolvedAtIndex: IndexInfo[] = [
+      {
+        name: 'rule_device_resolved_at',
+        key: { rule_id: 1, device_id: 1, 'audit.resolved_at': -1 },
+      },
+    ];
+
+    expect(checkIndexExists(resolvedAtIndex, RULE_DEVICE_OPEN_UNIQUE_EXPECTATION)).toBe(false);
+  });
+
+  it('does not let a rule_device_resolved_at-shaped index satisfy rule_device_open_unique even when unique and filter also match', () => {
+    // Isolates the field-exactness fix (item 3) from the `unique`/filter checks.
+    // Old behavior compared fields as a SUBSET match: every one of `expected.fields`
+    // just had to be present with the right value on the live index, so an index
+    // with an extra third field ({rule_id, device_id, 'audit.resolved_at'}) would
+    // satisfy an expectation of {rule_id, device_id}. Under the old comparison,
+    // this synthetic index — unique and filtered exactly like the real dedup
+    // index, but with the extra field — would have been wrongly ACCEPTED. Fields
+    // must now match exactly (same fields, same order), so it is rejected purely
+    // for the extra field.
+    const supersetShapedIndex: IndexInfo[] = [
+      {
+        name: 'rule_device_resolved_at',
+        key: { rule_id: 1, device_id: 1, 'audit.resolved_at': -1 },
+        unique: true,
+        partialFilterExpression: { is_open: true },
+      },
+    ];
+
+    expect(checkIndexExists(supersetShapedIndex, RULE_DEVICE_OPEN_UNIQUE_EXPECTATION)).toBe(false);
+  });
+});
+
+describe('checkIndexExists — supplementary properties', () => {
+  it('treats partialFilterExpression comparison as key-order-insensitive', () => {
+    // Item 1 requires "order-insensitive structural equality" for the filter
+    // comparison specifically (unlike the key/field comparison, which item 3
+    // requires to be order-SENSITIVE). A live filter with keys in a different
+    // order than the expectation must still match.
+    const differentKeyOrder: IndexInfo[] = [
+      {
+        name: 'rule_device_open_unique',
+        key: { rule_id: 1, device_id: 1 },
+        unique: true,
+        partialFilterExpression: { extra: 1, is_open: true },
+      },
+    ];
+    const expectation = {
+      fields: { rule_id: 1, device_id: 1 },
+      unique: true,
+      partialFilterExpression: { is_open: true, extra: 1 },
+    };
+
+    expect(checkIndexExists(differentKeyOrder, expectation)).toBe(true);
+  });
+});
+
+describe('keysMatch', () => {
+  it('accepts identical fields in identical order', () => {
+    expect(keysMatch({ rule_id: 1, device_id: 1 }, { rule_id: 1, device_id: 1 })).toBe(true);
+  });
+
+  it('rejects the same fields in a different order', () => {
+    // Item 3 explicitly requires "same fields, same order" — field order is
+    // functionally significant for compound indexes (it determines which query
+    // and sort patterns the index can serve), so this must not be treated as
+    // equivalent even though both sides contain the same field/value pairs.
+    expect(keysMatch({ device_id: 1, rule_id: 1 }, { rule_id: 1, device_id: 1 })).toBe(false);
+  });
+
+  it('rejects a superset of fields (the old subset-match bug)', () => {
+    expect(
+      keysMatch({ rule_id: 1, device_id: 1, 'audit.resolved_at': -1 }, { rule_id: 1, device_id: 1 })
+    ).toBe(false);
+  });
+
+  it('rejects a matching field with a different sort direction', () => {
+    expect(keysMatch({ rule_id: 1, device_id: -1 }, { rule_id: 1, device_id: 1 })).toBe(false);
+  });
+});
+
+describe('partialFilterExpressionsMatch', () => {
+  it('matches when both are undefined', () => {
+    expect(partialFilterExpressionsMatch(undefined, undefined)).toBe(true);
+  });
+
+  it('does not match when only the actual index has a filter', () => {
+    expect(partialFilterExpressionsMatch({ is_open: true }, undefined)).toBe(false);
+  });
+
+  it('does not match when only the expectation has a filter', () => {
+    expect(partialFilterExpressionsMatch(undefined, { is_open: true })).toBe(false);
+  });
+
+  it('does not match when filter values differ', () => {
+    expect(partialFilterExpressionsMatch({ is_open: false }, { is_open: true })).toBe(false);
+  });
+
+  it('matches identical filters regardless of key order', () => {
+    expect(partialFilterExpressionsMatch({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+  });
+});
+
+describe('indexShapeMatches — create-indexes-v2.ts mismatch detection', () => {
+  // The expected shape create-indexes-v2.ts declares for rule_device_open_unique.
+  const EXPECTED_SHAPE = {
+    fields: { rule_id: 1, device_id: 1 },
+    unique: true,
+    partialFilterExpression: { is_open: true },
+  };
+
+  it('ACCEPTS a live index that is an exact match', () => {
+    expect(
+      indexShapeMatches(
+        {
+          key: { rule_id: 1, device_id: 1 },
+          unique: true,
+          partialFilterExpression: { is_open: true },
+        },
+        EXPECTED_SHAPE
+      )
+    ).toBe(true);
+  });
+
+  it('REJECTS a plain unique index missing the partialFilterExpression', () => {
+    // Mirrors the central checkIndexExists case, for create-indexes-v2.ts's
+    // separate consumer: a same-name index existing in the database with this
+    // shape must be reported as a mismatch, not silently [SKIP]ped.
+    expect(
+      indexShapeMatches({ key: { rule_id: 1, device_id: 1 }, unique: true }, EXPECTED_SHAPE)
+    ).toBe(false);
+  });
+
+  it('REJECTS when unique does not match exactly, even if the expectation does not require it', () => {
+    // Unlike checkIndexExists (an "at-least-this-strict" existence check, where an
+    // expectation that does not require uniqueness is satisfied by any index),
+    // indexShapeMatches is an exact-equality check used to decide whether a
+    // pre-existing index is safe to leave alone. An unexpectedly-unique index is a
+    // real drift worth flagging, so `unique` must be compared exactly here.
+    const expectedWithoutUnique = { fields: { status: 1 } };
+    expect(indexShapeMatches({ key: { status: 1 }, unique: true }, expectedWithoutUnique)).toBe(
+      false
+    );
+  });
+});

--- a/__tests__/unit/types/alerting-type-contracts.test.ts
+++ b/__tests__/unit/types/alerting-type-contracts.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Type-level contracts for the alerting subsystem.
+ *
+ * MOST OF THIS FILE IS CHECKED BY `npx tsc --noEmit`, NOT BY JEST. ts-jest runs
+ * with `isolatedModules: true` (jest.config.js), which strips types without
+ * checking them — so a broken assertion here shows up as a `tsc` failure and a
+ * GREEN jest run. That is deliberate: these are compile-time invariants, and
+ * `tsc` is the gate that enforces them. The handful of real `it()` blocks below
+ * exist only to prove the runtime side of the same contracts still behaves.
+ *
+ * A `@ts-expect-error` that STOPS being an error is itself a `tsc` failure
+ * ("Unused '@ts-expect-error' directive"), so the negative assertions cannot
+ * quietly rot into no-ops.
+ *
+ * Three findings converge here:
+ *   - F1: the reading type list is copied by hand into several modules, and an
+ *     omission is silent at runtime (no bucket -> zero rules -> no alerts).
+ *   - E2: `redactAuditForDemo` used to be identity-typed, so a route that
+ *     skipped it looked exactly like a route that called it.
+ *   - E4: `CreateAlertRuleInput` / `UpdateAlertRuleInput` used to be flat
+ *     `z.infer` types that accepted request shapes the API always 400s.
+ */
+
+// Every import here except `@/lib/alerting/redact` is `import type`, so this
+// file pulls in no React component and no mongoose model at runtime — the
+// assertions below are checked by `tsc`, not by loading anything.
+import type { z } from 'zod';
+import type { ReadingTypeInList } from '@/models/v2/AlertRuleV2';
+import type { ReadingType as ModelReadingType } from '@/models/v2/ReadingV2';
+import type { DeviceType as ModelDeviceType } from '@/models/v2/DeviceV2';
+import type { ReadingType as ClientReadingType, DeviceType as ClientDeviceType } from '@/types/v2';
+import type {
+  ReadingTypeName,
+  CreateAlertRuleBody,
+  UpdateAlertRuleBody,
+} from '@/types/v2/alert.types';
+import type { DEVICE_TYPES as FILTER_MODAL_DEVICE_TYPES } from '@/app/devices/_components/DeviceFilterModal';
+import type { readingTypeSchema } from '@/lib/validations/v2/reading.validation';
+import type { deviceTypeSchema } from '@/lib/validations/v2/device.validation';
+import type {
+  updateAlertRuleSchema,
+  CreateAlertRuleInput,
+  UpdateAlertRuleInput,
+} from '@/lib/validations/v2/alert-rule.validation';
+import { redactAuditForDemo, jsonRedacted, type Redacted } from '@/lib/alerting/redact';
+
+// ============================================================================
+// ASSERTION HELPERS
+// ============================================================================
+
+/**
+ * Invariant (not merely bivariant) type equality. The conditional-in-a-generic
+ * trick is what makes `Equal<{a?: string}, {a: string | undefined}>` false —
+ * a plain mutual-`extends` check would call those equal and miss exactly the
+ * optionality drift these assertions are meant to catch.
+ */
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+
+/** One-directional assignability, for the cases where equality is too strong. */
+type Extends<A, B> = [A] extends [B] ? true : false;
+
+/** Fails to compile unless `T` is exactly `true`. */
+type Expect<T extends true> = T;
+
+// ============================================================================
+// F1 — every hand-maintained copy of the reading type list must agree
+// ============================================================================
+//
+// An omission here is invisible at runtime: `buildRuleBuckets`
+// (lib/alerting/rule-cache.ts) seeds one bucket per READING_TYPES entry,
+// `evaluateReadings` looks a reading's type up with `byType.get(type) ?? []`,
+// and a fleet-wide rule (no `selector.types`) is expanded across the same list.
+// One missing entry therefore silences alerting for that reading type
+// completely, including rules that never named a type at all — with no error,
+// no metric, no log, and the rule still showing as Enabled in the UI.
+//
+// The Mongoose `enum` arrays and the runtime shape of the Zod enums are checked
+// separately, at RUNTIME, in __tests__/unit/models/AlertRuleV2.test.ts —
+// `tsc` cannot see inside a `new Schema({ enum: [...] })`.
+
+type _ReadingTypesMatchesModelUnion = Expect<Equal<ReadingTypeInList, ModelReadingType>>;
+type _ClientReadingTypeMatchesModel = Expect<Equal<ClientReadingType, ModelReadingType>>;
+type _ReadingTypeNameMatchesModel = Expect<Equal<ReadingTypeName, ModelReadingType>>;
+type _ReadingZodEnumMatchesModel = Expect<
+  Equal<z.infer<typeof readingTypeSchema>, ModelReadingType>
+>;
+
+// Device types and reading types are ONE list in this codebase (CLAUDE.md's
+// "15 Device/Reading Types"): a device of type X emits readings of type X, and
+// `metric: 'value'` alert rules select devices by reading type. If that ever
+// stops being true by design, this is the assertion to change — deliberately,
+// and with the rule bucketer in hand — rather than something to let drift.
+type _DeviceTypeMatchesReadingType = Expect<Equal<ModelDeviceType, ModelReadingType>>;
+type _ClientDeviceTypeMatchesModel = Expect<Equal<ClientDeviceType, ModelDeviceType>>;
+type _DeviceZodEnumMatchesModel = Expect<Equal<z.infer<typeof deviceTypeSchema>, ModelDeviceType>>;
+
+// The device list page's filter options. `import type` of a value binding is
+// fully erased, so this node-environment test never loads the React component.
+// A type missing there is not a runtime failure — it is simply unfilterable in
+// the UI, which is why nothing else would catch it.
+type FilterModalDeviceType = (typeof FILTER_MODAL_DEVICE_TYPES)[number];
+type _FilterModalMatchesDeviceType = Expect<Equal<FilterModalDeviceType, ModelDeviceType>>;
+
+// ============================================================================
+// E4 — the rule-create / rule-update request types
+// ============================================================================
+
+/** Every body the hand-written union permits must be a body the schema accepts. */
+type _CreateBodyIsAccepted = Expect<Extends<CreateAlertRuleBody, CreateAlertRuleInput>>;
+type _UpdateBodyIsAccepted = Expect<
+  Extends<UpdateAlertRuleBody, z.input<typeof updateAlertRuleSchema>>
+>;
+
+/**
+ * And the reverse, which is the direction that was actually broken: the schema
+ * must not accept a CONDITION shape the hand-written union forbids. Before
+ * `createAlertRuleSchema` became a discriminated union this was false — the
+ * flat schema's `z.input` allowed `metric: 'value'` with `selector` absent, and
+ * the API 400d every such request.
+ *
+ * Scoped to the condition group for two measured reasons, both of which are
+ * seams rather than drift:
+ *
+ *   - `enabled`. The schema is `z.union([z.boolean(), z.string().transform(…)])`,
+ *     so it also accepts the string `'true'`; `CreateAlertRuleBody` describes
+ *     what the UI sends, which is always a real boolean. Verified by isolating
+ *     each base field: `enabled` is the only one that differs.
+ *   - `selector.types`. Zod's `.min(1)` enforces non-emptiness at RUNTIME but
+ *     infers a plain array, while the union states it as `[T, ...T[]]`.
+ *     TypeScript cannot recover the tuple, so that one axis is widened below
+ *     rather than compared.
+ */
+type WidenNonEmptyTuple<T> = T extends readonly [infer X, ...unknown[]] ? X[] : T;
+type WidenSelector<S> = { [K in keyof S]: WidenNonEmptyTuple<S[K]> };
+type WidenCondition<C> = C extends { selector: infer S }
+  ? Omit<C, 'selector'> & { selector: WidenSelector<S> }
+  : C;
+
+type ConditionGroup<T> = T extends unknown
+  ? Pick<T, Extract<keyof T, 'metric' | 'comparison' | 'threshold' | 'selector'>>
+  : never;
+
+type _CreateSchemaConditionIsNoLooser = Expect<
+  Extends<ConditionGroup<CreateAlertRuleInput>, ConditionGroup<WidenCondition<CreateAlertRuleBody>>>
+>;
+
+describe('alert rule request types', () => {
+  it('accepts a complete value-metric create body', () => {
+    const body: CreateAlertRuleInput = {
+      name: 'High temperature',
+      severity: 'critical',
+      metric: 'value',
+      comparison: 'gt',
+      threshold: 30,
+      selector: { types: ['temperature'] },
+    };
+
+    expect(body.metric).toBe('value');
+  });
+
+  it('rejects a value-metric create body with no selector', () => {
+    // @ts-expect-error metric 'value' requires a selector listing at least one reading type
+    const body: CreateAlertRuleInput = {
+      name: 'High temperature',
+      severity: 'critical',
+      metric: 'value',
+      comparison: 'gt',
+      threshold: 30,
+    };
+
+    expect(body.metric).toBe('value');
+  });
+
+  it('accepts a non-condition update', () => {
+    const body: UpdateAlertRuleInput = { enabled: false };
+    expect(body.enabled).toBe(false);
+  });
+
+  it('accepts a complete condition update', () => {
+    const body: UpdateAlertRuleInput = {
+      metric: 'value',
+      comparison: 'gte',
+      threshold: 40,
+      selector: { types: ['temperature'] },
+    };
+
+    expect(body.threshold).toBe(40);
+  });
+
+  it('rejects a partial condition update', () => {
+    // @ts-expect-error metric, comparison, threshold and selector move together
+    const body: UpdateAlertRuleInput = { threshold: 5 };
+    expect(body.threshold).toBe(5);
+  });
+});
+
+// ============================================================================
+// E2 — the redaction marker
+// ============================================================================
+
+interface AuditedRecord {
+  _id: string;
+  audit: { created_by: string; updated_by: string };
+}
+
+const unredacted: AuditedRecord = {
+  _id: 'alert_1',
+  audit: { created_by: 'admin@example.com', updated_by: 'admin@example.com' },
+};
+
+describe('redaction marker', () => {
+  it('accepts a record that went through redactAuditForDemo', () => {
+    const response = jsonRedacted(redactAuditForDemo(unredacted, true));
+    expect(response.status).toBe(200);
+  });
+
+  it('refuses a record that did not', () => {
+    // @ts-expect-error jsonRedacted only accepts a value carrying the Redacted<> marker
+    const response = jsonRedacted(unredacted);
+    expect(response.status).toBe(200);
+  });
+
+  it('preserves the input reference for a non-demo caller', () => {
+    // The marker is phantom: no property is written, so this is still the exact
+    // same object, which is the contract lib/alerting/redact.ts documents.
+    expect(redactAuditForDemo(unredacted, false)).toBe(unredacted);
+  });
+
+  it('redacts every actor field but leaves system alone', () => {
+    const redacted = redactAuditForDemo(
+      { audit: { created_by: 'admin@example.com', resolved_by: 'system' } },
+      true
+    );
+
+    expect(redacted.audit.created_by).toBe('an administrator');
+    expect(redacted.audit.resolved_by).toBe('system');
+  });
+});
+
+/** A redacted record stays usable as its underlying type. */
+type _RedactedIsStillTheRecord = Expect<Extends<Redacted<AuditedRecord>, AuditedRecord>>;
+/** …but the underlying type is NOT a redacted record — that is the whole point. */
+type _RecordIsNotRedacted = Expect<Equal<Extends<AuditedRecord, Redacted<AuditedRecord>>, false>>;
+
+/** Exported so the type-only aliases above are never "unused" to a linter. */
+export type AlertingTypeContracts = [
+  _ReadingTypesMatchesModelUnion,
+  _ClientReadingTypeMatchesModel,
+  _ReadingTypeNameMatchesModel,
+  _ReadingZodEnumMatchesModel,
+  _DeviceTypeMatchesReadingType,
+  _ClientDeviceTypeMatchesModel,
+  _DeviceZodEnumMatchesModel,
+  _FilterModalMatchesDeviceType,
+  _CreateBodyIsAccepted,
+  _UpdateBodyIsAccepted,
+  _CreateSchemaConditionIsNoLooser,
+  _RedactedIsStillTheRecord,
+  _RecordIsNotRedacted,
+];

--- a/__tests__/unit/types/reading-type-checklist.test.ts
+++ b/__tests__/unit/types/reading-type-checklist.test.ts
@@ -1,0 +1,130 @@
+/**
+ * CLAUDE.md's "Adding a New Device / Reading Type" checklist must stay complete.
+ *
+ * The reading/device type list is copied by hand into fourteen source files.
+ * Several of those copies fail SILENTLY when they are missed — the type is
+ * simply absent from a dropdown, or stored with unit `'raw'`, or given no
+ * alert-rule bucket at all. The checklist in CLAUDE.md is what a future agent
+ * follows, and CLAUDE.md is loaded into every session in this repo, so an
+ * incomplete checklist propagates the mistake rather than preventing it. It was
+ * already incomplete once: this PR added copies in `AlertRuleV2.READING_TYPES`
+ * and `ReadingTypeName` without the four-step list being updated.
+ *
+ * This test derives the file set by SCANNING, not by restating it — a file
+ * "carries a copy" if all fifteen type names appear in it. Add a fifteenth
+ * copy of the list anywhere under models/, lib/, types/, app/, components/ or
+ * scripts/ without naming it in the checklist and this fails.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+
+/**
+ * Deliberately spelled out rather than imported from `READING_TYPES`. This test
+ * is about the DOCUMENTATION of the copies; importing one of the copies to find
+ * the others would make a shrunken list scan for fewer names and quietly pass.
+ */
+const TYPE_NAMES = [
+  'temperature',
+  'humidity',
+  'occupancy',
+  'power',
+  'co2',
+  'pressure',
+  'light',
+  'motion',
+  'air_quality',
+  'water_flow',
+  'gas',
+  'vibration',
+  'voltage',
+  'current',
+  'energy',
+];
+
+const SOURCE_ROOTS = ['models', 'lib', 'types', 'app', 'components', 'scripts'];
+
+/**
+ * Tests restate the list constantly, and every deprecated tree (`_deprecated`,
+ * `_v1-deprecated`, `v1 (deprecated)`) is excluded from compilation by
+ * tsconfig.json — a copy in there is archaeology, not a maintenance burden.
+ */
+const EXCLUDED = /node_modules|[\\/]\.next|deprecated|__tests__|[\\/]e2e[\\/]/i;
+
+const SECTION_HEADING = '### Adding a New Device / Reading Type';
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (EXCLUDED.test(full)) continue;
+    if (entry.isDirectory()) out.push(...sourceFiles(full));
+    else if (/\.tsx?$/.test(entry.name)) out.push(full);
+  }
+  return out;
+}
+
+/** Every source file that spells out all fifteen type names. */
+function filesCarryingTheList(): string[] {
+  const matchers = TYPE_NAMES.map(name => new RegExp(`\\b${name}\\b`));
+
+  return SOURCE_ROOTS.filter(root => fs.existsSync(path.join(REPO_ROOT, root)))
+    .flatMap(root => sourceFiles(path.join(REPO_ROOT, root)))
+    .filter(file => {
+      const source = fs.readFileSync(file, 'utf8');
+      return matchers.every(matcher => matcher.test(source));
+    })
+    .map(file => path.relative(REPO_ROOT, file).split(path.sep).join('/'))
+    .sort();
+}
+
+/** The checklist section of CLAUDE.md, up to the next `### ` heading. */
+function checklistSection(): string {
+  const claudeMd = fs.readFileSync(path.join(REPO_ROOT, 'CLAUDE.md'), 'utf8');
+  const start = claudeMd.indexOf(SECTION_HEADING);
+  if (start === -1)
+    throw new Error(
+      `CLAUDE.md has no "${SECTION_HEADING}" section. It is the only place the ` +
+        'silent copies of the reading type list are enumerated — do not remove it.'
+    );
+
+  const rest = claudeMd.slice(start + SECTION_HEADING.length);
+  const end = rest.indexOf('\n### ');
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+describe('CLAUDE.md reading-type checklist', () => {
+  it('names every source file that carries a copy of the type list', () => {
+    const section = checklistSection();
+    const carriers = filesCarryingTheList();
+
+    // Sanity floor: if the scan finds almost nothing, the scan is broken and
+    // the assertion below would pass vacuously.
+    expect(carriers.length).toBeGreaterThan(8);
+
+    const undocumented = carriers.filter(file => !section.includes(file));
+
+    expect(undocumented).toEqual([]);
+  });
+
+  it('does not point at files that no longer exist', () => {
+    const linked = [...checklistSection().matchAll(/\]\(([^)]+)\)/g)].map(match => match[1]);
+
+    expect(linked.length).toBeGreaterThan(8);
+
+    const missing = linked.filter(target => !fs.existsSync(path.join(REPO_ROOT, target)));
+
+    expect(missing).toEqual([]);
+  });
+
+  it('explains the silent failure mode rather than just listing files', () => {
+    const section = checklistSection();
+
+    // The distinction between "tsc catches it" and "nothing catches it" is the
+    // reason the section is a table and not four bullet points.
+    expect(section).toContain('Silent');
+    expect(section).toContain('rule-cache.ts');
+  });
+});

--- a/__tests__/unit/validations/alert-rule.validation.test.ts
+++ b/__tests__/unit/validations/alert-rule.validation.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Alert Rule Validation Schema Tests
+ */
+
+import {
+  createAlertRuleSchema,
+  updateAlertRuleSchema,
+  listAlertRulesQuerySchema,
+} from '@/lib/validations/v2/alert-rule.validation';
+
+function validRule(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'High temperature',
+    metric: 'value',
+    comparison: 'gt',
+    threshold: 30,
+    severity: 'critical',
+    selector: { types: ['temperature'] },
+    ...overrides,
+  };
+}
+
+describe('createAlertRuleSchema', () => {
+  it('should accept a minimal valid rule and apply defaults', () => {
+    const result = createAlertRuleSchema.safeParse(validRule());
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.enabled).toBe(true);
+      expect(result.data.for_duration_seconds).toBe(0);
+      expect(result.data.cooldown_seconds).toBe(300);
+    }
+  });
+
+  it("should require selector.types when metric is 'value'", () => {
+    const result = createAlertRuleSchema.safeParse(validRule({ selector: {} }));
+
+    expect(result.success).toBe(false);
+    if (!result.success)
+      expect(result.error.issues.some(i => i.path.join('.') === 'selector.types')).toBe(true);
+  });
+
+  it("should reject an empty selector.types array when metric is 'value'", () => {
+    const result = createAlertRuleSchema.safeParse(validRule({ selector: { types: [] } }));
+    expect(result.success).toBe(false);
+  });
+
+  it('should allow anomaly_score rules with no selector.types', () => {
+    const result = createAlertRuleSchema.safeParse(
+      validRule({ metric: 'anomaly_score', threshold: 0.8, selector: {} })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('should allow battery_level rules with no selector.types', () => {
+    const result = createAlertRuleSchema.safeParse(
+      validRule({ metric: 'battery_level', comparison: 'lt', threshold: 20, selector: {} })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('should bound anomaly_score thresholds to 0-1', () => {
+    const tooHigh = createAlertRuleSchema.safeParse(
+      validRule({ metric: 'anomaly_score', threshold: 30, selector: {} })
+    );
+    const negative = createAlertRuleSchema.safeParse(
+      validRule({ metric: 'anomaly_score', threshold: -0.1, selector: {} })
+    );
+
+    expect(tooHigh.success).toBe(false);
+    expect(negative.success).toBe(false);
+  });
+
+  it('should bound battery_level thresholds to 0-100', () => {
+    const result = createAlertRuleSchema.safeParse(
+      validRule({ metric: 'battery_level', comparison: 'lt', threshold: 101, selector: {} })
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it('should leave value thresholds unconstrained', () => {
+    const result = createAlertRuleSchema.safeParse(
+      validRule({ threshold: -273.15, selector: { types: ['temperature'] } })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject an unknown reading type in the selector', () => {
+    const result = createAlertRuleSchema.safeParse(
+      validRule({ selector: { types: ['plasma'] } })
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it('should cap for_duration_seconds and cooldown_seconds at 86400', () => {
+    expect(createAlertRuleSchema.safeParse(validRule({ for_duration_seconds: 86401 })).success).toBe(false);
+    expect(createAlertRuleSchema.safeParse(validRule({ cooldown_seconds: 86401 })).success).toBe(false);
+  });
+
+  it('should accept the full selector shape', () => {
+    const result = createAlertRuleSchema.safeParse(
+      validRule({
+        selector: {
+          types: ['temperature', 'humidity'],
+          building_id: 'HQ',
+          floor: 3,
+          zone: 'north',
+          tags: ['critical', 'hvac'],
+        },
+      })
+    );
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('updateAlertRuleSchema', () => {
+  it('should accept a partial update of non-condition fields', () => {
+    const result = updateAlertRuleSchema.safeParse({ enabled: false });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject an empty update', () => {
+    const result = updateAlertRuleSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('should reject a partial condition update', () => {
+    const result = updateAlertRuleSchema.safeParse({ threshold: 40 });
+    expect(result.success).toBe(false);
+  });
+
+  it('should accept a complete condition update', () => {
+    const result = updateAlertRuleSchema.safeParse({
+      metric: 'value',
+      comparison: 'gte',
+      threshold: 40,
+      selector: { types: ['temperature'] },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should apply the metric threshold bounds to a complete condition update', () => {
+    const result = updateAlertRuleSchema.safeParse({
+      metric: 'anomaly_score',
+      comparison: 'gt',
+      threshold: 5,
+      selector: {},
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('listAlertRulesQuerySchema', () => {
+  it('should coerce string pagination params', () => {
+    const result = listAlertRulesQuerySchema.safeParse({ page: '2', limit: '50' });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.page).toBe(2);
+      expect(result.data.limit).toBe(50);
+    }
+  });
+
+  it('should coerce the enabled flag from a string', () => {
+    const result = listAlertRulesQuerySchema.safeParse({ enabled: 'false' });
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.enabled).toBe(false);
+  });
+
+  it('should reject an unknown sort field', () => {
+    const result = listAlertRulesQuerySchema.safeParse({ sortBy: 'nonsense' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/__tests__/unit/validations/alert-rule.validation.test.ts
+++ b/__tests__/unit/validations/alert-rule.validation.test.ts
@@ -111,6 +111,64 @@ describe('createAlertRuleSchema', () => {
     );
     expect(result.success).toBe(true);
   });
+
+  /**
+   * `createAlertRuleSchema` is a discriminated union on `metric`, not a flat
+   * object with cross-field refinements — see the comment on the schema for
+   * why. These pin the behaviour that must NOT have changed with that rewrite:
+   * the same bodies are accepted, the same bodies are rejected, and every arm
+   * still applies the same defaults.
+   */
+  describe('metric arms', () => {
+    it("should reject a 'value' rule with no selector key at all", () => {
+      const { selector: _selector, ...noSelector } = validRule();
+      expect(createAlertRuleSchema.safeParse(noSelector).success).toBe(false);
+    });
+
+    it('should reject an unknown metric', () => {
+      expect(createAlertRuleSchema.safeParse(validRule({ metric: 'humidity_delta' })).success).toBe(
+        false
+      );
+    });
+
+    it('should reject a missing metric', () => {
+      const { metric: _metric, ...noMetric } = validRule();
+      expect(createAlertRuleSchema.safeParse(noMetric).success).toBe(false);
+    });
+
+    it.each([
+      ['value', { metric: 'value', threshold: 30, selector: { types: ['temperature'] } }],
+      ['anomaly_score', { metric: 'anomaly_score', threshold: 0.8, selector: {} }],
+      ['battery_level', { metric: 'battery_level', comparison: 'lt', threshold: 20, selector: {} }],
+    ])('should apply the same defaults on the %s arm', (_name, overrides) => {
+      const result = createAlertRuleSchema.safeParse(validRule(overrides));
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.enabled).toBe(true);
+        expect(result.data.for_duration_seconds).toBe(0);
+        expect(result.data.cooldown_seconds).toBe(300);
+      }
+    });
+
+    it('should default selector to {} when a unit-free metric omits it', () => {
+      const { selector: _selector, ...noSelector } = validRule({
+        metric: 'anomaly_score',
+        threshold: 0.8,
+      });
+      const result = createAlertRuleSchema.safeParse(noSelector);
+
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.selector).toEqual({});
+    });
+
+    it('should still coerce the enabled flag from a string', () => {
+      const result = createAlertRuleSchema.safeParse(validRule({ enabled: 'false' }));
+
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.enabled).toBe(false);
+    });
+  });
 });
 
 describe('updateAlertRuleSchema', () => {

--- a/__tests__/unit/validations/alert.validation.test.ts
+++ b/__tests__/unit/validations/alert.validation.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Alert Validation Schema Tests
+ */
+
+import {
+  updateAlertSchema,
+  listAlertsQuerySchema,
+  getAlertQuerySchema,
+  alertIdParamSchema,
+} from '@/lib/validations/v2/alert.validation';
+
+describe('updateAlertSchema', () => {
+  it('should accept acknowledged', () => {
+    expect(updateAlertSchema.safeParse({ status: 'acknowledged' }).success).toBe(true);
+  });
+
+  it('should accept resolved with a note', () => {
+    const result = updateAlertSchema.safeParse({ status: 'resolved', note: 'Replaced sensor' });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject pending and firing as PATCH targets', () => {
+    expect(updateAlertSchema.safeParse({ status: 'pending' }).success).toBe(false);
+    expect(updateAlertSchema.safeParse({ status: 'firing' }).success).toBe(false);
+  });
+
+  it('should require a status', () => {
+    expect(updateAlertSchema.safeParse({ note: 'no status' }).success).toBe(false);
+  });
+
+  it('should cap the note at 1000 characters', () => {
+    const result = updateAlertSchema.safeParse({ status: 'resolved', note: 'x'.repeat(1001) });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('listAlertsQuerySchema', () => {
+  it('should accept a comma-separated status list', () => {
+    const result = listAlertsQuerySchema.safeParse({ status: 'firing,acknowledged' });
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.status).toEqual(['firing', 'acknowledged']);
+  });
+
+  it('should accept a single severity', () => {
+    const result = listAlertsQuerySchema.safeParse({ severity: 'critical' });
+    expect(result.success).toBe(true);
+  });
+
+  it('should reject an unknown status', () => {
+    expect(listAlertsQuerySchema.safeParse({ status: 'smouldering' }).success).toBe(false);
+  });
+
+  it('should validate rule_id as an ObjectId', () => {
+    expect(listAlertsQuerySchema.safeParse({ rule_id: 'not-an-objectid' }).success).toBe(false);
+    expect(listAlertsQuerySchema.safeParse({ rule_id: '507f1f77bcf86cd799439011' }).success).toBe(true);
+  });
+
+  it('should reject a start date after the end date', () => {
+    const result = listAlertsQuerySchema.safeParse({
+      startDate: '2026-08-02T00:00:00.000Z',
+      endDate: '2026-08-01T00:00:00.000Z',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('getAlertQuerySchema', () => {
+  it('should default include_device to false', () => {
+    const result = getAlertQuerySchema.safeParse({});
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.include_device).toBe(false);
+  });
+
+  it('should coerce include_device from a string', () => {
+    const result = getAlertQuerySchema.safeParse({ include_device: 'true' });
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.include_device).toBe(true);
+  });
+});
+
+describe('alertIdParamSchema', () => {
+  it('should reject a malformed id', () => {
+    expect(alertIdParamSchema.safeParse({ id: 'abc' }).success).toBe(false);
+  });
+});

--- a/app/alerts/[id]/page.tsx
+++ b/app/alerts/[id]/page.tsx
@@ -43,14 +43,28 @@ export default function AlertDetailPage() {
   }, [alert?.fired_at, alert?.breached_since]);
 
   // No new endpoint: the existing readings endpoint already requires a time
-  // range, and fired_at +/- 15 minutes satisfies it.
+  // range, and fired_at +/- 15 minutes satisfies it. limit/sortBy/sortDirection
+  // are explicit because the endpoint defaults to 20 rows, newest first — a
+  // silent default that would truncate exactly the early part of the window
+  // that shows the breach developing. limit: 100 is the endpoint's max and
+  // comfortably covers 30 minutes at any realistic reporting cadence;
+  // ascending puts the bracketing table in chronological order.
   const { data: bracketingReadings = [], isLoading: readingsLoading } = useQuery({
-    queryKey: queryKeys.readings.list({ device_id: alert?.device_id, ...range }),
+    queryKey: queryKeys.readings.list({
+      device_id: alert?.device_id,
+      ...range,
+      limit: 100,
+      sortBy: 'timestamp',
+      sortDirection: 'asc',
+    }),
     queryFn: async (): Promise<ReadingV2Response[]> => {
       const response = await v2Api.readings.list({
         device_id: alert!.device_id,
         startDate: range!.startDate,
         endDate: range!.endDate,
+        limit: 100,
+        sortBy: 'timestamp',
+        sortDirection: 'asc',
       });
       return response.data;
     },

--- a/app/alerts/[id]/page.tsx
+++ b/app/alerts/[id]/page.tsx
@@ -49,7 +49,17 @@ export default function AlertDetailPage() {
   // that shows the breach developing. limit: 100 is the endpoint's max and
   // comfortably covers 30 minutes at any realistic reporting cadence;
   // ascending puts the bracketing table in chronological order.
-  const { data: bracketingReadings = [], isLoading: readingsLoading } = useQuery({
+  const {
+    data: bracketingReadings = [],
+    isLoading: readingsLoading,
+    // Sibling to the alert query's own `error`/`refetch` above — prefixed
+    // the same way `readingsLoading` already is, so the two queries' state
+    // never collides. Threaded into AlertDetailView below so a failed fetch
+    // renders its own distinct error state instead of silently reading as
+    // "No readings in this window." (review finding A3).
+    error: readingsError,
+    refetch: refetchReadings,
+  } = useQuery({
     queryKey: queryKeys.readings.list({
       device_id: alert?.device_id,
       ...range,
@@ -119,6 +129,8 @@ export default function AlertDetailPage() {
             alert={alert}
             bracketingReadings={bracketingReadings}
             loading={readingsLoading}
+            readingsError={readingsError}
+            onRetryReadings={refetchReadings}
           />
         </div>
       )}

--- a/app/alerts/[id]/page.tsx
+++ b/app/alerts/[id]/page.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useMemo } from 'react';
+import Link from 'next/link';
+import { notFound, useParams } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import { ArrowLeft, Bell } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { AlertDetailView } from '@/components/alerts/AlertDetailView';
+import { useAlertDetail } from '@/lib/query/hooks';
+import { ApiClientError, v2Api } from '@/lib/api/v2-client';
+import { queryKeys } from '@/lib/query/queryClient';
+import type { ReadingV2Response } from '@/types/v2';
+
+const BRACKET_MINUTES = 15;
+
+/**
+ * Canonical, deep-linkable alert page: it survives a refresh and can be pasted
+ * into a chat mid-incident. Mirrors app/devices/[id]/page.tsx.
+ */
+export default function AlertDetailPage() {
+  const params = useParams<{ id: string }>();
+  const alertId = params?.id ? decodeURIComponent(params.id) : '';
+
+  // retry: false — a 404 must render the styled not-found state right away,
+  // not spin through the default two retries first (useAlertDetail's own
+  // config doesn't set this, so it has to be passed here).
+  const {
+    data: alert,
+    isLoading,
+    error,
+    refetch,
+  } = useAlertDetail(alertId, { include_device: true }, { retry: false });
+
+  const range = useMemo(() => {
+    const anchor = alert?.fired_at ?? alert?.breached_since;
+    if (!anchor) return null;
+    const at = new Date(anchor).getTime();
+    return {
+      startDate: new Date(at - BRACKET_MINUTES * 60_000).toISOString(),
+      endDate: new Date(at + BRACKET_MINUTES * 60_000).toISOString(),
+    };
+  }, [alert?.fired_at, alert?.breached_since]);
+
+  // No new endpoint: the existing readings endpoint already requires a time
+  // range, and fired_at +/- 15 minutes satisfies it.
+  const { data: bracketingReadings = [], isLoading: readingsLoading } = useQuery({
+    queryKey: queryKeys.readings.list({ device_id: alert?.device_id, ...range }),
+    queryFn: async (): Promise<ReadingV2Response[]> => {
+      const response = await v2Api.readings.list({
+        device_id: alert!.device_id,
+        startDate: range!.startDate,
+        endDate: range!.endDate,
+      });
+      return response.data;
+    },
+    enabled: !!alert?.device_id && !!range,
+  });
+
+  // apiCall() (lib/api/v2-client.ts) always throws ApiClientError, network
+  // failures included, so this narrows reliably: a genuine 404 renders the
+  // app-wide styled not-found state, while any other error (network, 500) is
+  // not "this alert doesn't exist" and gets a retry banner instead — the same
+  // distinction useDeviceDetail draws for app/devices/[id]/page.tsx.
+  const isNotFound = error instanceof ApiClientError && error.statusCode === 404;
+  if (!isLoading && isNotFound) notFound();
+  const loadError = !isLoading && error && !isNotFound ? error : null;
+
+  return (
+    <div className="min-h-screen bg-background p-4 md:p-6 lg:p-8">
+      <header className="mb-6 space-y-4">
+        <Link
+          href="/alerts"
+          className="inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+          Back to alerts
+        </Link>
+        <div className="flex items-center gap-3">
+          <Bell className="h-7 w-7 text-primary" aria-hidden="true" />
+          <h1 className="text-2xl md:text-3xl font-bold text-foreground break-all">
+            {alert?.rule_name ?? 'Alert'}
+          </h1>
+        </div>
+      </header>
+
+      {isLoading && (
+        <div className="flex items-center justify-center py-24">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600" />
+        </div>
+      )}
+
+      {loadError && (
+        <div className="mb-6 p-4 bg-destructive/10 border border-destructive/30 rounded-lg text-destructive text-sm">
+          Failed to load alert.
+          <Button variant="outline" size="sm" className="ml-4" onClick={() => refetch()}>
+            Retry
+          </Button>
+        </div>
+      )}
+
+      {alert && !isLoading && (
+        <div className="rounded-lg border border-border bg-card p-4 sm:p-6">
+          <AlertDetailView
+            alert={alert}
+            bracketingReadings={bracketingReadings}
+            loading={readingsLoading}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/alerts/page.tsx
+++ b/app/alerts/page.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { Suspense } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { Bell, SlidersHorizontal } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { AlertList } from '@/components/alerts/AlertList';
+
+/**
+ * Active alerts. History is a filter value on the same page rather than a
+ * separate route (`/alerts?status=resolved`), following the Phase 3 URL-sync
+ * precedent in app/devices/_components/useDeviceFilterParams.ts.
+ */
+function AlertsPageContent() {
+  const router = useRouter();
+
+  return (
+    <div className="min-h-screen bg-background p-4 md:p-6 lg:p-8">
+      <header className="mb-6 flex flex-wrap items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <Bell className="h-7 w-7 text-primary" aria-hidden="true" />
+          <h1 className="text-2xl md:text-3xl font-bold text-foreground">Alerts</h1>
+        </div>
+        <Button asChild variant="outline" size="sm">
+          <Link href="/alerts/rules">
+            <SlidersHorizontal className="h-4 w-4 mr-2" />
+            Manage rules
+          </Link>
+        </Button>
+      </header>
+
+      <AlertList onDeviceClick={deviceId => router.push(`/devices/${deviceId}`)} />
+    </div>
+  );
+}
+
+export default function AlertsPage() {
+  // AlertList reads its filter state from the URL via useAlertFilterParams
+  // (useSearchParams), which requires a Suspense boundary or the production
+  // build fails with a prerender error. Mirrors app/devices/page.tsx.
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-background p-4 md:p-6 lg:p-8">
+          <div className="flex items-center justify-center py-24">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+          </div>
+        </div>
+      }
+    >
+      <AlertsPageContent />
+    </Suspense>
+  );
+}

--- a/app/alerts/rules/page.tsx
+++ b/app/alerts/rules/page.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, Bell, Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { AlertRuleList } from '@/components/alerts/AlertRuleList';
+import { CreateAlertRuleModal } from '@/components/alerts/CreateAlertRuleModal';
+import { useAdminAction } from '@/lib/auth/rbac-client';
+
+/**
+ * Rule management: list, create, and delete alert rules. Mirrors
+ * app/alerts/page.tsx's header shell, with a back link to the active-alerts
+ * view rather than a Suspense boundary — AlertRuleList keeps its filter/page
+ * state local (no useSearchParams), unlike AlertList.
+ */
+export default function AlertRulesPage() {
+  const [createModalOpen, setCreateModalOpen] = useState(false);
+  // Same useAdminAction() contract as app/analytics/page.tsx's report button:
+  // enabled for admins; visible-but-disabled with a tooltip in demo mode;
+  // hidden otherwise. requireAdmin() server-side remains the real enforcement.
+  const newRuleAction = useAdminAction();
+
+  return (
+    <div className="min-h-screen bg-background p-4 md:p-6 lg:p-8">
+      <header className="mb-6 space-y-4">
+        <Link
+          href="/alerts"
+          className="inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+          Back to alerts
+        </Link>
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <Bell className="h-7 w-7 text-primary" aria-hidden="true" />
+            <h1 className="text-2xl md:text-3xl font-bold text-foreground">Alert Rules</h1>
+          </div>
+          {newRuleAction.visible && (
+            <Button
+              size="sm"
+              disabled={newRuleAction.disabled}
+              title={newRuleAction.tooltip}
+              onClick={() => setCreateModalOpen(true)}
+            >
+              <Plus className="h-4 w-4 mr-2" />
+              New rule
+            </Button>
+          )}
+        </div>
+      </header>
+
+      <AlertRuleList />
+
+      <CreateAlertRuleModal isOpen={createModalOpen} onClose={() => setCreateModalOpen(false)} />
+    </div>
+  );
+}

--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
-import AlertsPanel from '@/components/AlertsPanel';
+import AnomalyPanel from '@/components/AnomalyPanel';
 import DeviceHealthWidget from '@/components/DeviceHealthWidget';
 import EnergyUsageChart from '@/components/AnomalyChart';
 import GenerateReportModal from '@/components/GenerateReportModal';
@@ -81,7 +81,7 @@ export default function AnalyticsPage() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <EnergyUsageChart selectedFloor={selectedFloor} />
         <DeviceHealthWidget selectedFloor={selectedFloor} />
-        <AlertsPanel
+        <AnomalyPanel
           onDeviceClick={deviceId => router.push(`/devices/${deviceId}`)}
           maxAlerts={8}
         />

--- a/app/api/pusher/auth/route.ts
+++ b/app/api/pusher/auth/route.ts
@@ -1,0 +1,114 @@
+/**
+ * Pusher Private Channel Authorization
+ *
+ * POST /api/pusher/auth
+ *
+ * pusher-js calls this before it will join a `private-` channel. It is not a
+ * v2 API endpoint and it is not something a human ever calls; it exists purely
+ * to answer "may this socket join this channel?".
+ *
+ * ## Deliberate departure from the repo's response convention
+ *
+ * Every other route in this codebase answers with `jsonSuccess()` /
+ * `jsonPaginated()` — the `{ success, data, timestamp }` envelope. This one
+ * MUST NOT. pusher-js parses the body itself and looks for a bare
+ * `{ auth: "<key>:<signature>" }` object; anything wrapped around that is read
+ * as a malformed response and the subscription fails silently, with no alert
+ * ever reaching the browser and nothing in the server logs to explain it. The
+ * shape is dictated by Pusher's protocol, so `pusherServer.authorizeChannel()`
+ * output is returned verbatim.
+ *
+ * Errors are the normal envelope, because those are ours to shape and
+ * `withErrorHandler` produces them; pusher-js only inspects the status code on
+ * a failure, and a non-2xx of any shape means "rejected".
+ *
+ * ## Why this is not in `proxy.ts`'s public route list
+ *
+ * It must stay protected. `proxy.ts`'s matcher already covers `/(api|trpc)(.*)`
+ * and the path is absent from `isPublicRoute`, so a signed-out caller is turned
+ * away by the middleware before this handler runs — and `requireOrgMembership()`
+ * below turns them away again if it ever does. Adding it to the public list
+ * would reopen exactly the hole the private channel closes.
+ */
+
+import type { NextRequest } from 'next/server';
+import { pusherServer } from '@/lib/pusher';
+import { ALERT_CHANNEL } from '@/lib/pusher-channels';
+import { requireOrgMembership } from '@/lib/auth';
+import { withErrorHandler, ApiError } from '@/lib/errors';
+import { logger, recordRequest, createRequestTimer } from '@/lib/monitoring';
+
+/**
+ * Channels this endpoint will ever sign.
+ *
+ * An allow-list, not a prefix test. Signing whatever channel name the caller
+ * asks for would make this endpoint a generic signing oracle: any org member
+ * could mint an authorization for a channel they were never meant to read, and
+ * a future `private-tenant-<id>` channel would be readable by every member the
+ * day it was added. Membership grants access to the alert feed and nothing else.
+ */
+const AUTHORIZABLE_CHANNELS: ReadonlySet<string> = new Set([ALERT_CHANNEL]);
+
+/** Pusher socket ids are `<numeric>.<numeric>`. */
+const SOCKET_ID_PATTERN = /^\d+\.\d+$/;
+
+interface AuthParams {
+  socketId: string;
+  channelName: string;
+}
+
+/**
+ * Reads socket_id/channel_name off the request.
+ *
+ * pusher-js's `ajax` transport posts a urlencoded form. JSON is accepted too so
+ * a hand-written client (or a test) is not forced to build a form body.
+ */
+async function readAuthParams(request: NextRequest): Promise<AuthParams> {
+  const contentType = request.headers.get('content-type') ?? '';
+
+  if (contentType.includes('application/json')) {
+    const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+    return {
+      socketId: typeof body.socket_id === 'string' ? body.socket_id : '',
+      channelName: typeof body.channel_name === 'string' ? body.channel_name : '',
+    };
+  }
+
+  const params = new URLSearchParams(await request.text());
+  return {
+    socketId: params.get('socket_id') ?? '',
+    channelName: params.get('channel_name') ?? '',
+  };
+}
+
+export async function POST(request: NextRequest) {
+  const timer = createRequestTimer();
+
+  return withErrorHandler(async () => {
+    // Throws 401 when signed out, 403 when outside the allowed organization.
+    const authContext = await requireOrgMembership();
+
+    const { socketId, channelName } = await readAuthParams(request);
+
+    if (!SOCKET_ID_PATTERN.test(socketId))
+      throw ApiError.badRequest('A valid socket_id is required');
+
+    if (!AUTHORIZABLE_CHANNELS.has(channelName)) {
+      logger.warn('Rejected Pusher authorization for a non-authorizable channel', {
+        channelName,
+        userId: authContext.userId,
+      });
+      throw ApiError.forbidden(`Channel '${channelName}' cannot be authorized`);
+    }
+
+    // Raw Pusher payload — see the "deliberate departure" note at the top of
+    // this file. Do NOT wrap this in jsonSuccess().
+    const authResponse = pusherServer.authorizeChannel(socketId, channelName);
+
+    const duration = timer.elapsed();
+    recordRequest('POST', '/api/pusher/auth', 200, duration);
+    logger.debug('Pusher channel authorized', { channelName, duration });
+
+    return Response.json(authResponse);
+  })();
+}

--- a/app/api/pusher/auth/route.ts
+++ b/app/api/pusher/auth/route.ts
@@ -26,15 +26,36 @@
  *
  * It must stay protected. `proxy.ts`'s matcher already covers `/(api|trpc)(.*)`
  * and the path is absent from `isPublicRoute`, so a signed-out caller is turned
- * away by the middleware before this handler runs — and `requireOrgMembership()`
- * below turns them away again if it ever does. Adding it to the public list
+ * away by the middleware before this handler runs. Adding it to the public list
  * would reopen exactly the hole the private channel closes.
+ *
+ * ## What the handler itself actually enforces
+ *
+ * `requireOrgMembership()` is not, on its own, a second barrier against an
+ * anonymous caller. Under `DEMO_MODE=true`, `getAuthContext()` hands an
+ * anonymous visitor a synthetic `org:member` context (see `lib/auth/index.ts`),
+ * so the call SUCCEEDS and would otherwise reach `authorizeChannel()`. The
+ * only thing refusing that request today is `proxy.ts`, whose demo bypass is
+ * limited to GET/HEAD — one condition, in one file, guarding the route whose
+ * whole purpose is to be the second line of defense.
+ *
+ * So the handler rejects a demo caller explicitly, below. Between them:
+ *   - `requireOrgMembership()` covers signed-in callers — 401 when there is no
+ *     session and demo mode is off, 403 outside the allowed organization.
+ *   - the `isDemoCaller()` check covers the anonymous demo visitor, whatever
+ *     the middleware did or did not do with the request.
+ *
+ * A demo deployment therefore serves the app read-only and simply has no alert
+ * stream, which is the intended trade: `private-alerts` carries rule names,
+ * device ids, trigger values and resolver identities, and Pusher envelopes do
+ * not pass through `lib/alerting/redact.ts` — that module only covers the
+ * alert / alert-rule GET responses.
  */
 
 import type { NextRequest } from 'next/server';
 import { pusherServer } from '@/lib/pusher';
 import { ALERT_CHANNEL } from '@/lib/pusher-channels';
-import { requireOrgMembership } from '@/lib/auth';
+import { requireOrgMembership, isDemoCaller } from '@/lib/auth';
 import { withErrorHandler, ApiError } from '@/lib/errors';
 import { logger, recordRequest, createRequestTimer } from '@/lib/monitoring';
 
@@ -86,7 +107,17 @@ export async function POST(request: NextRequest) {
 
   return withErrorHandler(async () => {
     // Throws 401 when signed out, 403 when outside the allowed organization.
+    // It does NOT reject an anonymous caller under DEMO_MODE — see the
+    // "what the handler itself actually enforces" note at the top of the file.
     const authContext = await requireOrgMembership();
+
+    // The anonymous demo visitor. Never signed a private channel: `org:member`
+    // here is synthetic, granted so a stranger can browse read-only, and it
+    // must not be readable as consent to receive the live alert feed.
+    if (isDemoCaller(authContext)) {
+      logger.warn('Rejected Pusher authorization for an anonymous demo caller');
+      throw ApiError.forbidden('Demo access cannot subscribe to private channels');
+    }
 
     const { socketId, channelName } = await readAuthParams(request);
 

--- a/app/api/v2/alert-rules/[id]/route.ts
+++ b/app/api/v2/alert-rules/[id]/route.ts
@@ -27,7 +27,7 @@ import { withRequestValidation, ValidationPresets } from '@/lib/middleware';
 import { invalidateAlertRules } from '@/lib/cache';
 import { logger, recordRequest, createRequestTimer } from '@/lib/monitoring';
 import { requireAdmin, requireOrgMembership, getAuditUser, isDemoCaller } from '@/lib/auth';
-import { redactAuditForDemo } from '@/lib/alerting';
+import { redactAuditForDemo, jsonRedacted } from '@/lib/alerting';
 
 function assertValidId(id: string): void {
   const paramValidation = validateInput({ id }, alertRuleIdParamSchema);
@@ -69,7 +69,9 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     // Demo mode grants an anonymous visitor the same read access as a real org
     // member (see requireOrgMembership()) — never let that also hand them a
     // real administrator's email off audit.created_by/updated_by/deleted_by.
-    return jsonSuccess(redactAuditForDemo(rule, isDemoCaller(authContext)));
+    // jsonRedacted (not jsonSuccess) will not compile without the redaction
+    // call — see the Redacted<> note in lib/alerting/redact.ts.
+    return jsonRedacted(redactAuditForDemo(rule, isDemoCaller(authContext)));
   })();
 }
 
@@ -231,7 +233,9 @@ async function handleUpdateAlertRule(
     // Wrapped for the same reason as the POST on the sibling route: inert
     // behind requireAdmin() today, but its `alerts/[id]` counterpart already
     // redacts and a future RBAC change must not silently open this one.
-    return jsonSuccess(
+    // jsonRedacted refuses an unredacted record, so the asymmetry this PR
+    // shipped with (POST/PATCH redacting, their siblings not) cannot recur.
+    return jsonRedacted(
       redactAuditForDemo(updated, isDemoCaller(authContext)),
       'Alert rule updated successfully'
     );

--- a/app/api/v2/alert-rules/[id]/route.ts
+++ b/app/api/v2/alert-rules/[id]/route.ts
@@ -1,0 +1,167 @@
+/**
+ * V2 Single Alert Rule API Routes
+ *
+ * GET    /api/v2/alert-rules/[id] - Get a rule
+ * PATCH  /api/v2/alert-rules/[id] - Update a rule
+ * DELETE /api/v2/alert-rules/[id] - Soft delete a rule
+ *
+ * DELETE is SOFT. Alerts reference their rule; hard-deleting would orphan the
+ * history that justifies every alert it ever raised. `enabled: false` is the
+ * reversible off switch; deletion is the permanent one.
+ */
+
+import type { NextRequest } from 'next/server';
+import dbConnect from '@/lib/db';
+import AlertRuleV2 from '@/models/v2/AlertRuleV2';
+import {
+  updateAlertRuleSchema,
+  alertRuleIdParamSchema,
+} from '@/lib/validations/v2/alert-rule.validation';
+import { validateInput, validateBody } from '@/lib/validations/validator';
+import { withErrorHandler, ApiError, ErrorCodes } from '@/lib/errors';
+import { jsonSuccess } from '@/lib/api/response';
+import { withRateLimit } from '@/lib/ratelimit';
+import { withRequestValidation, ValidationPresets } from '@/lib/middleware';
+import { invalidateAlertRules } from '@/lib/cache';
+import { logger, recordRequest, createRequestTimer } from '@/lib/monitoring';
+import { requireAdmin, requireOrgMembership, getAuditUser } from '@/lib/auth';
+
+function assertValidId(id: string): void {
+  const paramValidation = validateInput({ id }, alertRuleIdParamSchema);
+  if (!paramValidation.success)
+    throw new ApiError(
+      ErrorCodes.VALIDATION_ERROR,
+      400,
+      paramValidation.errors.map(e => e.message).join(', '),
+      { errors: paramValidation.errors }
+    );
+}
+
+// ============================================================================
+// GET
+// ============================================================================
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const timer = createRequestTimer();
+
+  return withErrorHandler(async () => {
+    await requireOrgMembership();
+    await dbConnect();
+
+    const { id } = await params;
+    assertValidId(id);
+
+    const rule = await AlertRuleV2.findOne({
+      _id: id,
+      'audit.deleted_at': { $exists: false },
+    }).lean();
+
+    if (!rule)
+      throw new ApiError(ErrorCodes.ALERT_RULE_NOT_FOUND, 404, `Alert rule '${id}' not found`);
+
+    recordRequest('GET', '/api/v2/alert-rules/[id]', 200, timer.elapsed());
+
+    return jsonSuccess(rule);
+  })();
+}
+
+// ============================================================================
+// PATCH
+// ============================================================================
+
+async function handleUpdateAlertRule(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const timer = createRequestTimer();
+
+  return withErrorHandler(async () => {
+    const { userId, user } = await requireAdmin();
+    const auditUser = getAuditUser(userId, user);
+
+    await dbConnect();
+
+    const { id } = await params;
+    assertValidId(id);
+
+    const bodyValidation = await validateBody(request, updateAlertRuleSchema);
+    if (!bodyValidation.success)
+      throw new ApiError(
+        ErrorCodes.VALIDATION_ERROR,
+        400,
+        bodyValidation.errors.map(e => e.message).join(', '),
+        { errors: bodyValidation.errors }
+      );
+
+    const updated = await AlertRuleV2.findOneAndUpdate(
+      { _id: id, 'audit.deleted_at': { $exists: false } },
+      {
+        $set: {
+          ...bodyValidation.data,
+          'audit.updated_at': new Date(),
+          'audit.updated_by': auditUser,
+        },
+      },
+      { new: true, runValidators: true }
+    ).lean();
+
+    if (!updated)
+      throw new ApiError(ErrorCodes.ALERT_RULE_NOT_FOUND, 404, `Alert rule '${id}' not found`);
+
+    await invalidateAlertRules();
+
+    const duration = timer.elapsed();
+    recordRequest('PATCH', '/api/v2/alert-rules/[id]', 200, duration);
+    logger.info('Alert rule updated', {
+      ruleId: id,
+      updates: Object.keys(bodyValidation.data),
+      updatedBy: auditUser,
+      duration,
+    });
+
+    return jsonSuccess(updated, 'Alert rule updated successfully');
+  })();
+}
+
+export const PATCH = withRateLimit(
+  withRequestValidation(handleUpdateAlertRule, ValidationPresets.jsonApi)
+);
+
+// ============================================================================
+// DELETE
+// ============================================================================
+
+async function handleDeleteAlertRule(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const timer = createRequestTimer();
+
+  return withErrorHandler(async () => {
+    const { userId, user } = await requireAdmin();
+    const auditUser = getAuditUser(userId, user);
+
+    await dbConnect();
+
+    const { id } = await params;
+    assertValidId(id);
+
+    const deleted = await AlertRuleV2.softDelete(id, auditUser);
+
+    if (!deleted)
+      throw new ApiError(ErrorCodes.ALERT_RULE_NOT_FOUND, 404, `Alert rule '${id}' not found`);
+
+    await invalidateAlertRules();
+
+    const duration = timer.elapsed();
+    recordRequest('DELETE', '/api/v2/alert-rules/[id]', 200, duration);
+    logger.info('Alert rule deleted', { ruleId: id, deletedBy: auditUser, duration });
+
+    return jsonSuccess(
+      { _id: id, deleted: true, deleted_at: deleted.audit?.deleted_at },
+      'Alert rule deleted successfully'
+    );
+  })();
+}
+
+export const DELETE = withRateLimit(handleDeleteAlertRule);

--- a/app/api/v2/alert-rules/[id]/route.ts
+++ b/app/api/v2/alert-rules/[id]/route.ts
@@ -54,7 +54,9 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     const rule = await AlertRuleV2.findOne({
       _id: id,
       'audit.deleted_at': { $exists: false },
-    }).lean();
+    })
+      .select('-__v')
+      .lean();
 
     if (!rule)
       throw new ApiError(ErrorCodes.ALERT_RULE_NOT_FOUND, 404, `Alert rule '${id}' not found`);
@@ -103,7 +105,9 @@ async function handleUpdateAlertRule(
         },
       },
       { new: true, runValidators: true }
-    ).lean();
+    )
+      .select('-__v')
+      .lean();
 
     if (!updated)
       throw new ApiError(ErrorCodes.ALERT_RULE_NOT_FOUND, 404, `Alert rule '${id}' not found`);

--- a/app/api/v2/alert-rules/[id]/route.ts
+++ b/app/api/v2/alert-rules/[id]/route.ts
@@ -11,8 +11,10 @@
  */
 
 import type { NextRequest } from 'next/server';
+import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
-import AlertRuleV2 from '@/models/v2/AlertRuleV2';
+import AlertRuleV2, { type IAlertRuleV2 } from '@/models/v2/AlertRuleV2';
+import AlertV2 from '@/models/v2/AlertV2';
 import {
   updateAlertRuleSchema,
   alertRuleIdParamSchema,
@@ -72,6 +74,79 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
 }
 
 // ============================================================================
+// CONDITION CHANGES AND OPEN EPISODES
+// ============================================================================
+
+/**
+ * The three fields an alert SNAPSHOTS at fire time (see IAlertV2). `selector`
+ * is deliberately absent: it changes which devices are in scope, not what the
+ * snapshot on an already-open episode means.
+ */
+const SNAPSHOT_FIELDS = ['metric', 'comparison', 'threshold'] as const;
+
+const COMPARISON_WORDS = { gt: 'above', gte: 'at or above', lt: 'below', lte: 'at or below' };
+
+function describeCondition(rule: Pick<IAlertRuleV2, 'metric' | 'comparison' | 'threshold'>): string {
+  return `${rule.metric} ${COMPARISON_WORDS[rule.comparison]} ${rule.threshold}`;
+}
+
+/**
+ * Close every episode still open against a rule whose condition just changed.
+ *
+ * An open episode carries the OLD metric/comparison/threshold, but `last_value`
+ * and `resolved_value` are not snapshotted — they are whatever the evaluator
+ * measured last. Leave the episode open and the next evaluation auto-resolves
+ * it with a value measured against the NEW metric: switch a temperature rule to
+ * `battery_level` and history permanently records "value above 30" clearing at
+ * 87. Re-snapshotting instead would be worse — `trigger_value`, `fired_at` and
+ * `breached_since` would then describe a breach of a condition that never fired.
+ *
+ * So the episode is CLOSED at the boundary, while its snapshot is still true:
+ *   - firing / acknowledged -> resolved, `manual`, attributed to the admin who
+ *     edited the rule, with a note naming both conditions. `manual` is honest:
+ *     an administrator's action closed it. `auto` would claim the metric came
+ *     back within threshold, which is exactly the false history being fixed.
+ *     No `resolved_value` is written — nothing measured this episode closed.
+ *   - pending -> DELETED, matching how the evaluator and sweep retire pending
+ *     episodes (`deleteOne`/`deleteMany` guarded on `status: 'pending'`).
+ *     Resolving one would break the documented invariant that every visible
+ *     alert has `fired_at`.
+ */
+async function closeEpisodesOrphanedByConditionChange(
+  ruleId: string,
+  before: Pick<IAlertRuleV2, 'metric' | 'comparison' | 'threshold'>,
+  after: Pick<IAlertRuleV2, 'metric' | 'comparison' | 'threshold'>,
+  auditUser: string
+): Promise<{ resolved: number; deleted: number }> {
+  const rule_id = new Types.ObjectId(ruleId);
+  const now = new Date();
+
+  const [resolved, deleted] = await Promise.all([
+    AlertV2.updateMany(
+      { rule_id, status: { $in: ['firing', 'acknowledged'] } },
+      {
+        $set: {
+          status: 'resolved',
+          is_open: false,
+          'audit.updated_at': now,
+          'audit.updated_by': auditUser,
+          'audit.resolved_at': now,
+          'audit.resolved_by': auditUser,
+          'audit.resolution': 'manual',
+          'audit.note':
+            `Closed automatically: the rule condition changed from ` +
+            `"${describeCondition(before)}" to "${describeCondition(after)}", ` +
+            `so this episode's condition no longer exists.`,
+        },
+      }
+    ),
+    AlertV2.deleteMany({ rule_id, status: 'pending' }),
+  ]);
+
+  return { resolved: resolved.modifiedCount, deleted: deleted.deletedCount };
+}
+
+// ============================================================================
 // PATCH
 // ============================================================================
 
@@ -82,8 +157,8 @@ async function handleUpdateAlertRule(
   const timer = createRequestTimer();
 
   return withErrorHandler(async () => {
-    const { userId, user } = await requireAdmin();
-    const auditUser = getAuditUser(userId, user);
+    const authContext = await requireAdmin();
+    const auditUser = getAuditUser(authContext.userId, authContext.user);
 
     await dbConnect();
 
@@ -98,6 +173,20 @@ async function handleUpdateAlertRule(
         bodyValidation.errors.map(e => e.message).join(', '),
         { errors: bodyValidation.errors }
       );
+
+    // Read before writing: the snapshot fields' PREVIOUS values are what
+    // decide whether open episodes were orphaned, and they are also what the
+    // audit note has to name. `findOneAndUpdate` alone cannot give us both the
+    // old and the new document.
+    const before = await AlertRuleV2.findOne({
+      _id: id,
+      'audit.deleted_at': { $exists: false },
+    })
+      .select('metric comparison threshold')
+      .lean();
+
+    if (!before)
+      throw new ApiError(ErrorCodes.ALERT_RULE_NOT_FOUND, 404, `Alert rule '${id}' not found`);
 
     const updated = await AlertRuleV2.findOneAndUpdate(
       { _id: id, 'audit.deleted_at': { $exists: false } },
@@ -116,6 +205,17 @@ async function handleUpdateAlertRule(
     if (!updated)
       throw new ApiError(ErrorCodes.ALERT_RULE_NOT_FOUND, 404, `Alert rule '${id}' not found`);
 
+    // A no-op PATCH (same values resent, or a rename) must not close anything.
+    const conditionChanged = SNAPSHOT_FIELDS.some(field => before[field] !== updated[field]);
+
+    // BEFORE invalidateAlertRules(), not after: while the pre-mutation rule set
+    // is still cached, every episode the evaluator can create carries the OLD
+    // snapshot, so closing them all is correct. Invalidating first would open a
+    // window in which a genuinely new-condition episode gets closed as orphaned.
+    const closed = conditionChanged
+      ? await closeEpisodesOrphanedByConditionChange(id, before, updated, auditUser)
+      : null;
+
     await invalidateAlertRules();
 
     const duration = timer.elapsed();
@@ -125,9 +225,16 @@ async function handleUpdateAlertRule(
       updates: Object.keys(bodyValidation.data),
       updatedBy: auditUser,
       duration,
+      ...(closed ? { episodesResolved: closed.resolved, episodesDeleted: closed.deleted } : {}),
     });
 
-    return jsonSuccess(updated, 'Alert rule updated successfully');
+    // Wrapped for the same reason as the POST on the sibling route: inert
+    // behind requireAdmin() today, but its `alerts/[id]` counterpart already
+    // redacts and a future RBAC change must not silently open this one.
+    return jsonSuccess(
+      redactAuditForDemo(updated, isDemoCaller(authContext)),
+      'Alert rule updated successfully'
+    );
   })();
 }
 

--- a/app/api/v2/alert-rules/[id]/route.ts
+++ b/app/api/v2/alert-rules/[id]/route.ts
@@ -25,9 +25,16 @@ import { jsonSuccess } from '@/lib/api/response';
 import { withRateLimit } from '@/lib/ratelimit';
 import { withRequestValidation, ValidationPresets } from '@/lib/middleware';
 import { invalidateAlertRules } from '@/lib/cache';
-import { logger, recordRequest, createRequestTimer } from '@/lib/monitoring';
+import {
+  logger,
+  recordRequest,
+  createRequestTimer,
+  recordAlert,
+  captureException,
+} from '@/lib/monitoring';
 import { requireAdmin, requireOrgMembership, getAuditUser, isDemoCaller } from '@/lib/auth';
-import { redactAuditForDemo, jsonRedacted } from '@/lib/alerting';
+import { redactAuditForDemo, jsonRedacted, publishAlertEvents } from '@/lib/alerting';
+import type { ResolvedAlert } from '@/types/v2/alert.types';
 
 function assertValidId(id: string): void {
   const paramValidation = validateInput({ id }, alertRuleIdParamSchema);
@@ -112,13 +119,40 @@ function describeCondition(rule: Pick<IAlertRuleV2, 'metric' | 'comparison' | 't
  *   - pending -> DELETED, matching how the evaluator and sweep retire pending
  *     episodes (`deleteOne`/`deleteMany` guarded on `status: 'pending'`).
  *     Resolving one would break the documented invariant that every visible
- *     alert has `fired_at`.
+ *     alert has `fired_at`. Nothing is broadcast or counted for these: a
+ *     pending episode was never visible to a client and never counted as
+ *     fired, so announcing its resolution would invent an alert.
+ *
+ * Closing them in the database is only half the job. Nothing patches alert rows
+ * into the React Query cache (see useAlertsList's header comment) and
+ * `refetchOnWindowFocus` is off, so a close that is neither broadcast nor
+ * counted leaves the alerts list and the nav badge showing every one of these
+ * episodes as still firing until something else happens to invalidate them —
+ * indefinitely on a wall display — and leaves `alerts_resolved` short by the
+ * same number. So each closed episode is also published on the alert channel
+ * and recorded, exactly as a manual resolve through `PATCH /api/v2/alerts/[id]`
+ * is.
+ *
+ * IDENTIFYING what was closed: `updateMany` reports a count, not documents, so
+ * the episodes are read back afterwards, keyed on the `now` this function
+ * minted. Reading the ids BEFORE the update would race the other way — the
+ * evaluator can promote a pending episode to firing in between, and that
+ * episode would then be closed in the database but absent from the broadcast
+ * and the count, which is the exact defect being fixed. The read-back cannot
+ * miss one: `resolved` is terminal (`AlertV2.resolve` matches only
+ * firing/acknowledged, and the evaluator and sweep both act on `is_open: true`
+ * documents), so nothing can move a document out of the matched set after the
+ * update commits. The accepted residual is the reverse and it is benign: a
+ * concurrent PATCH on the SAME rule landing in the same millisecond would have
+ * its episodes read back here too, over-publishing an already-resolved episode
+ * and over-counting by that many.
  */
 async function closeEpisodesOrphanedByConditionChange(
   ruleId: string,
   before: Pick<IAlertRuleV2, 'metric' | 'comparison' | 'threshold'>,
   after: Pick<IAlertRuleV2, 'metric' | 'comparison' | 'threshold'>,
-  auditUser: string
+  auditUser: string,
+  actor: string
 ): Promise<{ resolved: number; deleted: number }> {
   const rule_id = new Types.ObjectId(ruleId);
   const now = new Date();
@@ -145,7 +179,83 @@ async function closeEpisodesOrphanedByConditionChange(
     AlertV2.deleteMany({ rule_id, status: 'pending' }),
   ]);
 
+  if (resolved.modifiedCount > 0)
+    await announceClosedEpisodes(rule_id, now, actor, resolved.modifiedCount);
+
   return { resolved: resolved.modifiedCount, deleted: deleted.deletedCount };
+}
+
+/**
+ * Read the episodes just closed above back out, count them and broadcast them.
+ *
+ * `actor` is the acting admin's opaque Clerk USER ID, never `auditUser`. Same
+ * reasoning as the ACTOR IDENTITY note in `app/api/v2/alerts/[id]/route.ts`:
+ * `audit.*_by` takes getAuditUser()'s value, which is an EMAIL whenever one is
+ * on file, while this payload reaches every client subscribed to the alert
+ * channel. The two must not be swapped.
+ *
+ * Neither the read-back, the metric nor the broadcast may fail the PATCH: the
+ * rule update and the episode closes are already committed, so a fault here has
+ * nothing left to roll back and a 500 would tell the admin their edit failed
+ * when it did not. It is escalated rather than merely logged, for the reason
+ * spelled out at the matching call site in `app/api/v2/alerts/[id]/route.ts`:
+ * logger.error only reaches a console line, so without this a permanently
+ * broken broadcast path is invisible while every PATCH keeps returning 200.
+ */
+async function announceClosedEpisodes(
+  rule_id: Types.ObjectId,
+  resolvedAt: Date,
+  actor: string,
+  expected: number
+): Promise<void> {
+  try {
+    const closed = await AlertV2.find({
+      rule_id,
+      status: 'resolved',
+      'audit.resolution': 'manual',
+      'audit.resolved_at': resolvedAt,
+    })
+      .select('_id rule_id device_id severity')
+      .lean();
+
+    // Only ever a symptom of the millisecond collision described above, but
+    // worth seeing if it is ever anything else.
+    if (closed.length !== expected)
+      logger.warn('Closed-episode read-back disagrees with the update count', {
+        ruleId: String(rule_id),
+        expected,
+        readBack: closed.length,
+      });
+
+    const events: ResolvedAlert[] = closed.map(alert => ({
+      _id: String(alert._id),
+      rule_id: String(alert.rule_id),
+      device_id: alert.device_id,
+      severity: alert.severity,
+      resolution: 'manual',
+      resolved_at: resolvedAt.toISOString(),
+      actor,
+    }));
+
+    // One per closed episode, not one per PATCH: `alerts_resolved` counts
+    // episodes, and the sweep and the evaluator both record it that way.
+    events.forEach(() => recordAlert('resolved', { resolution: 'manual' }));
+
+    await publishAlertEvents([], events);
+  } catch (error) {
+    logger.error('Closed-episode broadcast failed after a committed write', {
+      ruleId: String(rule_id),
+      error: error instanceof Error ? error.message : String(error),
+    });
+    try {
+      captureException(error instanceof Error ? error : new Error(String(error)), undefined, {
+        subsystem: 'alerting',
+      });
+    } catch {
+      // Deliberately swallowed — a misbehaving Sentry SDK must not turn an
+      // already-handled fault into an unhandled one.
+    }
+  }
 }
 
 // ============================================================================
@@ -214,8 +324,16 @@ async function handleUpdateAlertRule(
     // is still cached, every episode the evaluator can create carries the OLD
     // snapshot, so closing them all is correct. Invalidating first would open a
     // window in which a genuinely new-condition episode gets closed as orphaned.
+    // `authContext.userId`, not `auditUser`: the second argument is broadcast
+    // to every subscriber, the first is persisted. See announceClosedEpisodes.
     const closed = conditionChanged
-      ? await closeEpisodesOrphanedByConditionChange(id, before, updated, auditUser)
+      ? await closeEpisodesOrphanedByConditionChange(
+          id,
+          before,
+          updated,
+          auditUser,
+          authContext.userId
+        )
       : null;
 
     await invalidateAlertRules();

--- a/app/api/v2/alert-rules/[id]/route.ts
+++ b/app/api/v2/alert-rules/[id]/route.ts
@@ -24,7 +24,8 @@ import { withRateLimit } from '@/lib/ratelimit';
 import { withRequestValidation, ValidationPresets } from '@/lib/middleware';
 import { invalidateAlertRules } from '@/lib/cache';
 import { logger, recordRequest, createRequestTimer } from '@/lib/monitoring';
-import { requireAdmin, requireOrgMembership, getAuditUser } from '@/lib/auth';
+import { requireAdmin, requireOrgMembership, getAuditUser, isDemoCaller } from '@/lib/auth';
+import { redactAuditForDemo } from '@/lib/alerting';
 
 function assertValidId(id: string): void {
   const paramValidation = validateInput({ id }, alertRuleIdParamSchema);
@@ -45,7 +46,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
   const timer = createRequestTimer();
 
   return withErrorHandler(async () => {
-    await requireOrgMembership();
+    const authContext = await requireOrgMembership();
     await dbConnect();
 
     const { id } = await params;
@@ -63,7 +64,10 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
 
     recordRequest('GET', '/api/v2/alert-rules/[id]', 200, timer.elapsed());
 
-    return jsonSuccess(rule);
+    // Demo mode grants an anonymous visitor the same read access as a real org
+    // member (see requireOrgMembership()) — never let that also hand them a
+    // real administrator's email off audit.created_by/updated_by/deleted_by.
+    return jsonSuccess(redactAuditForDemo(rule, isDemoCaller(authContext)));
   })();
 }
 

--- a/app/api/v2/alert-rules/route.ts
+++ b/app/api/v2/alert-rules/route.ts
@@ -24,7 +24,8 @@ import { withRateLimit } from '@/lib/ratelimit';
 import { withRequestValidation, ValidationPresets } from '@/lib/middleware';
 import { invalidateAlertRules } from '@/lib/cache';
 import { logger, recordRequest, createRequestTimer } from '@/lib/monitoring';
-import { requireAdmin, requireOrgMembership, getAuditUser } from '@/lib/auth';
+import { requireAdmin, requireOrgMembership, getAuditUser, isDemoCaller } from '@/lib/auth';
+import { redactAuditForDemo } from '@/lib/alerting';
 
 const SORT_FIELD_MAP: Record<string, string> = {
   name: 'name',
@@ -41,7 +42,7 @@ export async function GET(request: NextRequest) {
   const timer = createRequestTimer();
 
   return withErrorHandler(async () => {
-    await requireOrgMembership();
+    const authContext = await requireOrgMembership();
     await dbConnect();
 
     const validationResult = validateQuery(request.nextUrl.searchParams, listAlertRulesQuerySchema);
@@ -76,8 +77,11 @@ export async function GET(request: NextRequest) {
 
     recordRequest('GET', '/api/v2/alert-rules', 200, timer.elapsed());
 
+    // Demo mode grants an anonymous visitor the same read access as a real org
+    // member (see requireOrgMembership()) — never let that also hand them a
+    // real administrator's email off audit.created_by/updated_by/deleted_by.
     return jsonPaginated(
-      rules,
+      redactAuditForDemo(rules, isDemoCaller(authContext)),
       calculateOffsetPagination(total, pagination.page, pagination.limit)
     );
   })();

--- a/app/api/v2/alert-rules/route.ts
+++ b/app/api/v2/alert-rules/route.ts
@@ -1,0 +1,129 @@
+/**
+ * V2 Alert Rules API Routes
+ *
+ * GET  /api/v2/alert-rules - List rules (soft-deleted excluded)
+ * POST /api/v2/alert-rules - Create a rule
+ *
+ * Path is `/api/v2/alert-rules` rather than `/api/v2/alerts/rules` so that no
+ * static segment competes with the `[id]` dynamic segment under /alerts.
+ */
+
+import type { NextRequest } from 'next/server';
+import dbConnect from '@/lib/db';
+import AlertRuleV2 from '@/models/v2/AlertRuleV2';
+import {
+  createAlertRuleSchema,
+  listAlertRulesQuerySchema,
+  type ListAlertRulesQuery,
+} from '@/lib/validations/v2/alert-rule.validation';
+import { validateQuery, validateBody } from '@/lib/validations/validator';
+import { withErrorHandler, ApiError, ErrorCodes } from '@/lib/errors';
+import { jsonSuccess, jsonPaginated } from '@/lib/api/response';
+import { getOffsetPaginationParams, calculateOffsetPagination } from '@/lib/api/pagination';
+import { withRateLimit } from '@/lib/ratelimit';
+import { withRequestValidation, ValidationPresets } from '@/lib/middleware';
+import { invalidateAlertRules } from '@/lib/cache';
+import { logger, recordRequest, createRequestTimer } from '@/lib/monitoring';
+import { requireAdmin, requireOrgMembership, getAuditUser } from '@/lib/auth';
+
+const SORT_FIELD_MAP: Record<string, string> = {
+  name: 'name',
+  created_at: 'audit.created_at',
+  updated_at: 'audit.updated_at',
+  severity: 'severity',
+};
+
+// ============================================================================
+// GET /api/v2/alert-rules
+// ============================================================================
+
+export async function GET(request: NextRequest) {
+  const timer = createRequestTimer();
+
+  return withErrorHandler(async () => {
+    await requireOrgMembership();
+    await dbConnect();
+
+    const validationResult = validateQuery(request.nextUrl.searchParams, listAlertRulesQuerySchema);
+    if (!validationResult.success)
+      throw new ApiError(
+        ErrorCodes.VALIDATION_ERROR,
+        400,
+        validationResult.errors.map(e => e.message).join(', '),
+        { errors: validationResult.errors }
+      );
+
+    const query = validationResult.data as ListAlertRulesQuery;
+    const pagination = getOffsetPaginationParams({ page: query.page, limit: query.limit });
+
+    const filter: Record<string, unknown> = { 'audit.deleted_at': { $exists: false } };
+    if (query.enabled !== undefined) filter.enabled = query.enabled;
+    if (query.metric) filter.metric = query.metric;
+    if (query.severity) filter.severity = query.severity;
+
+    const sortField = SORT_FIELD_MAP[query.sortBy ?? 'created_at'] ?? 'audit.created_at';
+    const sort: Record<string, 1 | -1> = { [sortField]: query.sortDirection === 'asc' ? 1 : -1 };
+
+    const [rules, total] = await Promise.all([
+      AlertRuleV2.find(filter).sort(sort).skip(pagination.skip).limit(pagination.limit).lean(),
+      AlertRuleV2.countDocuments(filter),
+    ]);
+
+    recordRequest('GET', '/api/v2/alert-rules', 200, timer.elapsed());
+
+    return jsonPaginated(
+      rules,
+      calculateOffsetPagination(total, pagination.page, pagination.limit)
+    );
+  })();
+}
+
+// ============================================================================
+// POST /api/v2/alert-rules
+// ============================================================================
+
+async function handleCreateAlertRule(request: NextRequest) {
+  const timer = createRequestTimer();
+
+  return withErrorHandler(async () => {
+    const { userId, user } = await requireAdmin();
+    const auditUser = getAuditUser(userId, user);
+
+    await dbConnect();
+
+    const bodyValidation = await validateBody(request, createAlertRuleSchema);
+    if (!bodyValidation.success) {
+      logger.validationFailure('/api/v2/alert-rules', bodyValidation.errors);
+      throw new ApiError(
+        ErrorCodes.VALIDATION_ERROR,
+        400,
+        bodyValidation.errors.map(e => e.message).join(', '),
+        { errors: bodyValidation.errors }
+      );
+    }
+
+    const now = new Date();
+    const created = await AlertRuleV2.create({
+      ...bodyValidation.data,
+      audit: {
+        created_at: now,
+        created_by: auditUser,
+        updated_at: now,
+        updated_by: auditUser,
+      },
+    });
+
+    // Without this the new rule takes up to 60s to affect evaluation.
+    await invalidateAlertRules();
+
+    const duration = timer.elapsed();
+    recordRequest('POST', '/api/v2/alert-rules', 201, duration);
+    logger.info('Alert rule created', { ruleId: String(created._id), createdBy: auditUser, duration });
+
+    return jsonSuccess(created.toObject(), 'Alert rule created successfully', 201);
+  })();
+}
+
+export const POST = withRateLimit(
+  withRequestValidation(handleCreateAlertRule, ValidationPresets.jsonApi)
+);

--- a/app/api/v2/alert-rules/route.ts
+++ b/app/api/v2/alert-rules/route.ts
@@ -65,7 +65,12 @@ export async function GET(request: NextRequest) {
     const sort: Record<string, 1 | -1> = { [sortField]: query.sortDirection === 'asc' ? 1 : -1 };
 
     const [rules, total] = await Promise.all([
-      AlertRuleV2.find(filter).sort(sort).skip(pagination.skip).limit(pagination.limit).lean(),
+      AlertRuleV2.find(filter)
+        .select('-__v')
+        .sort(sort)
+        .skip(pagination.skip)
+        .limit(pagination.limit)
+        .lean(),
       AlertRuleV2.countDocuments(filter),
     ]);
 
@@ -120,7 +125,7 @@ async function handleCreateAlertRule(request: NextRequest) {
     recordRequest('POST', '/api/v2/alert-rules', 201, duration);
     logger.info('Alert rule created', { ruleId: String(created._id), createdBy: auditUser, duration });
 
-    return jsonSuccess(created.toObject(), 'Alert rule created successfully', 201);
+    return jsonSuccess(created.toObject({ versionKey: false }), 'Alert rule created successfully', 201);
   })();
 }
 

--- a/app/api/v2/alert-rules/route.ts
+++ b/app/api/v2/alert-rules/route.ts
@@ -34,6 +34,21 @@ const SORT_FIELD_MAP: Record<string, string> = {
   severity: 'severity',
 };
 
+/**
+ * Urgency rank. Mongo sorts the raw string lexically, which puts `critical`
+ * last. Same `$switch` shape as /api/v2/alerts — deliberately one idiom across
+ * both endpoints rather than a second way of saying the same thing.
+ */
+const SEVERITY_RANK = {
+  $switch: {
+    branches: [
+      { case: { $eq: ['$severity', 'critical'] }, then: 3 },
+      { case: { $eq: ['$severity', 'warning'] }, then: 2 },
+    ],
+    default: 1, // info
+  },
+};
+
 // ============================================================================
 // GET /api/v2/alert-rules
 // ============================================================================
@@ -63,17 +78,30 @@ export async function GET(request: NextRequest) {
     if (query.severity) filter.severity = query.severity;
 
     const sortField = SORT_FIELD_MAP[query.sortBy ?? 'created_at'] ?? 'audit.created_at';
-    const sort: Record<string, 1 | -1> = { [sortField]: query.sortDirection === 'asc' ? 1 : -1 };
+    const direction: 1 | -1 = query.sortDirection === 'asc' ? 1 : -1;
+    const sort: Record<string, 1 | -1> = { [sortField]: direction };
 
-    const [rules, total] = await Promise.all([
-      AlertRuleV2.find(filter)
-        .select('-__v')
-        .sort(sort)
-        .skip(pagination.skip)
-        .limit(pagination.limit)
-        .lean(),
-      AlertRuleV2.countDocuments(filter),
-    ]);
+    // `filter` carries no ObjectId-typed path (see the alerts route for why
+    // that matters), so $match can consume it directly.
+    const rulesQuery =
+      query.sortBy === 'severity'
+        ? AlertRuleV2.aggregate([
+            { $match: filter },
+            { $addFields: { _severity_rank: SEVERITY_RANK } },
+            // audit.created_at breaks ties so paging is stable within a band.
+            { $sort: { _severity_rank: direction, 'audit.created_at': -1 } },
+            { $skip: pagination.skip },
+            { $limit: pagination.limit },
+            { $project: { __v: 0, _severity_rank: 0 } },
+          ])
+        : AlertRuleV2.find(filter)
+            .select('-__v')
+            .sort(sort)
+            .skip(pagination.skip)
+            .limit(pagination.limit)
+            .lean();
+
+    const [rules, total] = await Promise.all([rulesQuery, AlertRuleV2.countDocuments(filter)]);
 
     recordRequest('GET', '/api/v2/alert-rules', 200, timer.elapsed());
 
@@ -95,8 +123,8 @@ async function handleCreateAlertRule(request: NextRequest) {
   const timer = createRequestTimer();
 
   return withErrorHandler(async () => {
-    const { userId, user } = await requireAdmin();
-    const auditUser = getAuditUser(userId, user);
+    const authContext = await requireAdmin();
+    const auditUser = getAuditUser(authContext.userId, authContext.user);
 
     await dbConnect();
 
@@ -129,7 +157,16 @@ async function handleCreateAlertRule(request: NextRequest) {
     recordRequest('POST', '/api/v2/alert-rules', 201, duration);
     logger.info('Alert rule created', { ruleId: String(created._id), createdBy: auditUser, duration });
 
-    return jsonSuccess(created.toObject({ versionKey: false }), 'Alert rule created successfully', 201);
+    // requireAdmin() rejects a demo caller above, so this is inert today — it
+    // is here so a future RBAC change cannot quietly start returning
+    // audit.created_by/updated_by (a real administrator's email, via
+    // getAuditUser) to an anonymous demo visitor. Every response from the
+    // alert endpoints goes through one contract; this was the last hole in it.
+    return jsonSuccess(
+      redactAuditForDemo(created.toObject({ versionKey: false }), isDemoCaller(authContext)),
+      'Alert rule created successfully',
+      201
+    );
   })();
 }
 

--- a/app/api/v2/alert-rules/route.ts
+++ b/app/api/v2/alert-rules/route.ts
@@ -18,14 +18,13 @@ import {
 } from '@/lib/validations/v2/alert-rule.validation';
 import { validateQuery, validateBody } from '@/lib/validations/validator';
 import { withErrorHandler, ApiError, ErrorCodes } from '@/lib/errors';
-import { jsonSuccess, jsonPaginated } from '@/lib/api/response';
 import { getOffsetPaginationParams, calculateOffsetPagination } from '@/lib/api/pagination';
 import { withRateLimit } from '@/lib/ratelimit';
 import { withRequestValidation, ValidationPresets } from '@/lib/middleware';
 import { invalidateAlertRules } from '@/lib/cache';
 import { logger, recordRequest, createRequestTimer } from '@/lib/monitoring';
 import { requireAdmin, requireOrgMembership, getAuditUser, isDemoCaller } from '@/lib/auth';
-import { redactAuditForDemo } from '@/lib/alerting';
+import { redactAuditForDemo, jsonRedacted, jsonRedactedPaginated } from '@/lib/alerting';
 
 const SORT_FIELD_MAP: Record<string, string> = {
   name: 'name',
@@ -108,7 +107,7 @@ export async function GET(request: NextRequest) {
     // Demo mode grants an anonymous visitor the same read access as a real org
     // member (see requireOrgMembership()) — never let that also hand them a
     // real administrator's email off audit.created_by/updated_by/deleted_by.
-    return jsonPaginated(
+    return jsonRedactedPaginated(
       redactAuditForDemo(rules, isDemoCaller(authContext)),
       calculateOffsetPagination(total, pagination.page, pagination.limit)
     );
@@ -161,8 +160,10 @@ async function handleCreateAlertRule(request: NextRequest) {
     // is here so a future RBAC change cannot quietly start returning
     // audit.created_by/updated_by (a real administrator's email, via
     // getAuditUser) to an anonymous demo visitor. Every response from the
-    // alert endpoints goes through one contract; this was the last hole in it.
-    return jsonSuccess(
+    // alert endpoints goes through one contract; this was the last hole in it,
+    // and jsonRedacted is what now keeps it from reopening: it does not accept
+    // an unredacted record, so deleting the call below is a compile error.
+    return jsonRedacted(
       redactAuditForDemo(created.toObject({ versionKey: false }), isDemoCaller(authContext)),
       'Alert rule created successfully',
       201

--- a/app/api/v2/alerts/[id]/route.ts
+++ b/app/api/v2/alerts/[id]/route.ts
@@ -1,0 +1,201 @@
+/**
+ * V2 Single Alert API Routes
+ *
+ * GET   /api/v2/alerts/[id] - Get a single alert
+ * PATCH /api/v2/alerts/[id] - Acknowledge or resolve
+ *
+ * There is no DELETE. An alert is resolved, never cancelled and never removed —
+ * the history is the point.
+ *
+ * Status Transition Rules:
+ *   firing       -> acknowledged | resolved
+ *   acknowledged -> resolved
+ *   resolved     -> (terminal)
+ *   pending      -> (internal; not a legal PATCH target)
+ */
+
+import type { NextRequest } from 'next/server';
+import dbConnect from '@/lib/db';
+import AlertV2, {
+  AlertTransitionError,
+  type AlertTransitionCode,
+} from '@/models/v2/AlertV2';
+import DeviceV2 from '@/models/v2/DeviceV2';
+import {
+  updateAlertSchema,
+  getAlertQuerySchema,
+  alertIdParamSchema,
+  type GetAlertQuery,
+} from '@/lib/validations/v2/alert.validation';
+import { validateInput, validateQuery, validateBody } from '@/lib/validations/validator';
+import { withErrorHandler, ApiError, ErrorCodes } from '@/lib/errors';
+import { jsonSuccess } from '@/lib/api/response';
+import { withRateLimit } from '@/lib/ratelimit';
+import { withRequestValidation, ValidationPresets } from '@/lib/middleware';
+import { requireAdmin, requireOrgMembership, getAuditUser } from '@/lib/auth';
+import { logger, recordRequest, createRequestTimer, recordAlert } from '@/lib/monitoring';
+
+// ============================================================================
+// GET /api/v2/alerts/[id]
+// ============================================================================
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const timer = createRequestTimer();
+
+  return withErrorHandler(async () => {
+    await requireOrgMembership();
+    await dbConnect();
+
+    const { id } = await params;
+
+    const paramValidation = validateInput({ id }, alertIdParamSchema);
+    if (!paramValidation.success)
+      throw new ApiError(
+        ErrorCodes.VALIDATION_ERROR,
+        400,
+        paramValidation.errors.map(e => e.message).join(', '),
+        { errors: paramValidation.errors }
+      );
+
+    const queryValidation = validateQuery(request.nextUrl.searchParams, getAlertQuerySchema);
+    if (!queryValidation.success)
+      throw new ApiError(
+        ErrorCodes.VALIDATION_ERROR,
+        400,
+        queryValidation.errors.map(e => e.message).join(', '),
+        { errors: queryValidation.errors }
+      );
+
+    const query = queryValidation.data as GetAlertQuery;
+
+    const alert = await AlertV2.findById(id).lean();
+    if (!alert) throw new ApiError(ErrorCodes.ALERT_NOT_FOUND, 404, `Alert '${id}' not found`);
+
+    const response: Record<string, unknown> = { ...alert };
+
+    if (query.include_device) {
+      const device = await DeviceV2.findById(alert.device_id)
+        .select('_id serial_number type location')
+        .lean();
+
+      response.device = device
+        ? {
+            _id: device._id,
+            serial_number: device.serial_number,
+            type: device.type,
+            location: {
+              building_id: device.location?.building_id,
+              floor: device.location?.floor,
+              room_name: device.location?.room_name,
+            },
+          }
+        : null;
+
+      if (!device)
+        logger.warn('Device not found for alert', { alertId: id, deviceId: alert.device_id });
+    }
+
+    recordRequest('GET', '/api/v2/alerts/[id]', 200, timer.elapsed());
+
+    return jsonSuccess(response);
+  })();
+}
+
+// ============================================================================
+// ERROR MAPPING HELPER
+// ============================================================================
+
+/**
+ * Three codes, not four. ScheduleV2 needs four because its two terminal targets
+ * are symmetric — either can block the other. Alerts are not symmetric:
+ * `acknowledged` sits between `firing` and `resolved`.
+ */
+const TRANSITION_CODE_MAP: Record<AlertTransitionCode, { code: string; message: string }> = {
+  ALREADY_ACKNOWLEDGED: {
+    code: ErrorCodes.ALERT_ALREADY_ACKNOWLEDGED,
+    message: 'Alert is already acknowledged',
+  },
+  ALREADY_RESOLVED: {
+    code: ErrorCodes.ALERT_ALREADY_RESOLVED,
+    message: 'Alert is already resolved',
+  },
+  NOT_YET_FIRING: {
+    code: ErrorCodes.INVALID_ALERT_STATUS_TRANSITION,
+    message: 'Alert has not fired yet and cannot be acknowledged or resolved',
+  },
+};
+
+function rethrowAsApiError(error: unknown): never {
+  if (error instanceof AlertTransitionError) {
+    const mapped = TRANSITION_CODE_MAP[error.code];
+    throw new ApiError(mapped.code, 422, mapped.message);
+  }
+  throw error;
+}
+
+// ============================================================================
+// PATCH /api/v2/alerts/[id]
+// ============================================================================
+
+async function handleUpdateAlert(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const timer = createRequestTimer();
+
+  return withErrorHandler(async () => {
+    const { userId, user } = await requireAdmin();
+    const auditUser = getAuditUser(userId, user);
+
+    await dbConnect();
+
+    const { id } = await params;
+
+    const paramValidation = validateInput({ id }, alertIdParamSchema);
+    if (!paramValidation.success)
+      throw new ApiError(
+        ErrorCodes.VALIDATION_ERROR,
+        400,
+        paramValidation.errors.map(e => e.message).join(', '),
+        { errors: paramValidation.errors }
+      );
+
+    const bodyValidation = await validateBody(request, updateAlertSchema);
+    if (!bodyValidation.success)
+      throw new ApiError(
+        ErrorCodes.VALIDATION_ERROR,
+        400,
+        bodyValidation.errors.map(e => e.message).join(', '),
+        { errors: bodyValidation.errors }
+      );
+
+    const { status, note } = bodyValidation.data;
+
+    const updated =
+      status === 'acknowledged'
+        ? await AlertV2.acknowledge(id, auditUser).catch(rethrowAsApiError)
+        : await AlertV2.resolve(id, auditUser, 'manual').catch(rethrowAsApiError);
+
+    if (!updated) throw new ApiError(ErrorCodes.ALERT_NOT_FOUND, 404, `Alert '${id}' not found`);
+
+    if (note) {
+      updated.audit.note = note;
+      await updated.save();
+    }
+
+    if (status === 'resolved') recordAlert('resolved', { resolution: 'manual' });
+
+    const duration = timer.elapsed();
+    recordRequest('PATCH', '/api/v2/alerts/[id]', 200, duration);
+    logger.info('Alert transitioned', { alertId: id, status, by: auditUser, duration });
+
+    return jsonSuccess(
+      updated.toObject(),
+      status === 'acknowledged' ? 'Alert acknowledged' : 'Alert resolved'
+    );
+  })();
+}
+
+export const PATCH = withRateLimit(
+  withRequestValidation(handleUpdateAlert, ValidationPresets.jsonApi)
+);

--- a/app/api/v2/alerts/[id]/route.ts
+++ b/app/api/v2/alerts/[id]/route.ts
@@ -31,7 +31,6 @@ import {
 import type { ResolvedAlert } from '@/types/v2/alert.types';
 import { validateInput, validateQuery, validateBody } from '@/lib/validations/validator';
 import { withErrorHandler, ApiError, ErrorCodes } from '@/lib/errors';
-import { jsonSuccess } from '@/lib/api/response';
 import { withRateLimit } from '@/lib/ratelimit';
 import { withRequestValidation, ValidationPresets } from '@/lib/middleware';
 import { requireAdmin, requireOrgMembership, getAuditUser, isDemoCaller } from '@/lib/auth';
@@ -42,7 +41,12 @@ import {
   recordAlert,
   captureException,
 } from '@/lib/monitoring';
-import { publishAlertEvents, redactAuditForDemo } from '@/lib/alerting';
+import {
+  publishAlertEvents,
+  redactAuditForDemo,
+  jsonRedacted,
+  extendRedacted,
+} from '@/lib/alerting';
 
 // ============================================================================
 // GET /api/v2/alerts/[id]
@@ -89,33 +93,37 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     // real administrator's email off audit.acknowledged_by/resolved_by/etc.
     const alert = redactAuditForDemo(found, isDemoCaller(authContext));
 
-    const response: Record<string, unknown> = { ...alert };
+    const device = query.include_device
+      ? await DeviceV2.findById(alert.device_id).select('_id serial_number type location').lean()
+      : null;
 
-    if (query.include_device) {
-      const device = await DeviceV2.findById(alert.device_id)
-        .select('_id serial_number type location')
-        .lean();
-
-      response.device = device
-        ? {
-            _id: device._id,
-            serial_number: device.serial_number,
-            type: device.type,
-            location: {
-              building_id: device.location?.building_id,
-              floor: device.location?.floor,
-              room_name: device.location?.room_name,
-            },
-          }
-        : null;
-
-      if (!device)
-        logger.warn('Device not found for alert', { alertId: id, deviceId: alert.device_id });
-    }
+    if (query.include_device && !device)
+      logger.warn('Device not found for alert', { alertId: id, deviceId: alert.device_id });
 
     recordRequest('GET', '/api/v2/alerts/[id]', 200, timer.elapsed());
 
-    return jsonSuccess(response);
+    // `extendRedacted`, not a bare spread into `Record<string, unknown>`: the
+    // old annotation erased the Redacted<> marker, which is what lets
+    // jsonRedacted below prove the redaction actually happened. The device
+    // projection carries no actor field, so it needs no redaction of its own.
+    return jsonRedacted(
+      query.include_device
+        ? extendRedacted(alert, {
+            device: device
+              ? {
+                  _id: device._id,
+                  serial_number: device.serial_number,
+                  type: device.type,
+                  location: {
+                    building_id: device.location?.building_id,
+                    floor: device.location?.floor,
+                    room_name: device.location?.room_name,
+                  },
+                }
+              : null,
+          })
+        : alert
+    );
   })();
 }
 
@@ -350,7 +358,8 @@ async function handleUpdateAlert(
     // member for GET, but PATCH is requireAdmin()-only, so isDemoCaller here
     // is always false in practice — applied anyway for defense in depth and
     // to keep every response from these endpoints going through one contract.
-    return jsonSuccess(
+    // jsonRedacted is what makes "one contract" checkable rather than a habit.
+    return jsonRedacted(
       redactAuditForDemo(updated.toObject({ versionKey: false }), isDemoCaller(authContext)),
       status === 'acknowledged' ? 'Alert acknowledged' : 'Alert resolved'
     );

--- a/app/api/v2/alerts/[id]/route.ts
+++ b/app/api/v2/alerts/[id]/route.ts
@@ -226,10 +226,22 @@ const TRANSITION_PRECONDITION: Record<
  * transition is about to apply. The note write used to run after
  * acknowledge()/resolve() had already committed, so a throw returned 500 and
  * told the operator the acknowledge had FAILED when it had not; the natural
- * retry then returned 422 "already acknowledged". Failing here commits
- * nothing, so the retry is clean and returns 200. The precondition is what
+ * retry then returned 422 "already acknowledged". Failing HERE commits nothing,
+ * so that particular retry is clean and returns 200. The precondition is what
  * keeps the reordering honest: it matches exactly when the transition would
  * match, so a note cannot land on an alert whose transition is about to 422.
+ *
+ * The residual, stated plainly: these are still two writes, so the inversion is
+ * not eliminated, only turned around. A concurrent resolve landing BETWEEN them
+ * leaves the note committed and the transition throwing 404/422 — an operator
+ * note on an alert that was never acknowledged. That is strictly less harmful
+ * than the original (a note is additive; the old failure mode misreported a
+ * committed transition as a 500), and the shared precondition narrows the
+ * window to the gap between the two round trips, but it is a real residual. The
+ * fix that removes it entirely is one `findOneAndUpdate` carrying both the note
+ * and the transition; it was left alone here because it would mean reworking
+ * `AlertV2.acknowledge`/`resolve`, whose atomicity and error mapping this route
+ * depends on.
  *
  * Presence check, not truthiness: `if (note)` discarded an explicit
  * `note: ''`, so a caller could never clear a note. `$unset` removes the field
@@ -313,7 +325,9 @@ async function handleUpdateAlert(
     const { status, note } = bodyValidation.data;
 
     // Ordered deliberately: see writeNote's doc comment. A failure here
-    // commits nothing, so it can never misreport a transition that succeeded.
+    // commits nothing, so it can never misreport a transition that succeeded —
+    // at the cost of the reverse residual documented there (a note committed
+    // against a transition that then 404/422s on a concurrent resolve).
     if (note !== undefined) await writeNote(id, status, note);
 
     const updated = await applyTransition(id, status, auditUser);

--- a/app/api/v2/alerts/[id]/route.ts
+++ b/app/api/v2/alerts/[id]/route.ts
@@ -68,7 +68,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
     const query = queryValidation.data as GetAlertQuery;
 
-    const alert = await AlertV2.findById(id).lean();
+    const alert = await AlertV2.findById(id).select('-__v').lean();
     if (!alert) throw new ApiError(ErrorCodes.ALERT_NOT_FOUND, 404, `Alert '${id}' not found`);
 
     const response: Record<string, unknown> = { ...alert };
@@ -190,7 +190,7 @@ async function handleUpdateAlert(
     logger.info('Alert transitioned', { alertId: id, status, by: auditUser, duration });
 
     return jsonSuccess(
-      updated.toObject(),
+      updated.toObject({ versionKey: false }),
       status === 'acknowledged' ? 'Alert acknowledged' : 'Alert resolved'
     );
   })();

--- a/app/api/v2/alerts/[id]/route.ts
+++ b/app/api/v2/alerts/[id]/route.ts
@@ -34,6 +34,7 @@ import { withRateLimit } from '@/lib/ratelimit';
 import { withRequestValidation, ValidationPresets } from '@/lib/middleware';
 import { requireAdmin, requireOrgMembership, getAuditUser } from '@/lib/auth';
 import { logger, recordRequest, createRequestTimer, recordAlert } from '@/lib/monitoring';
+import { publishAlertEvents } from '@/lib/alerting';
 
 // ============================================================================
 // GET /api/v2/alerts/[id]
@@ -184,6 +185,23 @@ async function handleUpdateAlert(
     }
 
     if (status === 'resolved') recordAlert('resolved', { resolution: 'manual' });
+    if (status === 'resolved')
+      await publishAlertEvents(
+        [],
+        [
+          {
+            _id: String(updated._id),
+            rule_id: String(updated.rule_id),
+            device_id: updated.device_id,
+            severity: updated.severity,
+            resolution: 'manual',
+            resolved_at: new Date().toISOString(),
+            // The Clerk USER ID, never getAuditUser's email — this payload
+            // reaches every connected client, including anonymous demo visitors.
+            actor: userId,
+          },
+        ]
+      );
 
     const duration = timer.elapsed();
     recordRequest('PATCH', '/api/v2/alerts/[id]', 200, duration);

--- a/app/api/v2/alerts/[id]/route.ts
+++ b/app/api/v2/alerts/[id]/route.ts
@@ -32,9 +32,9 @@ import { withErrorHandler, ApiError, ErrorCodes } from '@/lib/errors';
 import { jsonSuccess } from '@/lib/api/response';
 import { withRateLimit } from '@/lib/ratelimit';
 import { withRequestValidation, ValidationPresets } from '@/lib/middleware';
-import { requireAdmin, requireOrgMembership, getAuditUser } from '@/lib/auth';
+import { requireAdmin, requireOrgMembership, getAuditUser, isDemoCaller } from '@/lib/auth';
 import { logger, recordRequest, createRequestTimer, recordAlert } from '@/lib/monitoring';
-import { publishAlertEvents } from '@/lib/alerting';
+import { publishAlertEvents, redactAuditForDemo } from '@/lib/alerting';
 
 // ============================================================================
 // GET /api/v2/alerts/[id]
@@ -44,7 +44,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
   const timer = createRequestTimer();
 
   return withErrorHandler(async () => {
-    await requireOrgMembership();
+    const authContext = await requireOrgMembership();
     await dbConnect();
 
     const { id } = await params;
@@ -69,8 +69,17 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
 
     const query = queryValidation.data as GetAlertQuery;
 
-    const alert = await AlertV2.findById(id).select('-__v').lean();
-    if (!alert) throw new ApiError(ErrorCodes.ALERT_NOT_FOUND, 404, `Alert '${id}' not found`);
+    const found = await AlertV2.findById(id).select('-__v').lean();
+    // `pending` is internal (see the list endpoint's header comment) and must
+    // never be visible to a client — treat it exactly like "does not exist"
+    // rather than leaking an alert whose for_duration_seconds hasn't elapsed.
+    if (!found || found.status === 'pending')
+      throw new ApiError(ErrorCodes.ALERT_NOT_FOUND, 404, `Alert '${id}' not found`);
+
+    // Demo mode grants an anonymous visitor the same read access as a real org
+    // member (see requireOrgMembership()) — never let that also hand them a
+    // real administrator's email off audit.acknowledged_by/resolved_by/etc.
+    const alert = redactAuditForDemo(found, isDemoCaller(authContext));
 
     const response: Record<string, unknown> = { ...alert };
 
@@ -145,7 +154,8 @@ async function handleUpdateAlert(
   const timer = createRequestTimer();
 
   return withErrorHandler(async () => {
-    const { userId, user } = await requireAdmin();
+    const authContext = await requireAdmin();
+    const { userId, user } = authContext;
     const auditUser = getAuditUser(userId, user);
 
     await dbConnect();
@@ -186,29 +196,46 @@ async function handleUpdateAlert(
 
     if (status === 'resolved') recordAlert('resolved', { resolution: 'manual' });
     if (status === 'resolved')
-      await publishAlertEvents(
-        [],
-        [
-          {
-            _id: String(updated._id),
-            rule_id: String(updated.rule_id),
-            device_id: updated.device_id,
-            severity: updated.severity,
-            resolution: 'manual',
-            resolved_at: new Date().toISOString(),
-            // The Clerk USER ID, never getAuditUser's email — this payload
-            // reaches every connected client, including anonymous demo visitors.
-            actor: userId,
-          },
-        ]
-      );
+      try {
+        await publishAlertEvents(
+          [],
+          [
+            {
+              _id: String(updated._id),
+              rule_id: String(updated.rule_id),
+              device_id: updated.device_id,
+              severity: updated.severity,
+              resolution: 'manual',
+              resolved_at: new Date().toISOString(),
+              // The Clerk USER ID, never getAuditUser's email — this payload
+              // reaches every connected client, including anonymous demo visitors.
+              actor: userId,
+            },
+          ]
+        );
+      } catch (error) {
+        // Mirrors safeEvaluateReadings's own nested try/catch around
+        // publishAlertEvents (lib/alerting/index.ts): notify.ts already
+        // swallows Pusher's own trigger failure internally, so the only
+        // residual here is envelope construction — but this route already
+        // committed the resolve to the database, so a broadcast fault must
+        // never turn that into a 500.
+        logger.error('Alert broadcast failed after a committed write', {
+          alertId: id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
 
     const duration = timer.elapsed();
     recordRequest('PATCH', '/api/v2/alerts/[id]', 200, duration);
     logger.info('Alert transitioned', { alertId: id, status, by: auditUser, duration });
 
+    // Demo mode grants an anonymous visitor the same read access as a real org
+    // member for GET, but PATCH is requireAdmin()-only, so isDemoCaller here
+    // is always false in practice — applied anyway for defense in depth and
+    // to keep every response from these endpoints going through one contract.
     return jsonSuccess(
-      updated.toObject({ versionKey: false }),
+      redactAuditForDemo(updated.toObject({ versionKey: false }), isDemoCaller(authContext)),
       status === 'acknowledged' ? 'Alert acknowledged' : 'Alert resolved'
     );
   })();

--- a/app/api/v2/alerts/[id]/route.ts
+++ b/app/api/v2/alerts/[id]/route.ts
@@ -19,6 +19,7 @@ import dbConnect from '@/lib/db';
 import AlertV2, {
   AlertTransitionError,
   type AlertTransitionCode,
+  type AlertStatus,
 } from '@/models/v2/AlertV2';
 import DeviceV2 from '@/models/v2/DeviceV2';
 import {
@@ -27,13 +28,20 @@ import {
   alertIdParamSchema,
   type GetAlertQuery,
 } from '@/lib/validations/v2/alert.validation';
+import type { ResolvedAlert } from '@/types/v2/alert.types';
 import { validateInput, validateQuery, validateBody } from '@/lib/validations/validator';
 import { withErrorHandler, ApiError, ErrorCodes } from '@/lib/errors';
 import { jsonSuccess } from '@/lib/api/response';
 import { withRateLimit } from '@/lib/ratelimit';
 import { withRequestValidation, ValidationPresets } from '@/lib/middleware';
 import { requireAdmin, requireOrgMembership, getAuditUser, isDemoCaller } from '@/lib/auth';
-import { logger, recordRequest, createRequestTimer, recordAlert } from '@/lib/monitoring';
+import {
+  logger,
+  recordRequest,
+  createRequestTimer,
+  recordAlert,
+  captureException,
+} from '@/lib/monitoring';
 import { publishAlertEvents, redactAuditForDemo } from '@/lib/alerting';
 
 // ============================================================================
@@ -144,6 +152,120 @@ function rethrowAsApiError(error: unknown): never {
 }
 
 // ============================================================================
+// ACTOR IDENTITY — two different strings, in scope together
+// ============================================================================
+
+/**
+ * `audit.*_by` gets getAuditUser()'s value: the acting admin's EMAIL whenever
+ * one is on file. The Pusher payload gets the opaque Clerk USER ID, because it
+ * reaches every connected client — including anonymous demo visitors — on a
+ * channel redact.ts does not cover. Both are `string`, both live in this one
+ * handler, and until now only a comment stood between them and a swap that
+ * would broadcast an administrator's email address.
+ *
+ * Branding makes that swap a COMPILE error instead. The two types are mutually
+ * unassignable; each constructor below refuses the opposite brand; and the two
+ * consumers (`applyTransition`, `buildResolvedEvent`) each demand their own, so
+ * a bare `string` cannot reach either without going through a constructor.
+ *
+ * Deliberately local and narrow: `getAuditUser` (lib/auth) and `ResolvedAlert`
+ * (types/v2) are outside this change's scope, so the brand is applied at this
+ * boundary rather than pushed into their signatures.
+ */
+declare const AuditIdentityBrand: unique symbol;
+declare const BroadcastActorBrand: unique symbol;
+
+/** Persisted to `audit.*_by`. May be an email. NEVER broadcast. */
+type AuditIdentity = string & { readonly [AuditIdentityBrand]: true };
+
+/** Broadcast to every connected client. MUST be the opaque Clerk user id. */
+type BroadcastActor = string & { readonly [BroadcastActorBrand]: true };
+
+function auditIdentity(
+  emailOrUserId: string & { readonly [BroadcastActorBrand]?: never }
+): AuditIdentity {
+  return emailOrUserId as AuditIdentity;
+}
+
+function broadcastActor(
+  clerkUserId: string & { readonly [AuditIdentityBrand]?: never }
+): BroadcastActor {
+  return clerkUserId as BroadcastActor;
+}
+
+// ============================================================================
+// TRANSITION + NOTE
+// ============================================================================
+
+/**
+ * The status each transition requires, mirroring the guards inside
+ * `AlertV2.acknowledge()` / `AlertV2.resolve()` (models/v2/AlertV2.ts). The
+ * note write below reuses it as its own precondition so the two writes agree
+ * about which alerts they may touch.
+ */
+const TRANSITION_PRECONDITION: Record<
+  'acknowledged' | 'resolved',
+  AlertStatus | { $in: AlertStatus[] }
+> = {
+  acknowledged: 'firing',
+  resolved: { $in: ['firing', 'acknowledged'] },
+};
+
+/**
+ * Attach — or clear — the operator's note.
+ *
+ * Runs BEFORE the transition, guarded on the same status precondition the
+ * transition is about to apply. The note write used to run after
+ * acknowledge()/resolve() had already committed, so a throw returned 500 and
+ * told the operator the acknowledge had FAILED when it had not; the natural
+ * retry then returned 422 "already acknowledged". Failing here commits
+ * nothing, so the retry is clean and returns 200. The precondition is what
+ * keeps the reordering honest: it matches exactly when the transition would
+ * match, so a note cannot land on an alert whose transition is about to 422.
+ *
+ * Presence check, not truthiness: `if (note)` discarded an explicit
+ * `note: ''`, so a caller could never clear a note. `$unset` removes the field
+ * rather than storing a meaningless empty string.
+ *
+ * updateOne rather than doc.save(): AlertV2's pre('save') hook stamps
+ * `audit.updated_at`, which the transition's own `$set` already sets — saving
+ * bumped it a second time for what is one operator action.
+ */
+async function writeNote(
+  id: string,
+  status: 'acknowledged' | 'resolved',
+  note: string
+): Promise<void> {
+  await AlertV2.updateOne(
+    { _id: id, status: TRANSITION_PRECONDITION[status] },
+    note === '' ? { $unset: { 'audit.note': '' } } : { $set: { 'audit.note': note } }
+  );
+}
+
+/** Demands an AuditIdentity, so passing the broadcast actor here will not compile. */
+function applyTransition(id: string, status: 'acknowledged' | 'resolved', by: AuditIdentity) {
+  return status === 'acknowledged'
+    ? AlertV2.acknowledge(id, by).catch(rethrowAsApiError)
+    : AlertV2.resolve(id, by, 'manual').catch(rethrowAsApiError);
+}
+
+/** Demands a BroadcastActor, so passing the audit identity here will not compile. */
+function buildResolvedEvent(
+  alert: { _id: unknown; rule_id: unknown; device_id: string; severity: ResolvedAlert['severity'] },
+  actor: BroadcastActor
+): ResolvedAlert {
+  return {
+    _id: String(alert._id),
+    rule_id: String(alert.rule_id),
+    device_id: alert.device_id,
+    severity: alert.severity,
+    resolution: 'manual',
+    resolved_at: new Date().toISOString(),
+    actor,
+  };
+}
+
+// ============================================================================
 // PATCH /api/v2/alerts/[id]
 // ============================================================================
 
@@ -156,7 +278,7 @@ async function handleUpdateAlert(
   return withErrorHandler(async () => {
     const authContext = await requireAdmin();
     const { userId, user } = authContext;
-    const auditUser = getAuditUser(userId, user);
+    const auditUser = auditIdentity(getAuditUser(userId, user));
 
     await dbConnect();
 
@@ -182,37 +304,18 @@ async function handleUpdateAlert(
 
     const { status, note } = bodyValidation.data;
 
-    const updated =
-      status === 'acknowledged'
-        ? await AlertV2.acknowledge(id, auditUser).catch(rethrowAsApiError)
-        : await AlertV2.resolve(id, auditUser, 'manual').catch(rethrowAsApiError);
+    // Ordered deliberately: see writeNote's doc comment. A failure here
+    // commits nothing, so it can never misreport a transition that succeeded.
+    if (note !== undefined) await writeNote(id, status, note);
+
+    const updated = await applyTransition(id, status, auditUser);
 
     if (!updated) throw new ApiError(ErrorCodes.ALERT_NOT_FOUND, 404, `Alert '${id}' not found`);
-
-    if (note) {
-      updated.audit.note = note;
-      await updated.save();
-    }
 
     if (status === 'resolved') recordAlert('resolved', { resolution: 'manual' });
     if (status === 'resolved')
       try {
-        await publishAlertEvents(
-          [],
-          [
-            {
-              _id: String(updated._id),
-              rule_id: String(updated.rule_id),
-              device_id: updated.device_id,
-              severity: updated.severity,
-              resolution: 'manual',
-              resolved_at: new Date().toISOString(),
-              // The Clerk USER ID, never getAuditUser's email — this payload
-              // reaches every connected client, including anonymous demo visitors.
-              actor: userId,
-            },
-          ]
-        );
+        await publishAlertEvents([], [buildResolvedEvent(updated, broadcastActor(userId))]);
       } catch (error) {
         // Mirrors safeEvaluateReadings's own nested try/catch around
         // publishAlertEvents (lib/alerting/index.ts): notify.ts already
@@ -224,6 +327,19 @@ async function handleUpdateAlert(
           alertId: id,
           error: error instanceof Error ? error.message : String(error),
         });
+        // Escalated, not merely logged — logger.error only reaches a console
+        // line (lib/monitoring/logger.ts), so without this a permanently
+        // broken broadcast path is invisible in production while every PATCH
+        // keeps returning 200. Same reasoning, and the same self-guarding, as
+        // reportToSentry() in lib/alerting/index.ts: a misbehaving Sentry SDK
+        // must not turn an already-handled fault into an unhandled one.
+        try {
+          captureException(error instanceof Error ? error : new Error(String(error)), undefined, {
+            subsystem: 'alerting',
+          });
+        } catch {
+          // Deliberately swallowed — see above.
+        }
       }
 
     const duration = timer.elapsed();

--- a/app/api/v2/alerts/route.ts
+++ b/app/api/v2/alerts/route.ts
@@ -13,10 +13,11 @@
  * unlike alert-rules (which calls `invalidateAlertRules()` on every mutation),
  * no invalidation hook is wired to those writes. A cache-aside layer here would
  * mean stale results for an operator actively triaging what is currently
- * firing. Nothing publishes alerts over Pusher yet either: both
- * `safeEvaluateReadings()` call sites (readings/ingest, cron/simulate) discard
- * its result after logging it. Real-time delivery is Task 13/14's job, not
- * this endpoint's.
+ * firing. Real-time delivery is handled separately: `safeEvaluateReadings()`
+ * and `safeSweepStaleAlerts()` (lib/alerting/index.ts) publish fired/resolved
+ * episodes over Pusher internally, as part of evaluation/sweep itself — this
+ * endpoint never publishes anything, it only ever serves a poll, a refresh,
+ * or an initial page load.
  */
 
 import type { NextRequest } from 'next/server';
@@ -31,7 +32,8 @@ import { withErrorHandler, ApiError, ErrorCodes } from '@/lib/errors';
 import { jsonPaginated } from '@/lib/api/response';
 import { getOffsetPaginationParams, calculateOffsetPagination } from '@/lib/api/pagination';
 import { logger, recordRequest, createRequestTimer } from '@/lib/monitoring';
-import { requireOrgMembership } from '@/lib/auth';
+import { requireOrgMembership, isDemoCaller } from '@/lib/auth';
+import { redactAuditForDemo } from '@/lib/alerting';
 
 /** Statuses a client may ever see. `pending` is internal and always excluded. */
 const VISIBLE_STATUSES = ['firing', 'acknowledged', 'resolved'] as const;
@@ -60,7 +62,7 @@ export async function GET(request: NextRequest) {
   const timer = createRequestTimer();
 
   return withErrorHandler(async () => {
-    await requireOrgMembership();
+    const authContext = await requireOrgMembership();
     await dbConnect();
 
     const validationResult = validateQuery(request.nextUrl.searchParams, listAlertsQuerySchema);
@@ -138,6 +140,9 @@ export async function GET(request: NextRequest) {
     recordRequest('GET', '/api/v2/alerts', 200, duration);
     logger.debug('Alerts list request', { duration, total, statuses });
 
-    return jsonPaginated(alerts, paginationInfo);
+    // Demo mode grants an anonymous visitor the same read access as a real org
+    // member (see requireOrgMembership()) — never let that also hand them a
+    // real administrator's email off audit.acknowledged_by/resolved_by/etc.
+    return jsonPaginated(redactAuditForDemo(alerts, isDemoCaller(authContext)), paginationInfo);
   })();
 }

--- a/app/api/v2/alerts/route.ts
+++ b/app/api/v2/alerts/route.ts
@@ -21,6 +21,7 @@
  */
 
 import type { NextRequest } from 'next/server';
+import { Types } from 'mongoose';
 import dbConnect from '@/lib/db';
 import AlertV2 from '@/models/v2/AlertV2';
 import {
@@ -114,10 +115,21 @@ export async function GET(request: NextRequest) {
 
     const direction: 1 | -1 = query.sortDirection === 'asc' ? 1 : -1;
 
+    // Mongoose casts QUERIES but never aggregation pipelines. `filter.rule_id`
+    // is the raw 24-hex string Zod produced: `countDocuments(filter)` casts it
+    // to an ObjectId and matches, `$match` compares a string against an
+    // ObjectId-typed field and matches nothing — so the aggregate branch used
+    // to report a non-zero `total` alongside zero rows. Cast into a COPY: the
+    // count must keep reading the one `filter` both branches agree on, and
+    // rule_id is the only ObjectId-typed path here (device_id, status,
+    // severity are strings; fired_at is already a Date).
+    const aggregateMatch =
+      query.rule_id ? { ...filter, rule_id: new Types.ObjectId(query.rule_id) } : filter;
+
     const alertsQuery =
       query.sortBy === 'severity'
         ? AlertV2.aggregate([
-            { $match: filter },
+            { $match: aggregateMatch },
             { $addFields: { _severity_rank: SEVERITY_RANK } },
             // fired_at breaks ties so paging is stable within a severity band.
             { $sort: { _severity_rank: direction, fired_at: -1 } },

--- a/app/api/v2/alerts/route.ts
+++ b/app/api/v2/alerts/route.ts
@@ -30,11 +30,10 @@ import {
 } from '@/lib/validations/v2/alert.validation';
 import { validateQuery } from '@/lib/validations/validator';
 import { withErrorHandler, ApiError, ErrorCodes } from '@/lib/errors';
-import { jsonPaginated } from '@/lib/api/response';
 import { getOffsetPaginationParams, calculateOffsetPagination } from '@/lib/api/pagination';
 import { logger, recordRequest, createRequestTimer } from '@/lib/monitoring';
 import { requireOrgMembership, isDemoCaller } from '@/lib/auth';
-import { redactAuditForDemo } from '@/lib/alerting';
+import { redactAuditForDemo, jsonRedactedPaginated } from '@/lib/alerting';
 
 /** Statuses a client may ever see. `pending` is internal and always excluded. */
 const VISIBLE_STATUSES = ['firing', 'acknowledged', 'resolved'] as const;
@@ -155,6 +154,11 @@ export async function GET(request: NextRequest) {
     // Demo mode grants an anonymous visitor the same read access as a real org
     // member (see requireOrgMembership()) — never let that also hand them a
     // real administrator's email off audit.acknowledged_by/resolved_by/etc.
-    return jsonPaginated(redactAuditForDemo(alerts, isDemoCaller(authContext)), paginationInfo);
+    // jsonRedactedPaginated (not jsonPaginated) will not compile without the
+    // redaction call — see the Redacted<> note in lib/alerting/redact.ts.
+    return jsonRedactedPaginated(
+      redactAuditForDemo(alerts, isDemoCaller(authContext)),
+      paginationInfo
+    );
   })();
 }

--- a/app/api/v2/alerts/route.ts
+++ b/app/api/v2/alerts/route.ts
@@ -1,0 +1,101 @@
+/**
+ * V2 Alerts API Route
+ *
+ * GET /api/v2/alerts - List alerts with pagination, filtering, and sorting
+ *
+ * Defaults to OPEN alerts (firing + acknowledged) and NEVER returns `pending`.
+ * `pending` is an internal state: it is what makes for_duration_seconds work
+ * without a second state store, it raises no notification, and it is deleted
+ * rather than resolved when the condition clears.
+ *
+ * Deliberately NOT cached. The list changes on every ingest and is already pushed
+ * over Pusher; a cache-aside layer would add staleness in exchange for nothing.
+ */
+
+import type { NextRequest } from 'next/server';
+import dbConnect from '@/lib/db';
+import AlertV2 from '@/models/v2/AlertV2';
+import {
+  listAlertsQuerySchema,
+  type ListAlertsQuery,
+} from '@/lib/validations/v2/alert.validation';
+import { validateQuery } from '@/lib/validations/validator';
+import { withErrorHandler, ApiError, ErrorCodes } from '@/lib/errors';
+import { jsonPaginated } from '@/lib/api/response';
+import { getOffsetPaginationParams, calculateOffsetPagination } from '@/lib/api/pagination';
+import { logger, recordRequest, createRequestTimer } from '@/lib/monitoring';
+import { requireOrgMembership } from '@/lib/auth';
+
+/** Statuses a client may ever see. `pending` is internal and always excluded. */
+const VISIBLE_STATUSES = ['firing', 'acknowledged', 'resolved'] as const;
+const OPEN_STATUSES = ['firing', 'acknowledged'] as const;
+
+const SORT_FIELD_MAP: Record<string, string> = {
+  created_at: 'audit.created_at',
+  fired_at: 'fired_at',
+  severity: 'severity',
+  status: 'status',
+  last_observed_at: 'last_observed_at',
+};
+
+export async function GET(request: NextRequest) {
+  const timer = createRequestTimer();
+
+  return withErrorHandler(async () => {
+    await requireOrgMembership();
+    await dbConnect();
+
+    const validationResult = validateQuery(request.nextUrl.searchParams, listAlertsQuerySchema);
+    if (!validationResult.success)
+      throw new ApiError(
+        ErrorCodes.VALIDATION_ERROR,
+        400,
+        validationResult.errors.map(e => e.message).join(', '),
+        { errors: validationResult.errors }
+      );
+
+    const query = validationResult.data as ListAlertsQuery;
+    const pagination = getOffsetPaginationParams({ page: query.page, limit: query.limit });
+
+    const filter: Record<string, unknown> = {};
+
+    // Intersect whatever the caller asked for with the visible set, so `pending`
+    // can never leak through an explicit status filter.
+    const requested = query.status
+      ? (Array.isArray(query.status) ? query.status : [query.status])
+      : [...OPEN_STATUSES];
+    const statuses = requested.filter(s => (VISIBLE_STATUSES as readonly string[]).includes(s));
+    filter.status = statuses.length === 1 ? statuses[0] : { $in: statuses };
+
+    if (query.severity) {
+      const severities = Array.isArray(query.severity) ? query.severity : [query.severity];
+      filter.severity = severities.length === 1 ? severities[0] : { $in: severities };
+    }
+
+    if (query.device_id) filter.device_id = query.device_id;
+    if (query.rule_id) filter.rule_id = query.rule_id;
+
+    if (query.startDate || query.endDate) {
+      const range: Record<string, Date> = {};
+      if (query.startDate) range.$gte = new Date(query.startDate);
+      if (query.endDate) range.$lte = new Date(query.endDate);
+      filter['audit.created_at'] = range;
+    }
+
+    const sortField = SORT_FIELD_MAP[query.sortBy ?? 'created_at'] ?? 'audit.created_at';
+    const sort: Record<string, 1 | -1> = { [sortField]: query.sortDirection === 'asc' ? 1 : -1 };
+
+    const [alerts, total] = await Promise.all([
+      AlertV2.find(filter).sort(sort).skip(pagination.skip).limit(pagination.limit).lean(),
+      AlertV2.countDocuments(filter),
+    ]);
+
+    const paginationInfo = calculateOffsetPagination(total, pagination.page, pagination.limit);
+
+    const duration = timer.elapsed();
+    recordRequest('GET', '/api/v2/alerts', 200, duration);
+    logger.debug('Alerts list request', { duration, total, statuses });
+
+    return jsonPaginated(alerts, paginationInfo);
+  })();
+}

--- a/app/api/v2/alerts/route.ts
+++ b/app/api/v2/alerts/route.ts
@@ -45,6 +45,17 @@ const SORT_FIELD_MAP: Record<string, string> = {
   last_observed_at: 'last_observed_at',
 };
 
+/** Urgency rank. Mongo sorts the raw string lexically, which puts `critical` last. */
+const SEVERITY_RANK = {
+  $switch: {
+    branches: [
+      { case: { $eq: ['$severity', 'critical'] }, then: 3 },
+      { case: { $eq: ['$severity', 'warning'] }, then: 2 },
+    ],
+    default: 1, // info
+  },
+};
+
 export async function GET(request: NextRequest) {
   const timer = createRequestTimer();
 
@@ -99,15 +110,27 @@ export async function GET(request: NextRequest) {
     const sortField = SORT_FIELD_MAP[query.sortBy ?? 'created_at'] ?? 'audit.created_at';
     const sort: Record<string, 1 | -1> = { [sortField]: query.sortDirection === 'asc' ? 1 : -1 };
 
-    const [alerts, total] = await Promise.all([
-      AlertV2.find(filter)
-        .select('-__v')
-        .sort(sort)
-        .skip(pagination.skip)
-        .limit(pagination.limit)
-        .lean(),
-      AlertV2.countDocuments(filter),
-    ]);
+    const direction: 1 | -1 = query.sortDirection === 'asc' ? 1 : -1;
+
+    const alertsQuery =
+      query.sortBy === 'severity'
+        ? AlertV2.aggregate([
+            { $match: filter },
+            { $addFields: { _severity_rank: SEVERITY_RANK } },
+            // fired_at breaks ties so paging is stable within a severity band.
+            { $sort: { _severity_rank: direction, fired_at: -1 } },
+            { $skip: pagination.skip },
+            { $limit: pagination.limit },
+            { $project: { __v: 0, _severity_rank: 0 } },
+          ])
+        : AlertV2.find(filter)
+            .select('-__v')
+            .sort(sort)
+            .skip(pagination.skip)
+            .limit(pagination.limit)
+            .lean();
+
+    const [alerts, total] = await Promise.all([alertsQuery, AlertV2.countDocuments(filter)]);
 
     const paginationInfo = calculateOffsetPagination(total, pagination.page, pagination.limit);
 

--- a/app/api/v2/alerts/route.ts
+++ b/app/api/v2/alerts/route.ts
@@ -75,11 +75,18 @@ export async function GET(request: NextRequest) {
     if (query.device_id) filter.device_id = query.device_id;
     if (query.rule_id) filter.rule_id = query.rule_id;
 
+    // Filter on `fired_at`, the domain event — NOT `audit.created_at`, which is
+    // stamped when the invisible `pending` episode is first created. With a
+    // non-zero for_duration_seconds those differ by the whole duration, so a
+    // client asking "which alerts fired in this window" would get the wrong set.
+    // Matches how readings filter on `timestamp` and schedules on
+    // `scheduled_date`. Every visible alert has `fired_at`: pending episodes are
+    // deleted rather than resolved, so they never reach a client.
     if (query.startDate || query.endDate) {
       const range: Record<string, Date> = {};
       if (query.startDate) range.$gte = new Date(query.startDate);
       if (query.endDate) range.$lte = new Date(query.endDate);
-      filter['audit.created_at'] = range;
+      filter.fired_at = range;
     }
 
     const sortField = SORT_FIELD_MAP[query.sortBy ?? 'created_at'] ?? 'audit.created_at';

--- a/app/api/v2/alerts/route.ts
+++ b/app/api/v2/alerts/route.ts
@@ -8,8 +8,15 @@
  * without a second state store, it raises no notification, and it is deleted
  * rather than resolved when the condition clears.
  *
- * Deliberately NOT cached. The list changes on every ingest and is already pushed
- * over Pusher; a cache-aside layer would add staleness in exchange for nothing.
+ * Deliberately NOT cached. The set changes whenever the evaluator fires or
+ * resolves an episode — i.e. on every ingest, see lib/alerting/index.ts — and,
+ * unlike alert-rules (which calls `invalidateAlertRules()` on every mutation),
+ * no invalidation hook is wired to those writes. A cache-aside layer here would
+ * mean stale results for an operator actively triaging what is currently
+ * firing. Nothing publishes alerts over Pusher yet either: both
+ * `safeEvaluateReadings()` call sites (readings/ingest, cron/simulate) discard
+ * its result after logging it. Real-time delivery is Task 13/14's job, not
+ * this endpoint's.
  */
 
 import type { NextRequest } from 'next/server';
@@ -93,7 +100,12 @@ export async function GET(request: NextRequest) {
     const sort: Record<string, 1 | -1> = { [sortField]: query.sortDirection === 'asc' ? 1 : -1 };
 
     const [alerts, total] = await Promise.all([
-      AlertV2.find(filter).sort(sort).skip(pagination.skip).limit(pagination.limit).lean(),
+      AlertV2.find(filter)
+        .select('-__v')
+        .sort(sort)
+        .skip(pagination.skip)
+        .limit(pagination.limit)
+        .lean(),
       AlertV2.countDocuments(filter),
     ]);
 

--- a/app/api/v2/cron/simulate/route.ts
+++ b/app/api/v2/cron/simulate/route.ts
@@ -4,7 +4,7 @@ import { pusherServer } from '@/lib/pusher';
 import DeviceV2, { type IDeviceV2 } from '@/models/v2/DeviceV2';
 import ReadingV2 from '@/models/v2/ReadingV2';
 import { type NextRequest, NextResponse } from 'next/server';
-import { logger } from '@/lib/monitoring';
+import { captureException, logger, recordIngestion } from '@/lib/monitoring';
 import { safeEvaluateReadings, safeSweepStaleAlerts } from '@/lib/alerting';
 import {
   generateSimulatedReadings,
@@ -65,6 +65,38 @@ export async function GET(request: NextRequest) {
     //    is the only thing downstream steps may treat as having happened.
     const insertedReadings = await ReadingV2.bulkInsertReadings(newReadings);
     const rejectedCount = newReadings.length - insertedReadings.length;
+
+    // 2b. Make rejection observable. It used to appear ONLY in the response
+    //     body of a 200 {success:true} — no log, no metric — which makes total
+    //     rejection the most dangerous state this handler has: nothing fires,
+    //     `last_observed_at` stops advancing on every open alert, and after
+    //     ALERT_STALE_AFTER_SECONDS the sweep auto-resolves every one of them
+    //     as `stale`. The dashboard then shows a green checkmark precisely
+    //     because ingest is fully down. The response contract is unchanged;
+    //     this is observability, not behaviour.
+    recordIngestion(insertedReadings.length, rejectedCount);
+
+    if (rejectedCount > 0) {
+      const rejectionContext = {
+        generated: newReadings.length,
+        inserted: insertedReadings.length,
+        rejected: rejectedCount,
+        deviceCount: devices.length,
+      };
+
+      if (insertedReadings.length === 0) {
+        // Total rejection is an outage, not a data-quality blip: escalate.
+        logger.error('Simulated reading ingest rejected every reading', rejectionContext);
+        captureException(
+          new Error(
+            `Simulated reading ingest rejected all ${rejectedCount} readings; alert staleness will begin auto-resolving open alerts`
+          ),
+          rejectionContext
+        );
+      } else
+        logger.warn('Simulated reading ingest partially rejected', rejectionContext);
+
+    }
 
     // 3. Trigger Real-time Update (The "Hot" Path). Broadcast only what was
     //    actually written — a rejected reading must never appear on a client

--- a/app/api/v2/cron/simulate/route.ts
+++ b/app/api/v2/cron/simulate/route.ts
@@ -58,8 +58,13 @@ export async function GET(request: NextRequest) {
         { status: 404 }
       );
 
-    // 2. Insert into DB (The "Cold" Store)
-    await ReadingV2.bulkInsertReadings(newReadings);
+    // 2. Insert into DB (The "Cold" Store). bulkInsertReadings runs
+    //    insertMany with { ordered: false }: documents that fail validation
+    //    are silently skipped and it resolves with only the readings that
+    //    were actually written, without throwing. Capture that subset — it
+    //    is the only thing downstream steps may treat as having happened.
+    const insertedReadings = await ReadingV2.bulkInsertReadings(newReadings);
+    const rejectedCount = newReadings.length - insertedReadings.length;
 
     // 3. Trigger Real-time Update (The "Hot" Path)
     try {
@@ -71,8 +76,10 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    // 4. Evaluate alert rules against the readings we just wrote.
-    const evaluation = await safeEvaluateReadings(newReadings, devices);
+    // 4. Evaluate alert rules against the readings that actually persisted.
+    //    A reading bulkInsertReadings rejected doesn't exist in the DB, so it
+    //    must never be allowed to fire or resolve an alert.
+    const evaluation = await safeEvaluateReadings(insertedReadings, devices);
 
     // An alert firing (or auto-resolving) is a domain event in its own right;
     // nothing else in this handler logs it.
@@ -91,12 +98,15 @@ export async function GET(request: NextRequest) {
     //    device query of its own.
     await safeSweepStaleAlerts(new Set(devices.map(device => String(device._id))));
 
-    // Count anomalies for response
-    const anomalyCount = newReadings.filter(r => r.quality?.is_anomaly === true).length;
+    // Count anomalies among the readings that actually persisted. One that
+    // was rejected at insert time was never passed to safeEvaluateReadings
+    // above and doesn't exist in the DB, so it must not inflate this count.
+    const anomalyCount = insertedReadings.filter(r => r.quality.is_anomaly === true).length;
 
     return NextResponse.json({
       success: true,
-      count: newReadings.length,
+      count: insertedReadings.length,
+      rejected: rejectedCount,
       anomalies: anomalyCount,
       timestamp: new Date().toISOString(),
     });

--- a/app/api/v2/cron/simulate/route.ts
+++ b/app/api/v2/cron/simulate/route.ts
@@ -66,13 +66,21 @@ export async function GET(request: NextRequest) {
     const insertedReadings = await ReadingV2.bulkInsertReadings(newReadings);
     const rejectedCount = newReadings.length - insertedReadings.length;
 
-    // 3. Trigger Real-time Update (The "Hot" Path)
+    // 3. Trigger Real-time Update (The "Hot" Path). Broadcast only what was
+    //    actually written — a rejected reading must never appear on a client
+    //    tile as though it were stored. toObject() strips the Mongoose
+    //    document wrapper; versionKey: false keeps `__v` out of a payload
+    //    that is already sized against Pusher's 10 KB cap.
     try {
-      await pusherServer.trigger('InfraSight', 'new-readings', newReadings);
+      await pusherServer.trigger(
+        'InfraSight',
+        'new-readings',
+        insertedReadings.map(r => r.toObject({ versionKey: false }))
+      );
     } catch (pusherError) {
       logger.error('Pusher trigger failed after successful DB write', {
         error: pusherError instanceof Error ? pusherError.message : String(pusherError),
-        readingsCount: newReadings.length,
+        readingsCount: insertedReadings.length,
       });
     }
 

--- a/app/api/v2/cron/simulate/route.ts
+++ b/app/api/v2/cron/simulate/route.ts
@@ -1,14 +1,17 @@
 import crypto from 'crypto';
 import dbConnect from '@/lib/db';
 import { pusherServer } from '@/lib/pusher';
-import DeviceV2 from '@/models/v2/DeviceV2';
+import DeviceV2, { type IDeviceV2 } from '@/models/v2/DeviceV2';
 import ReadingV2 from '@/models/v2/ReadingV2';
 import { type NextRequest, NextResponse } from 'next/server';
 import { logger } from '@/lib/monitoring';
+import { safeEvaluateReadings, safeSweepStaleAlerts } from '@/lib/alerting';
 import {
   generateSimulatedReadings,
   type SimulatedDevice,
 } from '@/lib/simulation/readings';
+
+type CronDevice = SimulatedDevice & Pick<IDeviceV2, 'metadata'>;
 
 // ============================================================================
 // API ROUTE HANDLER
@@ -40,8 +43,8 @@ export async function GET(request: NextRequest) {
     await dbConnect();
 
     const devices = await DeviceV2.findActive()
-      .select({ _id: 1, type: 1, location: 1 })
-      .lean<SimulatedDevice[]>();
+      .select({ _id: 1, type: 1, location: 1, 'metadata.tags': 1 })
+      .lean<CronDevice[]>();
 
     // 1. Generate mock data
     const newReadings = generateSimulatedReadings(devices);
@@ -67,6 +70,14 @@ export async function GET(request: NextRequest) {
         readingsCount: newReadings.length,
       });
     }
+
+    // 4. Evaluate alert rules against the readings we just wrote.
+    await safeEvaluateReadings(newReadings, devices);
+
+    // 5. Sweep alerts whose device has stopped reporting. Cron path only — the
+    //    reporting set is the devices we just emitted for, so this needs no
+    //    device query of its own.
+    await safeSweepStaleAlerts(new Set(devices.map(device => String(device._id))));
 
     // Count anomalies for response
     const anomalyCount = newReadings.filter(r => r.quality?.is_anomaly === true).length;

--- a/app/api/v2/cron/simulate/route.ts
+++ b/app/api/v2/cron/simulate/route.ts
@@ -72,7 +72,19 @@ export async function GET(request: NextRequest) {
     }
 
     // 4. Evaluate alert rules against the readings we just wrote.
-    await safeEvaluateReadings(newReadings, devices);
+    const evaluation = await safeEvaluateReadings(newReadings, devices);
+
+    // An alert firing (or auto-resolving) is a domain event in its own right;
+    // nothing else in this handler logs it.
+    if (evaluation.fired.length || evaluation.resolved.length) {
+      const affected = [...evaluation.fired, ...evaluation.resolved];
+      logger.info('Alert rules fired or resolved during simulation', {
+        fired: evaluation.fired.length,
+        resolved: evaluation.resolved.length,
+        ruleIds: [...new Set(affected.map(a => a.rule_id))],
+        deviceIds: [...new Set(affected.map(a => a.device_id))],
+      });
+    }
 
     // 5. Sweep alerts whose device has stopped reporting. Cron path only — the
     //    reporting set is the devices we just emitted for, so this needs no

--- a/app/api/v2/devices/route.ts
+++ b/app/api/v2/devices/route.ts
@@ -281,7 +281,9 @@ async function handleCreateDevice(request: NextRequest) {
         { field: '_id', value: deviceData._id }
       );
 
-    // Create device with audit metadata
+    // Create device with audit metadata. created_at and updated_at share one clock read
+    // so a brand-new device never looks like it was already edited (see DeviceV2 pre-save).
+    const now = new Date();
     const deviceDoc: Partial<IDeviceV2> = {
       ...deviceData,
       configuration: deviceData.configuration
@@ -291,13 +293,13 @@ async function handleCreateDevice(request: NextRequest) {
           }
         : undefined,
       audit: {
-        created_at: new Date(),
+        created_at: now,
         created_by: auditUser,
-        updated_at: new Date(),
+        updated_at: now,
         updated_by: auditUser,
       },
       health: {
-        last_seen: new Date(),
+        last_seen: now,
         uptime_percentage: 100,
         error_count: 0,
         ...deviceData.health,

--- a/app/api/v2/readings/ingest/route.ts
+++ b/app/api/v2/readings/ingest/route.ts
@@ -28,7 +28,13 @@ import { safeEvaluateReadings } from '@/lib/alerting';
 // Phase 5 imports
 import { withRateLimit } from '@/lib/ratelimit';
 import { withRequestValidation, ValidationPresets } from '@/lib/middleware';
-import { logger, recordIngestion, recordRequest, createRequestTimer } from '@/lib/monitoring';
+import {
+  captureException,
+  createRequestTimer,
+  logger,
+  recordIngestion,
+  recordRequest,
+} from '@/lib/monitoring';
 import { invalidateReadings } from '@/lib/cache';
 
 // Auth
@@ -321,13 +327,41 @@ async function handleIngest(request: NextRequest) {
     recordIngestion(results.inserted, results.rejected);
     recordRequest('POST', '/api/v2/readings/ingest', 201, duration);
 
-    logger.info('Readings ingested', {
+    // Rejection is reported in the response body and counted by
+    // recordIngestion above, but it used to be LOGGED at info alongside a plain
+    // success — a fully-rejected batch read identically to a healthy one in the
+    // log stream, and nothing escalated. That matters here more than anywhere:
+    // a reading that never persisted is never evaluated, so `last_observed_at`
+    // stops advancing on every open alert and the staleness sweep eventually
+    // auto-resolves all of them as `stale` — a green dashboard produced BY the
+    // outage. Split by severity, and separate the two kinds of rejection: a
+    // caller naming devices that do not exist is a client mistake, while the
+    // datastore refusing writes it was asked to make is an outage.
+    const rejectedAtInsert = validReadings.length - results.inserted;
+    const summary = {
       inserted: results.inserted,
       rejected: results.rejected,
+      rejectedUnknownDevice: results.rejected - rejectedAtInsert,
+      rejectedAtInsert,
       duration,
       deviceCount: existingDeviceIds.size,
       submittedBy: auditUser,
-    });
+    };
+
+    if (results.rejected === 0) logger.info('Readings ingested', summary);
+    else if (results.inserted === 0) {
+      logger.error('Readings ingest rejected every reading', summary);
+      // Only the datastore-side failure pages anyone. A payload made entirely
+      // of unknown device ids is a 4xx-shaped caller error already itemized in
+      // the response's `errors[]`, not an ingest outage.
+      if (rejectedAtInsert > 0)
+        captureException(
+          new Error(
+            `Readings ingest persisted none of ${validReadings.length} valid readings; alert staleness will begin auto-resolving open alerts`
+          ),
+          summary
+        );
+    } else logger.warn('Readings ingested with rejections', summary);
 
     return jsonSuccess(
       {

--- a/app/api/v2/readings/ingest/route.ts
+++ b/app/api/v2/readings/ingest/route.ts
@@ -190,7 +190,15 @@ async function handleIngest(request: NextRequest) {
       }
     }
 
-    // Batch insert valid readings
+    // Batch insert valid readings, accumulating exactly the documents that
+    // persisted. `insertedReadings` — never `validReadings`, which is only
+    // what was ATTEMPTED — is what alert evaluation below must see: a
+    // reading that never made it into `readings_v2` must never be allowed to
+    // fire or resolve an alert. Mirrors the cron path's identical fix
+    // (commits 2480e01, 4cb3d26), which threads bulkInsertReadings' returned
+    // subset through the same way.
+    const insertedReadings: Partial<IReadingV2>[] = [];
+
     if (validReadings.length > 0)
       // Process in batches to avoid overwhelming the database
       for (let i = 0; i < validReadings.length; i += BATCH_SIZE) {
@@ -202,6 +210,7 @@ async function handleIngest(request: NextRequest) {
           });
           const successfulInsertsInBatch = insertResult.length;
           results.inserted += successfulInsertsInBatch;
+          insertedReadings.push(...insertResult);
           const batchFailures = batch.length - successfulInsertsInBatch;
           if (batchFailures > 0) {
             results.rejected += batchFailures;
@@ -212,12 +221,42 @@ async function handleIngest(request: NextRequest) {
             });
           }
         } catch (error: unknown) {
-          // Handle bulk write errors (some may have succeeded)
+          // Handle bulk write errors (some may have succeeded). With
+          // `ordered: false`, MongoBulkWriteError.insertedIds is the driver's
+          // index -> _id map for exactly the documents THIS batch actually
+          // wrote (index is relative to `batch`, not the full request) — map
+          // those indices back to `batch` to recover the persisted subset.
           let successfulInsertsInBatch = 0;
           if (error && typeof error === 'object' && 'insertedCount' in error) {
-            const bulkError = error as { insertedCount: number };
+            const bulkError = error as {
+              insertedCount: number;
+              insertedIds?: Record<number, unknown>;
+            };
             successfulInsertsInBatch = bulkError.insertedCount ?? 0;
             results.inserted += successfulInsertsInBatch;
+
+            if (bulkError.insertedIds)
+              for (const key of Object.keys(bulkError.insertedIds)) {
+                const persisted = batch[Number(key)];
+                if (persisted) insertedReadings.push(persisted);
+              }
+            else if (successfulInsertsInBatch > 0)
+              // No insertedIds to identify which specific entries survived.
+              // Deliberate under-approximation: treat this batch as
+              // contributing NOTHING to evaluation rather than guessing.
+              // `results.inserted` above still counts them correctly for the
+              // response — only alert evaluation loses visibility into a
+              // reading that genuinely persisted this cycle, which is a real
+              // but strictly safer failure than the bug being fixed (a
+              // non-existent reading firing an alert).
+              logger.warn(
+                'Bulk insert partially failed without insertedIds; this batch will not be evaluated for alerts',
+                {
+                  batchStart: i,
+                  batchSize: batch.length,
+                  insertedCount: successfulInsertsInBatch,
+                }
+              );
           }
 
           // Count failures
@@ -252,11 +291,14 @@ async function handleIngest(request: NextRequest) {
       });
     }
 
-    // Evaluate alert rules. Runs strictly after the inserts have committed and
-    // cannot affect them; safeEvaluateReadings never throws.
-    if (results.inserted > 0) {
+    // Evaluate alert rules against the readings that actually persisted.
+    // Runs strictly after the inserts have committed and cannot affect them;
+    // safeEvaluateReadings never throws. Gated on insertedReadings, not
+    // results.inserted: the two can differ (see the insertedIds-less
+    // fallback above), and only the former is safe to hand to the evaluator.
+    if (insertedReadings.length > 0) {
       const evaluation = await safeEvaluateReadings(
-        validReadings,
+        insertedReadings,
         existingDevices as unknown as Parameters<typeof safeEvaluateReadings>[1]
       );
 

--- a/app/api/v2/readings/ingest/route.ts
+++ b/app/api/v2/readings/ingest/route.ts
@@ -254,11 +254,25 @@ async function handleIngest(request: NextRequest) {
 
     // Evaluate alert rules. Runs strictly after the inserts have committed and
     // cannot affect them; safeEvaluateReadings never throws.
-    if (results.inserted > 0)
-      await safeEvaluateReadings(
+    if (results.inserted > 0) {
+      const evaluation = await safeEvaluateReadings(
         validReadings,
         existingDevices as unknown as Parameters<typeof safeEvaluateReadings>[1]
       );
+
+      // An alert firing (or auto-resolving) is a domain event in its own right,
+      // not just an ingest side effect — log it distinctly from the "Readings
+      // ingested" summary below, which says nothing about alerting.
+      if (evaluation.fired.length || evaluation.resolved.length) {
+        const affected = [...evaluation.fired, ...evaluation.resolved];
+        logger.info('Alert rules fired or resolved during ingest', {
+          fired: evaluation.fired.length,
+          resolved: evaluation.resolved.length,
+          ruleIds: [...new Set(affected.map(a => a.rule_id))],
+          deviceIds: [...new Set(affected.map(a => a.device_id))],
+        });
+      }
+    }
 
     // Record metrics
     const duration = timer.elapsed();

--- a/app/api/v2/readings/ingest/route.ts
+++ b/app/api/v2/readings/ingest/route.ts
@@ -23,6 +23,7 @@ import {
 import { validateInput } from '@/lib/validations/validator';
 import { withErrorHandler, ApiError, ErrorCodes } from '@/lib/errors';
 import { jsonSuccess } from '@/lib/api/response';
+import { safeEvaluateReadings } from '@/lib/alerting';
 
 // Phase 5 imports
 import { withRateLimit } from '@/lib/ratelimit';
@@ -139,11 +140,13 @@ async function handleIngest(request: NextRequest) {
     // Check idempotency (simple in-memory check - in production use Redis)
     // For now, we'll skip idempotency check implementation
 
-    // Validate that devices exist (batch check)
+    // Validate that devices exist (batch check). The projection carries every
+    // field the alert selector needs — evaluation reuses this result rather than
+    // issuing a second device query.
     const deviceIds = [...new Set(data.readings.map(r => r.device_id))];
     const existingDevices = await DeviceV2.find(
       { _id: { $in: deviceIds }, 'audit.deleted_at': { $exists: false } },
-      { _id: 1 }
+      { _id: 1, type: 1, location: 1, 'metadata.tags': 1 }
     ).lean();
 
     const existingDeviceIds = new Set(existingDevices.map(d => d._id));
@@ -248,6 +251,14 @@ async function handleIngest(request: NextRequest) {
         // Error already logged in invalidateReadings
       });
     }
+
+    // Evaluate alert rules. Runs strictly after the inserts have committed and
+    // cannot affect them; safeEvaluateReadings never throws.
+    if (results.inserted > 0)
+      await safeEvaluateReadings(
+        validReadings,
+        existingDevices as unknown as Parameters<typeof safeEvaluateReadings>[1]
+      );
 
     // Record metrics
     const duration = timer.elapsed();

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { queryClient } from '@/lib/query/queryClient';
 import { PusherProvider } from '@/lib/pusher-context';
+import { AlertToaster } from '@/components/alerts/AlertToaster';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
@@ -57,6 +58,7 @@ export default function RootLayout({
                   pauseOnHover
                   theme="colored"
                 />
+                <AlertToaster />
               </PusherProvider>
             </ClerkThemeProvider>
           </ThemeProvider>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,8 +11,20 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { queryClient } from '@/lib/query/queryClient';
 import { PusherProvider } from '@/lib/pusher-context';
 import { AlertToaster } from '@/components/alerts/AlertToaster';
+import { RealtimeStatusBanner } from '@/components/alerts/RealtimeStatusBanner';
+import { SignedIn } from '@clerk/nextjs';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
+
+/**
+ * Cap on simultaneously visible toasts.
+ *
+ * Alerts are produced by a background evaluator, not by a click: one ingest can
+ * fire up to ALERT_EVENT_MAX (20) at once. Without a limit those stack past the
+ * top of the viewport and cover the app. Overflow is queued by react-toastify
+ * and shown as earlier toasts expire.
+ */
+const MAX_VISIBLE_TOASTS = 4;
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -47,18 +59,52 @@ export default function RootLayout({
             disableTransitionOnChange
           >
             <ClerkThemeProvider>
+              {/*
+                PusherProvider stays an ancestor of {children}: DeviceGrid,
+                FloorPlan and AnomalyChart read live readings through its
+                context, and readings are public (they were before alerting
+                existed). What is gated below is everything that receives or
+                renders ALERT data.
+
+                Note the provider is not itself wrapped in <SignedIn>: that
+                component renders nothing until Clerk has loaded, so gating the
+                provider would blank the whole app on every cold load and cut
+                the readings context off from the pages inside it. The alert
+                feed is gated twice instead — visibly here, and at the source by
+                the private channel, whose /api/pusher/auth endpoint refuses a
+                signed-out socket outright.
+              */}
               <PusherProvider>
                 <DemoBanner />
                 <TopNav />
+                <SignedIn>
+                  <RealtimeStatusBanner />
+                </SignedIn>
                 <main className="min-h-screen">{children}</main>
+                {/*
+                  autoClose={false} stays as the CONTAINER default so
+                  user-initiated toasts raised elsewhere in the app keep the
+                  behaviour they were written against. AlertToaster overrides it
+                  per toast, and per-toast options win over container props.
+                */}
                 <ToastContainer
                   position="bottom-center"
                   autoClose={false}
+                  limit={MAX_VISIBLE_TOASTS}
                   pauseOnFocusLoss
                   pauseOnHover
                   theme="colored"
                 />
-                <AlertToaster />
+                {/*
+                  Gated: AlertToaster is what turns an alert envelope into a
+                  visible popup carrying rule_name, device_id and trigger_value.
+                  /sign-in renders inside this layout, so before this gate a
+                  signed-out visitor sitting on the login page was shown the
+                  fleet's live alert traffic.
+                */}
+                <SignedIn>
+                  <AlertToaster />
+                </SignedIn>
               </PusherProvider>
             </ClerkThemeProvider>
           </ThemeProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@
 import DeviceDetailModal from '@/components/DeviceDetailModal';
 import GenerateReportModal from '@/components/GenerateReportModal';
 import {
+  ActiveAlertsWidget,
   AnomalyDetectionChart,
   CriticalIssuesPanel,
   MaintenanceWidget,
@@ -168,8 +169,13 @@ export default function Home() {
 
       {/* Main Content Grid */}
       <section className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Left Column - Critical Issues + Anomaly Chart */}
+        {/* Left Column - Active Alerts + Critical Issues + Anomaly Chart */}
         <div className="lg:col-span-2 space-y-6">
+          {/* Active Alerts Widget */}
+          <div className="min-h-70">
+            <ActiveAlertsWidget />
+          </div>
+
           {/* Critical Issues Panel */}
           <div className="min-h-75">
             <CriticalIssuesPanel onIssueClick={handleDeviceClick} maxItems={5} />

--- a/components/AnomalyPanel.tsx
+++ b/components/AnomalyPanel.tsx
@@ -6,12 +6,12 @@ import { Badge } from '@/components/ui/badge';
 import { v2Api, type AnomalyData } from '@/lib/api/v2-client';
 import { AlertTriangle, Battery, Clock, TrendingUp, Zap } from 'lucide-react';
 
-interface AlertsPanelProps {
+interface AnomalyPanelProps {
   onDeviceClick?: (deviceId: string) => void;
   maxAlerts?: number;
 }
 
-export default function AlertsPanel({ onDeviceClick, maxAlerts = 10 }: AlertsPanelProps) {
+export default function AnomalyPanel({ onDeviceClick, maxAlerts = 10 }: AnomalyPanelProps) {
   const [anomalies, setAnomalies] = useState<AnomalyData[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -28,7 +28,7 @@ export default function AlertsPanel({ onDeviceClick, maxAlerts = 10 }: AlertsPan
         // Extract anomalies array from the response object
         setAnomalies(response.data.anomalies || []);
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load alerts');
+        setError(err instanceof Error ? err.message : 'Failed to load anomalies');
         console.error('Error fetching anomalies:', err);
       } finally {
         if (showLoading) setLoading(false);
@@ -101,7 +101,7 @@ export default function AlertsPanel({ onDeviceClick, maxAlerts = 10 }: AlertsPan
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <AlertTriangle className="h-5 w-5" />
-            Recent Alerts
+            Recent Anomalies
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -118,7 +118,7 @@ export default function AlertsPanel({ onDeviceClick, maxAlerts = 10 }: AlertsPan
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-red-600 dark:text-red-400">
             <AlertTriangle className="h-5 w-5" />
-            Alerts - Error
+            Anomalies - Error
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -133,7 +133,7 @@ export default function AlertsPanel({ onDeviceClick, maxAlerts = 10 }: AlertsPan
         <CardTitle className="flex items-center justify-between">
           <span className="flex items-center gap-2">
             <AlertTriangle className="h-5 w-5" />
-            Recent Alerts
+            Recent Anomalies
           </span>
           {anomalies.length > 0 && (
             <Badge variant="destructive" className="ml-2">

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -45,9 +45,11 @@ export default function TopNav() {
   const { data: openAlertCount = 0 } = useOpenAlertCount();
 
   // Same invalidation AlertToaster performs, so the badge updates on the
-  // same event that raises a toast. Memoized so usePusherAlerts's effect
-  // (which re-subscribes when the callback identity changes) doesn't
-  // re-subscribe on every TopNav render.
+  // same event that raises a toast. Memoized for a stable callback identity:
+  // usePusherAlerts holds the callback in a ref (see its own doc comment), so
+  // a non-memoized version here would not actually cause extra re-subscribes
+  // — but a stable reference is still good practice and keeps this
+  // useCallback's dependency array honest.
   const handleAlertEvent = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: queryKeys.alerts.all });
   }, [queryClient]);
@@ -86,7 +88,10 @@ export default function TopNav() {
                   <Icon className="h-4 w-4" />
                   {item.label}
                   {item.href === '/alerts' && openAlertCount > 0 && (
-                    <span className="ml-1 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-destructive px-1.5 text-xs font-semibold text-destructive-foreground">
+                    <span
+                      aria-label={`${openAlertCount} open alerts`}
+                      className="ml-1 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-destructive px-1.5 text-xs font-semibold text-destructive-foreground"
+                    >
                       {openAlertCount}
                     </span>
                   )}
@@ -144,7 +149,10 @@ export default function TopNav() {
                     <Icon className="h-5 w-5" />
                     {item.label}
                     {item.href === '/alerts' && openAlertCount > 0 && (
-                      <span className="ml-1 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-destructive px-1.5 text-xs font-semibold text-destructive-foreground">
+                      <span
+                        aria-label={`${openAlertCount} open alerts`}
+                        className="ml-1 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-destructive px-1.5 text-xs font-semibold text-destructive-foreground"
+                      >
                         {openAlertCount}
                       </span>
                     )}

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -35,14 +35,59 @@ const navItems = [
   { href: '/floor-plan', label: 'Floor Plan', icon: Map },
 ];
 
+/**
+ * The '/alerts' nav item's count affordance — shared by desktop and mobile
+ * nav so the two sites can't drift out of sync (review finding A1 flagged
+ * exactly that: "both badge sites are gated on `> 0`").
+ *
+ * A failed fetch renders a visually distinct DEGRADED badge (muted/amber
+ * "!") rather than silently falling back to the all-clear (no badge) — the
+ * two states must never be pixel-identical. `degraded` wins over `count`
+ * unconditionally: even a stale non-zero count sitting in the cache during a
+ * failed background refetch should not be trusted over the fact that the
+ * fetch just failed.
+ */
+function AlertCountBadge({ count, degraded }: { count: number; degraded: boolean }) {
+  if (degraded) {
+    return (
+      <span
+        aria-label="Open alert count unavailable"
+        title="Open alert count unavailable"
+        className="ml-1 inline-flex h-5 min-w-5 items-center justify-center rounded-full border border-amber-200 bg-amber-100 px-1.5 text-xs font-semibold text-amber-700 dark:border-amber-800 dark:bg-amber-900/30 dark:text-amber-300"
+      >
+        !
+      </span>
+    );
+  }
+
+  if (count <= 0) return null;
+
+  return (
+    <span
+      aria-label={`${count} open alerts`}
+      className="ml-1 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-destructive px-1.5 text-xs font-semibold text-destructive-foreground"
+    >
+      {count}
+    </span>
+  );
+}
+
 export default function TopNav() {
   const pathname = usePathname();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const { isAdmin } = useRbac();
+  const { isAdmin, isLoaded, isSignedIn } = useRbac();
   const queryClient = useQueryClient();
   // pagination.total off a one-row page — see useOpenAlertCount's own doc
   // comment for why this beats useAlertsList({ limit: 100 }).data?.length.
-  const { data: openAlertCount = 0 } = useOpenAlertCount();
+  const { data: openAlertCount = 0, error: openAlertCountError } = useOpenAlertCount();
+  // A failed fetch must never render as the all-clear (review finding A1): a
+  // 500, an expired session, or a Mongo timeout used to default straight to
+  // 0 via the destructure above, which is pixel-identical to "zero open
+  // alerts" on every page in the app. Gated on isLoaded && isSignedIn so the
+  // signed-out / still-loading render — where the query may legitimately
+  // 401 or simply hasn't resolved yet — never trips the degraded badge; only
+  // a fetch failure for an actually-authenticated viewer counts as degraded.
+  const openAlertCountDegraded = Boolean(isLoaded && isSignedIn && openAlertCountError);
 
   // Same invalidation AlertToaster performs, so the badge updates on the
   // same event that raises a toast. Memoized for a stable callback identity:
@@ -87,13 +132,8 @@ export default function TopNav() {
                 >
                   <Icon className="h-4 w-4" />
                   {item.label}
-                  {item.href === '/alerts' && openAlertCount > 0 && (
-                    <span
-                      aria-label={`${openAlertCount} open alerts`}
-                      className="ml-1 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-destructive px-1.5 text-xs font-semibold text-destructive-foreground"
-                    >
-                      {openAlertCount}
-                    </span>
+                  {item.href === '/alerts' && (
+                    <AlertCountBadge count={openAlertCount} degraded={openAlertCountDegraded} />
                   )}
                 </Link>
               );
@@ -148,13 +188,8 @@ export default function TopNav() {
                   >
                     <Icon className="h-5 w-5" />
                     {item.label}
-                    {item.href === '/alerts' && openAlertCount > 0 && (
-                      <span
-                        aria-label={`${openAlertCount} open alerts`}
-                        className="ml-1 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-destructive px-1.5 text-xs font-semibold text-destructive-foreground"
-                      >
-                        {openAlertCount}
-                      </span>
+                    {item.href === '/alerts' && (
+                      <AlertCountBadge count={openAlertCount} degraded={openAlertCountDegraded} />
                     )}
                   </Link>
                 );

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -48,7 +48,7 @@ const navItems = [
  * fetch just failed.
  */
 function AlertCountBadge({ count, degraded }: { count: number; degraded: boolean }) {
-  if (degraded) {
+  if (degraded)
     return (
       <span
         aria-label="Open alert count unavailable"
@@ -58,7 +58,6 @@ function AlertCountBadge({ count, degraded }: { count: number; degraded: boolean
         !
       </span>
     );
-  }
 
   if (count <= 0) return null;
 

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -2,19 +2,34 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { LayoutDashboard, Monitor, Wrench, BarChart3, Map, Menu, X, ArchiveX } from 'lucide-react';
-import { useState } from 'react';
+import {
+  LayoutDashboard,
+  Monitor,
+  Wrench,
+  BarChart3,
+  Map,
+  Menu,
+  X,
+  ArchiveX,
+  Bell,
+} from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { Logo } from '@/components/logo';
 import { cn } from '@/lib/utils';
 import { SignedIn, SignedOut, SignInButton } from '@clerk/nextjs';
 import { Button } from '@/components/ui/button';
 import { UserButtonWithTheme } from '@/components/user-button-with-theme';
 import { useRbac } from '@/lib/auth/rbac-client';
+import { useOpenAlertCount } from '@/lib/query/hooks';
+import { usePusherAlerts } from '@/lib/pusher-context';
+import { queryKeys } from '@/lib/query/queryClient';
 
 const navItems = [
   { href: '/', label: 'Dashboard', icon: LayoutDashboard },
   { href: '/devices', label: 'Devices', icon: Monitor },
   { href: '/devices/deleted', label: 'Deleted Devices', icon: ArchiveX, adminOnly: true },
+  { href: '/alerts', label: 'Alerts', icon: Bell },
   { href: '/maintenance', label: 'Maintenance', icon: Wrench },
   { href: '/analytics', label: 'Analytics', icon: BarChart3 },
   { href: '/floor-plan', label: 'Floor Plan', icon: Map },
@@ -24,6 +39,19 @@ export default function TopNav() {
   const pathname = usePathname();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const { isAdmin } = useRbac();
+  const queryClient = useQueryClient();
+  // pagination.total off a one-row page — see useOpenAlertCount's own doc
+  // comment for why this beats useAlertsList({ limit: 100 }).data?.length.
+  const { data: openAlertCount = 0 } = useOpenAlertCount();
+
+  // Same invalidation AlertToaster performs, so the badge updates on the
+  // same event that raises a toast. Memoized so usePusherAlerts's effect
+  // (which re-subscribes when the callback identity changes) doesn't
+  // re-subscribe on every TopNav render.
+  const handleAlertEvent = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.alerts.all });
+  }, [queryClient]);
+  usePusherAlerts(handleAlertEvent);
 
   return (
     <nav className="sticky top-0 z-50 w-full border-b border-border bg-background/95 backdrop-blur-md supports-backdrop-filter:bg-background/80">
@@ -57,6 +85,11 @@ export default function TopNav() {
                 >
                   <Icon className="h-4 w-4" />
                   {item.label}
+                  {item.href === '/alerts' && openAlertCount > 0 && (
+                    <span className="ml-1 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-destructive px-1.5 text-xs font-semibold text-destructive-foreground">
+                      {openAlertCount}
+                    </span>
+                  )}
                 </Link>
               );
             })}
@@ -110,6 +143,11 @@ export default function TopNav() {
                   >
                     <Icon className="h-5 w-5" />
                     {item.label}
+                    {item.href === '/alerts' && openAlertCount > 0 && (
+                      <span className="ml-1 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-destructive px-1.5 text-xs font-semibold text-destructive-foreground">
+                        {openAlertCount}
+                      </span>
+                    )}
                   </Link>
                 );
                 })}

--- a/components/alerts/AlertDetailView.tsx
+++ b/components/alerts/AlertDetailView.tsx
@@ -33,6 +33,20 @@ interface AlertDetailViewProps {
    * Optional; omitted entirely when unknown or zero.
    */
   forDurationSeconds?: number;
+  /**
+   * Set when the bracketing-readings fetch itself failed. Distinct from a
+   * genuinely empty `bracketingReadings` array: "No readings in this
+   * window." is the signature of a stale/device_inactive close (the sensor
+   * stopped reporting) and must never be what a fetch failure renders as —
+   * that would be the wrong diagnosis, mid-incident (review finding A3).
+   * Optional because a caller may not have wired a readings-error branch
+   * (the readings query can fail without this being populated, in which
+   * case the section falls back to the empty-state copy — see the task
+   * report for whether that wiring exists yet).
+   */
+  readingsError?: unknown;
+  /** Retry affordance for the readings-error state — typically the readings query's own refetch. */
+  onRetryReadings?: () => void;
 }
 
 function humanizeDuration(seconds: number): string {
@@ -81,6 +95,8 @@ export function AlertDetailView({
   bracketingReadings,
   loading,
   forDurationSeconds,
+  readingsError,
+  onRetryReadings,
 }: AlertDetailViewProps) {
   // Same useAdminAction() contract as AlertList's row actions and
   // app/analytics/page.tsx's report button: enabled for admins;
@@ -220,6 +236,15 @@ export function AlertDetailView({
         {loading ? (
           <div className="flex items-center justify-center py-8">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+          </div>
+        ) : readingsError ? (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+            <p>Failed to load readings for this window.</p>
+            {onRetryReadings && (
+              <Button variant="outline" size="sm" className="mt-2" onClick={onRetryReadings}>
+                Retry
+              </Button>
+            )}
           </div>
         ) : bracketingReadings.length === 0 ? (
           <p className="text-sm text-muted-foreground">No readings in this window.</p>

--- a/components/alerts/AlertDetailView.tsx
+++ b/components/alerts/AlertDetailView.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import Link from 'next/link';
+import { toast } from 'react-toastify';
+import { CheckCircle, Eye, Flame, Zap } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { AlertSeverityBadge } from './AlertSeverityBadge';
+import { AlertStatusBadge } from './AlertStatusBadge';
+import { describeCondition } from './AlertList';
+import { useAcknowledgeAlert, useResolveAlert } from '@/lib/query/hooks';
+import { useAdminAction } from '@/lib/auth/rbac-client';
+import type { AlertResolution, AlertV2Response } from '@/types/v2';
+
+/** A single reading bracketing the alert's fired_at, +/- 15 minutes. */
+export interface BracketingReading {
+  timestamp: string;
+  value: number;
+}
+
+interface AlertDetailViewProps {
+  alert: AlertV2Response;
+  bracketingReadings: BracketingReading[];
+  /**
+   * Whether the bracketing readings are still being fetched. The alert itself
+   * is always already-loaded by the time this component is rendered (the page
+   * only renders it once `useAlertDetail` has settled), so this only gates the
+   * readings section.
+   */
+  loading: boolean;
+  /**
+   * The firing rule's `for_duration_seconds`, when the caller has it (the
+   * alert wire shape alone doesn't carry it — it belongs to the rule).
+   * Optional; omitted entirely when unknown or zero.
+   */
+  forDurationSeconds?: number;
+}
+
+function humanizeDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds} seconds`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'}`;
+  const hours = Math.round(minutes / 60);
+  return `${hours} hour${hours === 1 ? '' : 's'}`;
+}
+
+/**
+ * How each resolution reason reads on the timeline. 'stale' and
+ * 'device_inactive' must not sound like the underlying problem was fixed —
+ * the sensor merely stopped reporting, so the episode was closed, not solved.
+ * Deliberately avoids the word "resolved" (the status badge already says
+ * that) so this text and the badge don't collide as duplicate matches.
+ */
+const RESOLUTION_LABELS: Record<AlertResolution, string> = {
+  manual: 'closed manually',
+  auto: 'closed automatically — back within threshold',
+  stale: 'closed — stale (no recent readings)',
+  device_inactive: 'closed — device went inactive',
+};
+
+function formatTimestamp(iso: string): string {
+  return new Date(iso).toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+/**
+ * Presentational alert detail: header, plain-language condition, lifecycle
+ * timeline, values, device link, and bracketing readings.
+ *
+ * Shared by the canonical `/alerts/[id]` page and any future quick-inspection
+ * drawer, so the two cannot drift apart (mirrors DeviceDetailView). Acknowledge
+ * / Resolve are self-contained here, the same way AlertList owns its own
+ * mutations — there is no callback prop for them.
+ */
+export function AlertDetailView({
+  alert,
+  bracketingReadings,
+  loading,
+  forDurationSeconds,
+}: AlertDetailViewProps) {
+  // Same useAdminAction() contract as AlertList's row actions and
+  // app/analytics/page.tsx's report button: enabled for admins;
+  // visible-but-disabled with a tooltip in demo mode (so a visitor can see the
+  // workflow exists); hidden otherwise. requireAdmin() server-side is the
+  // real enforcement in every case. Two calls name the two actions distinctly,
+  // matching AlertList.
+  const ackAction = useAdminAction();
+  const resolveAction = useAdminAction();
+  const acknowledge = useAcknowledgeAlert();
+  const resolve = useResolveAlert();
+
+  const act = (mutation: typeof acknowledge, successMessage: string) =>
+    mutation.mutate(
+      { id: alert._id },
+      {
+        onSuccess: () => toast.success(successMessage),
+        onError: (err: Error) => toast.error(err.message),
+      }
+    );
+
+  const condition = forDurationSeconds
+    ? `${describeCondition(alert)} for ${humanizeDuration(forDurationSeconds)}`
+    : describeCondition(alert);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-2 min-w-0">
+          <div className="flex flex-wrap items-center gap-3">
+            <h2 className="text-xl sm:text-2xl font-bold text-foreground break-all">
+              {alert.rule_name}
+            </h2>
+            <AlertSeverityBadge severity={alert.severity} />
+            <AlertStatusBadge status={alert.status} />
+          </div>
+          <p className="text-sm text-muted-foreground">{condition}</p>
+        </div>
+
+        <div className="flex items-center gap-2 shrink-0">
+          {ackAction.visible && alert.status === 'firing' && (
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={ackAction.disabled || acknowledge.isPending}
+              title={ackAction.tooltip}
+              onClick={() => act(acknowledge, 'Alert acknowledged')}
+            >
+              <Eye className="h-4 w-4 mr-1" aria-hidden="true" />
+              Acknowledge
+            </Button>
+          )}
+          {resolveAction.visible && alert.is_open && (
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={resolveAction.disabled || resolve.isPending}
+              title={resolveAction.tooltip}
+              onClick={() => act(resolve, 'Alert resolved')}
+            >
+              <CheckCircle className="h-4 w-4 mr-1" aria-hidden="true" />
+              Resolve
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {/* Lifecycle timeline */}
+        <div className="space-y-3">
+          <h3 className="font-semibold text-foreground">Timeline</h3>
+          <ol className="space-y-2 text-sm text-muted-foreground">
+            <li className="flex items-start gap-2">
+              <Flame className="h-4 w-4 mt-0.5 shrink-0" aria-hidden="true" />
+              <span>Breached since {formatTimestamp(alert.breached_since)}</span>
+            </li>
+            {alert.fired_at && (
+              <li className="flex items-start gap-2">
+                <Zap className="h-4 w-4 mt-0.5 shrink-0 text-red-500" aria-hidden="true" />
+                <span>Fired {formatTimestamp(alert.fired_at)}</span>
+              </li>
+            )}
+            {alert.audit.acknowledged_at && (
+              <li className="flex items-start gap-2">
+                <Eye className="h-4 w-4 mt-0.5 shrink-0 text-amber-500" aria-hidden="true" />
+                <span>
+                  Acknowledged {formatTimestamp(alert.audit.acknowledged_at)}
+                  {alert.audit.acknowledged_by ? ` by ${alert.audit.acknowledged_by}` : ''}
+                </span>
+              </li>
+            )}
+            {alert.audit.resolved_at && (
+              <li className="flex items-start gap-2">
+                <CheckCircle
+                  className="h-4 w-4 mt-0.5 shrink-0 text-green-500"
+                  aria-hidden="true"
+                />
+                <span>
+                  {formatTimestamp(alert.audit.resolved_at)} —{' '}
+                  {alert.audit.resolution ? RESOLUTION_LABELS[alert.audit.resolution] : 'closed'}
+                  {alert.audit.resolved_by ? ` by ${alert.audit.resolved_by}` : ''}
+                </span>
+              </li>
+            )}
+          </ol>
+        </div>
+
+        {/* Values */}
+        <div className="space-y-3">
+          <h3 className="font-semibold text-foreground">Values</h3>
+          <div className="space-y-1 text-sm text-muted-foreground">
+            <p>Trigger value: {alert.trigger_value}</p>
+            <p>Last value: {alert.last_value}</p>
+            {/* Deliberately unset on manual/swept resolutions — only auto-resolution
+                has a reading to attribute. Its absence is normal, not an error. */}
+            {alert.resolved_value !== undefined && <p>Closing value: {alert.resolved_value}</p>}
+            <p>Threshold: {alert.threshold}</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Device link */}
+      <div className="text-sm">
+        <span className="text-muted-foreground">Device: </span>
+        <Link
+          href={`/devices/${alert.device_id}`}
+          className="font-medium text-primary hover:underline"
+        >
+          {alert.device_id}
+        </Link>
+      </div>
+
+      {/* Bracketing readings */}
+      <div className="space-y-3">
+        <h3 className="font-semibold text-foreground">Readings around the trigger (+/-15m)</h3>
+        {loading ? (
+          <div className="flex items-center justify-center py-8">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+          </div>
+        ) : bracketingReadings.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No readings in this window.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border text-left text-muted-foreground">
+                  <th className="py-1 pr-4 font-medium">Timestamp</th>
+                  <th className="py-1 font-medium">Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                {bracketingReadings.map(reading => (
+                  <tr key={reading.timestamp} className="border-b border-border/50 last:border-0">
+                    <td className="py-1 pr-4">{formatTimestamp(reading.timestamp)}</td>
+                    <td className="py-1">{reading.value}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default AlertDetailView;

--- a/components/alerts/AlertDetailView.tsx
+++ b/components/alerts/AlertDetailView.tsx
@@ -39,10 +39,10 @@ interface AlertDetailViewProps {
    * window." is the signature of a stale/device_inactive close (the sensor
    * stopped reporting) and must never be what a fetch failure renders as —
    * that would be the wrong diagnosis, mid-incident (review finding A3).
-   * Optional because a caller may not have wired a readings-error branch
-   * (the readings query can fail without this being populated, in which
-   * case the section falls back to the empty-state copy — see the task
-   * report for whether that wiring exists yet).
+   * Optional because a caller may not have wired a readings-error branch,
+   * in which case the readings query can fail without this being populated
+   * and the section falls back to the empty-state copy. The only caller
+   * today, `app/alerts/[id]/page.tsx`, does wire it.
    */
   readingsError?: unknown;
   /** Retry affordance for the readings-error state — typically the readings query's own refetch. */

--- a/components/alerts/AlertList.tsx
+++ b/components/alerts/AlertList.tsx
@@ -10,7 +10,7 @@ import { AlertSeverityBadge } from './AlertSeverityBadge';
 import { AlertStatusBadge } from './AlertStatusBadge';
 import { useAlertFilterParams } from './useAlertFilterParams';
 import { useAlertsList, useAcknowledgeAlert, useResolveAlert } from '@/lib/query/hooks';
-import { useRbac } from '@/lib/auth/rbac-client';
+import { useAdminAction } from '@/lib/auth/rbac-client';
 import type {
   AlertComparison,
   AlertSeverity,
@@ -55,14 +55,51 @@ export function describeCondition(
   return `${alert.metric} ${COMPARISON_WORDS[alert.comparison]} ${alert.threshold}`;
 }
 
-const ADMIN_ONLY_TOOLTIP = 'Admin role required — sign in as an admin to act on alerts';
+const RELATIVE_TIME_FORMATTER = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+/** Largest-unit-first thresholds for stepping a duration down into a display unit. */
+const RELATIVE_TIME_DIVISIONS: Array<{ amount: number; unit: Intl.RelativeTimeFormatUnit }> = [
+  { amount: 60, unit: 'seconds' },
+  { amount: 60, unit: 'minutes' },
+  { amount: 24, unit: 'hours' },
+  { amount: 7, unit: 'days' },
+  { amount: 4.34524, unit: 'weeks' },
+  { amount: 12, unit: 'months' },
+  { amount: Infinity, unit: 'years' },
+];
+
+/**
+ * "5 minutes ago" / "2 hours ago" — a small local helper rather than a
+ * date-fns dependency the repo doesn't otherwise carry (ScheduleList.tsx
+ * only ever needs absolute dates, via toLocaleDateString). Wraps the
+ * built-in Intl.RelativeTimeFormat. Shared with AlertDetailView (Task 16).
+ */
+export function formatRelativeTime(isoString: string): string {
+  let duration = (new Date(isoString).getTime() - Date.now()) / 1000;
+
+  for (const division of RELATIVE_TIME_DIVISIONS) {
+    if (Math.abs(duration) < division.amount)
+      return RELATIVE_TIME_FORMATTER.format(Math.round(duration), division.unit);
+
+    duration /= division.amount;
+  }
+
+  return RELATIVE_TIME_FORMATTER.format(Math.round(duration), 'years');
+}
 
 export function AlertList({
   initialFilters = {},
   showHeader = true,
   onDeviceClick,
 }: AlertListProps) {
-  const { isAdmin } = useRbac();
+  // Same useAdminAction() contract as app/analytics/page.tsx's report button:
+  // enabled for admins; visible-but-disabled with a tooltip in demo mode (so a
+  // visitor can see the workflow exists); hidden otherwise. requireAdmin()
+  // server-side is the real enforcement in every case. Two calls (rather than
+  // one shared value) name the two actions distinctly, matching how the hook
+  // is used elsewhere for a single action.
+  const ackAction = useAdminAction();
+  const resolveAction = useAdminAction();
   // URL is the source of truth — see useAlertFilterParams below.
   const { status, setStatus, severity, setSeverity, page, setPage } =
     useAlertFilterParams(initialFilters);
@@ -153,27 +190,30 @@ export function AlertList({
                 {describeCondition(alert)} — last {alert.last_value}
               </span>
 
+              {/* fired_at is unset while an episode is still pending; breached_since always exists. */}
+              <span className="text-sm text-muted-foreground">
+                {formatRelativeTime(alert.fired_at ?? alert.breached_since)}
+              </span>
+
               <div className="ml-auto flex items-center gap-2">
-                {/* Disabled, never hidden: a visitor should learn the workflow exists.
-                    requireAdmin() server-side is the real enforcement. */}
-                {alert.status === 'firing' && (
+                {ackAction.visible && alert.status === 'firing' && (
                   <Button
                     variant="outline"
                     size="sm"
-                    disabled={!isAdmin || acknowledge.isPending}
-                    title={isAdmin ? undefined : ADMIN_ONLY_TOOLTIP}
+                    disabled={ackAction.disabled || acknowledge.isPending}
+                    title={ackAction.tooltip}
                     onClick={() => act(acknowledge, alert._id, 'Alert acknowledged')}
                   >
                     <Eye className="h-4 w-4 mr-1" />
                     Acknowledge
                   </Button>
                 )}
-                {alert.is_open && (
+                {resolveAction.visible && alert.is_open && (
                   <Button
                     variant="outline"
                     size="sm"
-                    disabled={!isAdmin || resolve.isPending}
-                    title={isAdmin ? undefined : ADMIN_ONLY_TOOLTIP}
+                    disabled={resolveAction.disabled || resolve.isPending}
+                    title={resolveAction.tooltip}
                     onClick={() => act(resolve, alert._id, 'Alert resolved')}
                   >
                     <CheckCircle className="h-4 w-4 mr-1" />
@@ -193,6 +233,7 @@ export function AlertList({
             onClick={() => setPage(page - 1)}
           >
             <ChevronLeft className="h-4 w-4" />
+            Previous
           </Button>
           <span className="text-sm text-muted-foreground">Page {page}</span>
           <Button
@@ -201,6 +242,7 @@ export function AlertList({
             disabled={(alerts?.length ?? 0) < PAGE_SIZE}
             onClick={() => setPage(page + 1)}
           >
+            Next
             <ChevronRight className="h-4 w-4" />
           </Button>
         </div>

--- a/components/alerts/AlertList.tsx
+++ b/components/alerts/AlertList.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import Link from 'next/link';
+import { toast } from 'react-toastify';
+import { CheckCircle, Eye, ChevronLeft, ChevronRight, RefreshCw } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Select } from '@/components/ui/select';
+import { AlertSeverityBadge } from './AlertSeverityBadge';
+import { AlertStatusBadge } from './AlertStatusBadge';
+import { useAlertFilterParams } from './useAlertFilterParams';
+import { useAlertsList, useAcknowledgeAlert, useResolveAlert } from '@/lib/query/hooks';
+import { useRbac } from '@/lib/auth/rbac-client';
+import type {
+  AlertComparison,
+  AlertSeverity,
+  AlertStatus,
+  AlertV2Response,
+  ListAlertsQueryParams,
+} from '@/types/v2';
+
+interface AlertListProps {
+  initialFilters?: Partial<ListAlertsQueryParams>;
+  showHeader?: boolean;
+  onDeviceClick?: (deviceId: string) => void;
+}
+
+const STATUS_OPTIONS = [
+  { value: 'open', label: 'Open' },
+  { value: 'firing', label: 'Firing' },
+  { value: 'acknowledged', label: 'Acknowledged' },
+  { value: 'resolved', label: 'Resolved (history)' },
+];
+
+const SEVERITY_OPTIONS = [
+  { value: 'all', label: 'All Severities' },
+  { value: 'critical', label: 'Critical' },
+  { value: 'warning', label: 'Warning' },
+  { value: 'info', label: 'Info' },
+];
+
+const PAGE_SIZE = 10;
+
+const COMPARISON_WORDS: Record<AlertComparison, string> = {
+  gt: 'above',
+  gte: 'at or above',
+  lt: 'below',
+  lte: 'at or below',
+};
+
+/** "temperature above 30" / "battery_level below 20" — shared with AlertDetailView. */
+export function describeCondition(
+  alert: Pick<AlertV2Response, 'metric' | 'comparison' | 'threshold'>
+): string {
+  return `${alert.metric} ${COMPARISON_WORDS[alert.comparison]} ${alert.threshold}`;
+}
+
+const ADMIN_ONLY_TOOLTIP = 'Admin role required — sign in as an admin to act on alerts';
+
+export function AlertList({
+  initialFilters = {},
+  showHeader = true,
+  onDeviceClick,
+}: AlertListProps) {
+  const { isAdmin } = useRbac();
+  // URL is the source of truth — see useAlertFilterParams below.
+  const { status, setStatus, severity, setSeverity, page, setPage } =
+    useAlertFilterParams(initialFilters);
+
+  const filters: ListAlertsQueryParams = {
+    ...initialFilters,
+    // 'open' is the server default (firing + acknowledged), so it is sent as absent.
+    ...(status !== 'open' ? { status: status as AlertStatus } : {}),
+    ...(severity !== 'all' ? { severity: severity as AlertSeverity } : {}),
+    page,
+    limit: PAGE_SIZE,
+  };
+
+  const { data: alerts, isLoading, error, refetch } = useAlertsList(filters);
+  const acknowledge = useAcknowledgeAlert();
+  const resolve = useResolveAlert();
+
+  const act = (mutation: typeof acknowledge, id: string, successMessage: string) =>
+    mutation.mutate(
+      { id },
+      {
+        onSuccess: () => toast.success(successMessage),
+        onError: (err: Error) => toast.error(err.message),
+      }
+    );
+
+  return (
+    <Card>
+      {showHeader && (
+        <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-3">
+          <CardTitle>Alerts</CardTitle>
+          <div className="flex items-center gap-2">
+            <Select
+              label="Status"
+              value={status}
+              onValueChange={setStatus}
+              options={STATUS_OPTIONS}
+              size="sm"
+            />
+            <Select
+              label="Severity"
+              value={severity}
+              onValueChange={setSeverity}
+              options={SEVERITY_OPTIONS}
+              size="sm"
+            />
+            <Button variant="outline" size="sm" onClick={() => refetch()}>
+              <RefreshCw className="h-4 w-4" />
+            </Button>
+          </div>
+        </CardHeader>
+      )}
+
+      <CardContent>
+        {isLoading && (
+          <div className="flex items-center justify-center py-12">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+          </div>
+        )}
+
+        {error && !isLoading && (
+          <p className="py-8 text-center text-sm text-destructive">Failed to load alerts</p>
+        )}
+
+        {!isLoading && !error && alerts?.length === 0 && (
+          <p className="py-8 text-center text-sm text-muted-foreground">No open alerts.</p>
+        )}
+
+        <ul className="divide-y divide-border">
+          {alerts?.map(alert => (
+            <li key={alert._id} className="flex flex-wrap items-center gap-3 py-3">
+              <AlertSeverityBadge severity={alert.severity} />
+              <AlertStatusBadge status={alert.status} />
+
+              <Link href={`/alerts/${alert._id}`} className="font-medium hover:underline">
+                {alert.rule_name}
+              </Link>
+
+              <button
+                type="button"
+                className="text-sm text-muted-foreground hover:text-foreground"
+                onClick={() => onDeviceClick?.(alert.device_id)}
+              >
+                {alert.device_id}
+              </button>
+
+              <span className="text-sm text-muted-foreground">
+                {describeCondition(alert)} — last {alert.last_value}
+              </span>
+
+              <div className="ml-auto flex items-center gap-2">
+                {/* Disabled, never hidden: a visitor should learn the workflow exists.
+                    requireAdmin() server-side is the real enforcement. */}
+                {alert.status === 'firing' && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={!isAdmin || acknowledge.isPending}
+                    title={isAdmin ? undefined : ADMIN_ONLY_TOOLTIP}
+                    onClick={() => act(acknowledge, alert._id, 'Alert acknowledged')}
+                  >
+                    <Eye className="h-4 w-4 mr-1" />
+                    Acknowledge
+                  </Button>
+                )}
+                {alert.is_open && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={!isAdmin || resolve.isPending}
+                    title={isAdmin ? undefined : ADMIN_ONLY_TOOLTIP}
+                    onClick={() => act(resolve, alert._id, 'Alert resolved')}
+                  >
+                    <CheckCircle className="h-4 w-4 mr-1" />
+                    Resolve
+                  </Button>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-4 flex items-center justify-between">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page === 1}
+            onClick={() => setPage(page - 1)}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <span className="text-sm text-muted-foreground">Page {page}</span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={(alerts?.length ?? 0) < PAGE_SIZE}
+            onClick={() => setPage(page + 1)}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default AlertList;

--- a/components/alerts/AlertList.tsx
+++ b/components/alerts/AlertList.tsx
@@ -11,6 +11,7 @@ import { AlertStatusBadge } from './AlertStatusBadge';
 import { useAlertFilterParams } from './useAlertFilterParams';
 import { useAlertsList, useAcknowledgeAlert, useResolveAlert } from '@/lib/query/hooks';
 import { useAdminAction } from '@/lib/auth/rbac-client';
+import { cn } from '@/lib/utils';
 import type {
   AlertComparison,
   AlertSeverity,
@@ -113,7 +114,7 @@ export function AlertList({
     limit: PAGE_SIZE,
   };
 
-  const { data: alerts, isLoading, error, refetch } = useAlertsList(filters);
+  const { data: alerts, isLoading, error, refetch, isFetching } = useAlertsList(filters);
   const acknowledge = useAcknowledgeAlert();
   const resolve = useResolveAlert();
 
@@ -146,8 +147,8 @@ export function AlertList({
               options={SEVERITY_OPTIONS}
               size="sm"
             />
-            <Button variant="outline" size="sm" onClick={() => refetch()}>
-              <RefreshCw className="h-4 w-4" />
+            <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
+              <RefreshCw className={cn('h-4 w-4', isFetching && 'animate-spin')} />
             </Button>
           </div>
         </CardHeader>
@@ -168,7 +169,12 @@ export function AlertList({
           <p className="py-8 text-center text-sm text-muted-foreground">No open alerts.</p>
         )}
 
-        <ul className="divide-y divide-border">
+        <ul
+          className={cn(
+            'divide-y divide-border transition-opacity',
+            isFetching && !isLoading && 'opacity-60'
+          )}
+        >
           {alerts?.map(alert => (
             <li key={alert._id} className="flex flex-wrap items-center gap-3 py-3">
               <AlertSeverityBadge severity={alert.severity} />
@@ -190,7 +196,12 @@ export function AlertList({
                 {describeCondition(alert)} — last {alert.last_value}
               </span>
 
-              {/* fired_at is unset while an episode is still pending; breached_since always exists. */}
+              {/* fired_at is typed optional, but every alert this list ever
+                  receives has one set: the list route never returns
+                  `pending` episodes — they are deleted rather than resolved,
+                  so they never reach a client (app/api/v2/alerts/route.ts).
+                  This is defensive against the type, not a real pending-row
+                  case; breached_since always exists regardless. */}
               <span className="text-sm text-muted-foreground">
                 {formatRelativeTime(alert.fired_at ?? alert.breached_since)}
               </span>
@@ -229,7 +240,7 @@ export function AlertList({
           <Button
             variant="outline"
             size="sm"
-            disabled={page === 1}
+            disabled={page === 1 || isFetching}
             onClick={() => setPage(page - 1)}
           >
             <ChevronLeft className="h-4 w-4" />
@@ -239,7 +250,7 @@ export function AlertList({
           <Button
             variant="outline"
             size="sm"
-            disabled={(alerts?.length ?? 0) < PAGE_SIZE}
+            disabled={(alerts?.length ?? 0) < PAGE_SIZE || isFetching}
             onClick={() => setPage(page + 1)}
           >
             Next

--- a/components/alerts/AlertRuleList.tsx
+++ b/components/alerts/AlertRuleList.tsx
@@ -21,6 +21,7 @@ import { AlertSeverityBadge } from './AlertSeverityBadge';
 import { describeCondition } from './AlertList';
 import { useAlertRulesList, useUpdateAlertRule, useDeleteAlertRule } from '@/lib/query/hooks';
 import { useAdminAction } from '@/lib/auth/rbac-client';
+import { cn } from '@/lib/utils';
 import type { AlertRuleV2Response, AlertRuleSelector } from '@/types/v2';
 
 const PAGE_SIZE = 10;
@@ -60,7 +61,13 @@ export function AlertRuleList() {
   const [page, setPage] = useState(1);
   const [ruleToDelete, setRuleToDelete] = useState<AlertRuleV2Response | null>(null);
 
-  const { data: rules, isLoading, error, refetch } = useAlertRulesList({
+  const {
+    data: rules,
+    isLoading,
+    error,
+    refetch,
+    isFetching,
+  } = useAlertRulesList({
     page,
     limit: PAGE_SIZE,
   });
@@ -98,8 +105,8 @@ export function AlertRuleList() {
     <Card>
       <CardHeader className="flex flex-row items-center justify-between pb-2">
         <CardTitle>Alert Rules</CardTitle>
-        <Button variant="ghost" size="sm" onClick={() => refetch()}>
-          <RefreshCw className="h-4 w-4" />
+        <Button variant="ghost" size="sm" onClick={() => refetch()} disabled={isFetching}>
+          <RefreshCw className={cn('h-4 w-4', isFetching && 'animate-spin')} />
         </Button>
       </CardHeader>
 
@@ -118,7 +125,12 @@ export function AlertRuleList() {
           <p className="py-8 text-center text-sm text-muted-foreground">No alert rules.</p>
         )}
 
-        <ul className="divide-y divide-border">
+        <ul
+          className={cn(
+            'divide-y divide-border transition-opacity',
+            isFetching && !isLoading && 'opacity-60'
+          )}
+        >
           {rules?.map(rule => (
             <li key={rule._id} className="flex flex-wrap items-center gap-3 py-3">
               {toggleAction.visible && (
@@ -165,7 +177,7 @@ export function AlertRuleList() {
           <Button
             variant="outline"
             size="sm"
-            disabled={page === 1}
+            disabled={page === 1 || isFetching}
             onClick={() => setPage(page - 1)}
           >
             <ChevronLeft className="h-4 w-4" />
@@ -175,7 +187,7 @@ export function AlertRuleList() {
           <Button
             variant="outline"
             size="sm"
-            disabled={(rules?.length ?? 0) < PAGE_SIZE}
+            disabled={(rules?.length ?? 0) < PAGE_SIZE || isFetching}
             onClick={() => setPage(page + 1)}
           >
             Next

--- a/components/alerts/AlertRuleList.tsx
+++ b/components/alerts/AlertRuleList.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'react-toastify';
+import { RefreshCw, Trash2, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { AlertSeverityBadge } from './AlertSeverityBadge';
+import { describeCondition } from './AlertList';
+import { useAlertRulesList, useUpdateAlertRule, useDeleteAlertRule } from '@/lib/query/hooks';
+import { useAdminAction } from '@/lib/auth/rbac-client';
+import type { AlertRuleV2Response, AlertRuleSelector } from '@/types/v2';
+
+const PAGE_SIZE = 10;
+
+/** Flattens the selector's dimensions into display chips: reading types, then location/tag constraints. */
+function selectorChips(selector: AlertRuleSelector): string[] {
+  const chips: string[] = [...(selector.types ?? [])];
+  if (selector.building_id) chips.push(selector.building_id);
+  if (selector.floor !== undefined) chips.push(`Floor ${selector.floor}`);
+  if (selector.zone) chips.push(selector.zone);
+  chips.push(...(selector.tags ?? []));
+  return chips;
+}
+
+export function AlertRuleList() {
+  // Same useAdminAction() contract as AlertList.tsx's Acknowledge/Resolve and
+  // app/analytics/page.tsx's report button: enabled for admins; visible-but-
+  // disabled with a tooltip in demo mode; hidden otherwise. requireAdmin()
+  // server-side is the real enforcement in every case. Two calls (rather than
+  // one shared value) name the two actions distinctly.
+  const toggleAction = useAdminAction();
+  const deleteAction = useAdminAction();
+
+  const [page, setPage] = useState(1);
+  const [ruleToDelete, setRuleToDelete] = useState<AlertRuleV2Response | null>(null);
+
+  const { data: rules, isLoading, error, refetch } = useAlertRulesList({
+    page,
+    limit: PAGE_SIZE,
+  });
+  const updateRule = useUpdateAlertRule();
+  const deleteRule = useDeleteAlertRule();
+
+  const handleToggle = (rule: AlertRuleV2Response) => {
+    updateRule.mutate(
+      { id: rule._id, data: { enabled: !rule.enabled } },
+      {
+        onSuccess: () => toast.success(rule.enabled ? 'Rule disabled' : 'Rule enabled'),
+        onError: (err: Error) => toast.error(err.message),
+      }
+    );
+  };
+
+  // Never window.confirm (it blocks the page) — an AlertDialog drives an
+  // inline confirm state instead, matching app/devices/page.tsx's delete flow.
+  const handleDeleteConfirm = (e: React.MouseEvent) => {
+    // Prevent AlertDialogAction's default close behavior so the dialog stays
+    // open (showing a pending/disabled state) until the mutation settles.
+    e.preventDefault();
+    if (!ruleToDelete) return;
+
+    deleteRule.mutate(ruleToDelete._id, {
+      onSuccess: () => {
+        toast.success('Alert rule deleted');
+        setRuleToDelete(null);
+      },
+      onError: (err: Error) => toast.error(err.message),
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <CardTitle>Alert Rules</CardTitle>
+        <Button variant="ghost" size="sm" onClick={() => refetch()}>
+          <RefreshCw className="h-4 w-4" />
+        </Button>
+      </CardHeader>
+
+      <CardContent>
+        {isLoading && (
+          <div className="flex items-center justify-center py-12">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+          </div>
+        )}
+
+        {error && !isLoading && (
+          <p className="py-8 text-center text-sm text-destructive">Failed to load alert rules</p>
+        )}
+
+        {!isLoading && !error && rules?.length === 0 && (
+          <p className="py-8 text-center text-sm text-muted-foreground">No alert rules.</p>
+        )}
+
+        <ul className="divide-y divide-border">
+          {rules?.map(rule => (
+            <li key={rule._id} className="flex flex-wrap items-center gap-3 py-3">
+              {toggleAction.visible && (
+                <Checkbox
+                  aria-label={`${rule.enabled ? 'Disable' : 'Enable'} ${rule.name}`}
+                  checked={rule.enabled}
+                  disabled={toggleAction.disabled || updateRule.isPending}
+                  title={toggleAction.tooltip}
+                  onCheckedChange={() => handleToggle(rule)}
+                />
+              )}
+
+              <span className="font-medium">{rule.name}</span>
+              <AlertSeverityBadge severity={rule.severity} />
+              <span className="text-sm text-muted-foreground">{describeCondition(rule)}</span>
+
+              <div className="flex flex-wrap gap-1">
+                {selectorChips(rule.selector).map(chip => (
+                  <Badge key={chip} variant="secondary">
+                    {chip}
+                  </Badge>
+                ))}
+              </div>
+
+              {deleteAction.visible && (
+                <div className="ml-auto">
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label={`Delete ${rule.name}`}
+                    disabled={deleteAction.disabled || deleteRule.isPending}
+                    title={deleteAction.tooltip}
+                    onClick={() => setRuleToDelete(rule)}
+                  >
+                    <Trash2 className="h-4 w-4 text-destructive" />
+                  </Button>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-4 flex items-center justify-between">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page === 1}
+            onClick={() => setPage(page - 1)}
+          >
+            <ChevronLeft className="h-4 w-4" />
+            Previous
+          </Button>
+          <span className="text-sm text-muted-foreground">Page {page}</span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={(rules?.length ?? 0) < PAGE_SIZE}
+            onClick={() => setPage(page + 1)}
+          >
+            Next
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </CardContent>
+
+      <AlertDialog
+        open={!!ruleToDelete}
+        onOpenChange={open => {
+          if (!deleteRule.isPending && !open) setRuleToDelete(null);
+        }}
+      >
+        <AlertDialogContent
+          onEscapeKeyDown={e => deleteRule.isPending && e.preventDefault()}
+        >
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Alert Rule</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete{' '}
+              <span className="font-semibold">{ruleToDelete?.name}</span>? This action cannot be
+              undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              onClick={() => setRuleToDelete(null)}
+              disabled={deleteRule.isPending}
+            >
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteConfirm}
+              disabled={deleteRule.isPending}
+              className="bg-destructive text-white hover:bg-destructive/90"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  );
+}
+
+export default AlertRuleList;

--- a/components/alerts/AlertRuleList.tsx
+++ b/components/alerts/AlertRuleList.tsx
@@ -25,13 +25,26 @@ import type { AlertRuleV2Response, AlertRuleSelector } from '@/types/v2';
 
 const PAGE_SIZE = 10;
 
-/** Flattens the selector's dimensions into display chips: reading types, then location/tag constraints. */
-function selectorChips(selector: AlertRuleSelector): string[] {
-  const chips: string[] = [...(selector.types ?? [])];
-  if (selector.building_id) chips.push(selector.building_id);
-  if (selector.floor !== undefined) chips.push(`Floor ${selector.floor}`);
-  if (selector.zone) chips.push(selector.zone);
-  chips.push(...(selector.tags ?? []));
+/**
+ * Flattens the selector's dimensions into display chips: reading types, then
+ * location/tag constraints.
+ *
+ * `selector` is typed as required on `AlertRuleV2Response`, but a rule with no
+ * constraints at all (e.g. the seeded "Low battery" rule, which deliberately
+ * has no `selector.types` -- battery is a device property) is persisted with
+ * `selector: {}`, and Mongoose's default `minimize` behavior strips that empty
+ * object entirely before it reaches Mongo. The field is genuinely absent on
+ * read, exactly the runtime shape `matchesSelector` (lib/alerting/selector.ts)
+ * and the rule bucketer (lib/alerting/rule-cache.ts) already guard against --
+ * this mirrors that same optional-chaining convention rather than trusting
+ * the (inaccurate, for this one case) non-optional type.
+ */
+function selectorChips(selector: AlertRuleSelector | undefined): string[] {
+  const chips: string[] = [...(selector?.types ?? [])];
+  if (selector?.building_id) chips.push(selector.building_id);
+  if (selector?.floor !== undefined) chips.push(`Floor ${selector.floor}`);
+  if (selector?.zone) chips.push(selector.zone);
+  chips.push(...(selector?.tags ?? []));
   return chips;
 }
 

--- a/components/alerts/AlertSeverityBadge.tsx
+++ b/components/alerts/AlertSeverityBadge.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { Info, AlertTriangle, AlertOctagon } from 'lucide-react';
+import type { AlertSeverity } from '@/types/v2';
+import { cn } from '@/lib/utils';
+
+interface AlertSeverityBadgeProps {
+  severity: AlertSeverity;
+  className?: string;
+  showIcon?: boolean;
+}
+
+const SEVERITY_CONFIG: Record<
+  AlertSeverity,
+  { label: string; className: string; icon: typeof Info }
+> = {
+  info: {
+    label: 'Info',
+    className:
+      'bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-800',
+    icon: Info,
+  },
+  warning: {
+    label: 'Warning',
+    className:
+      'bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-800',
+    icon: AlertTriangle,
+  },
+  critical: {
+    label: 'Critical',
+    className:
+      'bg-red-100 text-red-700 border-red-200 dark:bg-red-900/30 dark:text-red-300 dark:border-red-800',
+    icon: AlertOctagon,
+  },
+};
+
+export function AlertSeverityBadge({
+  severity,
+  className,
+  showIcon = true,
+}: AlertSeverityBadgeProps) {
+  const config = SEVERITY_CONFIG[severity];
+  const Icon = config.icon;
+
+  return (
+    <Badge variant="outline" className={cn(config.className, className)}>
+      {showIcon && <Icon className="h-3 w-3 mr-1" />}
+      {config.label}
+    </Badge>
+  );
+}
+
+export default AlertSeverityBadge;

--- a/components/alerts/AlertStatusBadge.tsx
+++ b/components/alerts/AlertStatusBadge.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { Clock, Zap, Eye, CheckCircle } from 'lucide-react';
+import type { AlertStatus } from '@/types/v2';
+import { cn } from '@/lib/utils';
+
+interface AlertStatusBadgeProps {
+  status: AlertStatus;
+  className?: string;
+  showIcon?: boolean;
+}
+
+const STATUS_CONFIG: Record<
+  AlertStatus,
+  { label: string; className: string; icon: typeof Clock }
+> = {
+  pending: {
+    label: 'Pending',
+    className:
+      'bg-gray-100 text-gray-600 border-gray-200 dark:bg-gray-800 dark:text-gray-400 dark:border-gray-700',
+    icon: Clock,
+  },
+  firing: {
+    label: 'Firing',
+    className:
+      'bg-red-100 text-red-700 border-red-200 dark:bg-red-900/30 dark:text-red-300 dark:border-red-800',
+    icon: Zap,
+  },
+  acknowledged: {
+    label: 'Acknowledged',
+    className:
+      'bg-amber-100 text-amber-700 border-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-800',
+    icon: Eye,
+  },
+  resolved: {
+    label: 'Resolved',
+    className:
+      'bg-green-100 text-green-700 border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-800',
+    icon: CheckCircle,
+  },
+};
+
+export function AlertStatusBadge({
+  status,
+  className,
+  showIcon = true,
+}: AlertStatusBadgeProps) {
+  const config = STATUS_CONFIG[status];
+  const Icon = config.icon;
+
+  return (
+    <Badge variant="outline" className={cn(config.className, className)}>
+      {showIcon && <Icon className="h-3 w-3 mr-1" />}
+      {config.label}
+    </Badge>
+  );
+}
+
+export default AlertStatusBadge;

--- a/components/alerts/AlertToaster.tsx
+++ b/components/alerts/AlertToaster.tsx
@@ -15,6 +15,29 @@ const TOAST_TYPE: Record<AlertSeverity, 'error' | 'warning' | 'info'> = {
 };
 
 /**
+ * How long each severity stays on screen, in milliseconds.
+ *
+ * Every value is finite on purpose. The container's default is
+ * `autoClose={false}`, which was survivable while every toast was raised by a
+ * user one at a time — but alerts come from a background evaluator that can
+ * emit up to ALERT_EVENT_MAX (20) from a single ingest, and toasts that never
+ * expire stack past the top of the viewport and stay there across every route
+ * change until the tab is reloaded.
+ *
+ * Critical lingers longest because it is the one worth interrupting for; info
+ * is a glance. Nothing is lost either way — the alert is on /alerts, and the
+ * toast is only the interruption.
+ */
+const TOAST_AUTO_CLOSE_MS: Record<AlertSeverity, number> = {
+  critical: 15_000,
+  warning: 8_000,
+  info: 5_000,
+};
+
+/** Storms are the loudest thing the app can say, so they get the critical dwell. */
+const STORM_AUTO_CLOSE_MS = TOAST_AUTO_CLOSE_MS.critical;
+
+/**
  * Raises toasts for alerts that start firing and keeps the cached alert list in
  * step with what the server just did. Renders nothing.
  *
@@ -35,7 +58,14 @@ export function AlertToaster() {
           for (const alert of event.alerts)
             toast[TOAST_TYPE[alert.severity]](
               `${alert.rule_name} — ${alert.device_id} (${alert.trigger_value})`,
-              { onClick: () => router.push(`/alerts/${alert._id}`) }
+              {
+                // Keyed on the alert id so a re-broadcast of the same episode
+                // replaces its own toast instead of stacking a second copy.
+                toastId: alert._id,
+                autoClose: TOAST_AUTO_CLOSE_MS[alert.severity],
+                closeOnClick: true,
+                onClick: () => router.push(`/alerts/${alert._id}`),
+              }
             );
           queryClient.invalidateQueries({ queryKey: queryKeys.alerts.all });
           break;
@@ -54,6 +84,12 @@ export function AlertToaster() {
           // the app as the worst. It still invalidates, so lists reconcile.
           if (event.of === 'fired')
             toast.error(`${event.count} alerts firing`, {
+              // Keyed on `since` rather than a fixed string: two separate storms
+              // are two separate pieces of news and both deserve to be seen,
+              // while a re-broadcast of the same one does not stack.
+              toastId: `alert-storm-${event.since}`,
+              autoClose: STORM_AUTO_CLOSE_MS,
+              closeOnClick: true,
               onClick: () => router.push('/alerts'),
             });
           queryClient.invalidateQueries({ queryKey: queryKeys.alerts.all });

--- a/components/alerts/AlertToaster.tsx
+++ b/components/alerts/AlertToaster.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
+import { usePusherAlerts } from '@/lib/pusher-context';
+import { queryKeys } from '@/lib/query/queryClient';
+import type { AlertEvent, AlertSeverity } from '@/types/v2';
+
+const TOAST_TYPE: Record<AlertSeverity, 'error' | 'warning' | 'info'> = {
+  critical: 'error',
+  warning: 'warning',
+  info: 'info',
+};
+
+/**
+ * Raises toasts for alerts that start firing and keeps the cached alert list in
+ * step with what the server just did. Renders nothing.
+ *
+ * Only `fired` raises a toast. `resolved` is broadcast so open lists reconcile
+ * without a refetch, but a popup per device when a floor-wide condition clears
+ * is noise. Because firing is always system-generated, no viewer can ever cause a
+ * toast with their own acknowledge or resolve — the acting admin gets feedback
+ * from their own mutation instead.
+ */
+export function AlertToaster() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const handleEvent = useCallback(
+    (event: AlertEvent) => {
+      switch (event.kind) {
+        case 'fired':
+          for (const alert of event.alerts)
+            toast[TOAST_TYPE[alert.severity]](
+              `${alert.rule_name} — ${alert.device_id} (${alert.trigger_value})`,
+              { onClick: () => router.push(`/alerts/${alert._id}`) }
+            );
+          queryClient.invalidateQueries({ queryKey: queryKeys.alerts.all });
+          break;
+
+        case 'resolved':
+          // No toast: reconcile silently.
+          queryClient.invalidateQueries({ queryKey: queryKeys.alerts.all });
+          break;
+
+        case 'storm':
+          // The storm envelope deliberately carries no rows, so there is nothing
+          // to patch — invalidate and let the list refetch.
+          //
+          // Only a FIRED storm toasts. A resolved storm is a mass recovery, and
+          // announcing it with the same red banner would report the best news in
+          // the app as the worst. It still invalidates, so lists reconcile.
+          if (event.of === 'fired')
+            toast.error(`${event.count} alerts firing`, {
+              onClick: () => router.push('/alerts'),
+            });
+          queryClient.invalidateQueries({ queryKey: queryKeys.alerts.all });
+          break;
+      }
+    },
+    [queryClient, router]
+  );
+
+  usePusherAlerts(handleEvent);
+
+  return null;
+}
+
+export default AlertToaster;

--- a/components/alerts/CreateAlertRuleModal.tsx
+++ b/components/alerts/CreateAlertRuleModal.tsx
@@ -1,0 +1,465 @@
+'use client';
+
+import * as React from 'react';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'react-toastify';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Select } from '@/components/ui/select';
+import { TagInput } from '@/components/devices/TagInput';
+import { useCreateAlertRule } from '@/lib/query/hooks';
+import type {
+  AlertMetric,
+  AlertComparison,
+  AlertSeverity,
+  ReadingTypeName,
+  CreateAlertRuleBody,
+} from '@/types/v2';
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+interface CreateAlertRuleModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+interface RuleFormState {
+  name: string;
+  description: string;
+  enabled: boolean;
+  metric: AlertMetric;
+  comparison: AlertComparison;
+  /** Kept as a string so the number input stays a normal controlled field. */
+  threshold: string;
+  severity: AlertSeverity;
+  /** Displayed in minutes; converted to for_duration_seconds on submit. */
+  durationMinutes: string;
+  cooldownSeconds: string;
+  types: ReadingTypeName[];
+  buildingId: string;
+  floor: string;
+  zone: string;
+  tags: string[];
+}
+
+type FormErrors = Record<string, string>;
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+const METRIC_OPTIONS: { value: AlertMetric; label: string }[] = [
+  { value: 'value', label: 'Value' },
+  { value: 'anomaly_score', label: 'Anomaly score' },
+  { value: 'battery_level', label: 'Battery level' },
+];
+
+const COMPARISON_OPTIONS: { value: AlertComparison; label: string }[] = [
+  { value: 'gt', label: 'Above' },
+  { value: 'gte', label: 'At or above' },
+  { value: 'lt', label: 'Below' },
+  { value: 'lte', label: 'At or below' },
+];
+
+const SEVERITY_OPTIONS: { value: AlertSeverity; label: string }[] = [
+  { value: 'info', label: 'Info' },
+  { value: 'warning', label: 'Warning' },
+  { value: 'critical', label: 'Critical' },
+];
+
+/** The 15 reading types (models/v2/AlertRuleV2.ts:READING_TYPES), matching CreateDeviceModal's device-type list. */
+const READING_TYPE_OPTIONS: { value: ReadingTypeName; label: string }[] = [
+  { value: 'temperature', label: 'Temperature' },
+  { value: 'humidity', label: 'Humidity' },
+  { value: 'occupancy', label: 'Occupancy' },
+  { value: 'power', label: 'Power' },
+  { value: 'co2', label: 'CO2' },
+  { value: 'pressure', label: 'Pressure' },
+  { value: 'light', label: 'Light' },
+  { value: 'motion', label: 'Motion' },
+  { value: 'air_quality', label: 'Air Quality' },
+  { value: 'water_flow', label: 'Water Flow' },
+  { value: 'gas', label: 'Gas' },
+  { value: 'vibration', label: 'Vibration' },
+  { value: 'voltage', label: 'Voltage' },
+  { value: 'current', label: 'Current' },
+  { value: 'energy', label: 'Energy' },
+];
+
+const INITIAL_FORM_STATE: RuleFormState = {
+  name: '',
+  description: '',
+  enabled: true,
+  metric: 'value',
+  comparison: 'gt',
+  threshold: '',
+  severity: 'warning',
+  durationMinutes: '0',
+  cooldownSeconds: '300',
+  types: [],
+  buildingId: '',
+  floor: '',
+  zone: '',
+  tags: [],
+};
+
+// ============================================================================
+// VALIDATION
+// ============================================================================
+
+/**
+ * Mirrors the server's two cross-field refinements
+ * (lib/validations/v2/alert-rule.validation.ts) as a UX affordance so a user
+ * is told before submitting rather than getting a 400 back. The server
+ * remains the enforcement point — this is not a security boundary.
+ */
+function validate(form: RuleFormState): FormErrors {
+  const errors: FormErrors = {};
+
+  if (!form.name.trim()) errors.name = 'Name is required';
+
+  const threshold = Number(form.threshold);
+  if (form.threshold.trim() === '' || Number.isNaN(threshold)) 
+    errors.threshold = 'Threshold is required';
+   else if (form.metric === 'anomaly_score' && (threshold < 0 || threshold > 1)) 
+    errors.threshold = 'Threshold must be between 0 and 1 for anomaly_score';
+   else if (form.metric === 'battery_level' && (threshold < 0 || threshold > 100)) 
+    errors.threshold = 'Threshold must be between 0 and 100 for battery_level';
+  
+
+  if (form.metric === 'value' && form.types.length === 0)
+    errors.types = 'Select at least one reading type when the metric is a raw value';
+
+  return errors;
+}
+
+// ============================================================================
+// REQUEST BODY
+// ============================================================================
+
+/**
+ * `CreateAlertRuleBody` (types/v2/alert.types.ts:121) is discriminated on
+ * `metric`, and the 'value' arm requires `selector.types` to be a non-empty
+ * tuple. A flat `{ ...base, metric, comparison, threshold, selector }` spread
+ * from a union-typed `form.metric` does not compile — TypeScript cannot pick
+ * an arm from a non-literal discriminant, and `ReadingTypeName[]` is not
+ * assignable to `[ReadingTypeName, ...ReadingTypeName[]]` no matter which arm
+ * is chosen. Branching on the discriminant and destructuring the array proves
+ * non-emptiness to the compiler — no `as` cast, which would defeat the type
+ * that exists precisely to make the invalid state unrepresentable.
+ */
+function buildCreateBody(form: RuleFormState): CreateAlertRuleBody | null {
+  const base = {
+    name: form.name.trim(),
+    description: form.description.trim() || undefined,
+    enabled: form.enabled,
+    for_duration_seconds: Number(form.durationMinutes || 0) * 60,
+    severity: form.severity,
+    cooldown_seconds: Number(form.cooldownSeconds || 0),
+  };
+
+  const selector = {
+    ...(form.buildingId ? { building_id: form.buildingId } : {}),
+    ...(form.floor !== '' ? { floor: Number(form.floor) } : {}),
+    ...(form.zone ? { zone: form.zone } : {}),
+    ...(form.tags.length ? { tags: form.tags } : {}),
+  };
+
+  if (form.metric === 'value') {
+    // The destructure is what proves non-emptiness to the compiler.
+    // validate() has already blocked this branch, so null is unreachable.
+    const [firstType, ...restTypes] = form.types;
+    if (!firstType) return null;
+
+    return {
+      ...base,
+      metric: 'value',
+      comparison: form.comparison,
+      threshold: Number(form.threshold),
+      selector: { ...selector, types: [firstType, ...restTypes] },
+    };
+  }
+
+  return {
+    ...base,
+    metric: form.metric, // narrowed to 'anomaly_score' | 'battery_level'
+    comparison: form.comparison,
+    threshold: Number(form.threshold),
+    selector,
+  };
+}
+
+// ============================================================================
+// HELPER COMPONENTS
+// ============================================================================
+
+interface FormFieldProps {
+  label: string;
+  htmlFor: string;
+  error?: string;
+  required?: boolean;
+  children: React.ReactNode;
+}
+
+/** Every input in this form gets a real `<label htmlFor>` so tests and screen readers can find it. */
+function FormField({ label, htmlFor, error, required, children }: FormFieldProps) {
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={htmlFor} className="text-sm">
+        {label}
+        {required && <span className="text-destructive ml-0.5">*</span>}
+      </Label>
+      {children}
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}
+
+// ============================================================================
+// MAIN COMPONENT
+// ============================================================================
+
+export function CreateAlertRuleModal({ isOpen, onClose }: CreateAlertRuleModalProps) {
+  const [form, setForm] = React.useState<RuleFormState>(INITIAL_FORM_STATE);
+  const [errors, setErrors] = React.useState<FormErrors>({});
+  const createRule = useCreateAlertRule();
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      setForm(INITIAL_FORM_STATE);
+      setErrors({});
+    }
+  }, [isOpen]);
+
+  const update = <K extends keyof RuleFormState>(key: K, value: RuleFormState[K]) => {
+    setForm(prev => ({ ...prev, [key]: value }));
+  };
+
+  const toggleType = (type: ReadingTypeName, checked: boolean) => {
+    setForm(prev => ({
+      ...prev,
+      types: checked ? [...prev.types, type] : prev.types.filter(t => t !== type),
+    }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const validationErrors = validate(form);
+    setErrors(validationErrors);
+    if (Object.keys(validationErrors).length > 0) return;
+
+    const body = buildCreateBody(form);
+    if (!body) return; // Unreachable given validate() above; satisfies the compiler only.
+
+    createRule.mutate(body, {
+      onSuccess: () => {
+        toast.success('Alert rule created');
+        onClose();
+      },
+      onError: (err: Error) => toast.error(err.message),
+    });
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={open => !open && onClose()}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>New Alert Rule</DialogTitle>
+          <DialogDescription>
+            Define a threshold condition. When it holds for the configured duration, an alert
+            fires.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <FormField label="Name" htmlFor="rule-name" error={errors.name} required>
+              <Input
+                id="rule-name"
+                value={form.name}
+                onChange={e => update('name', e.target.value)}
+                placeholder="e.g., High temperature"
+                error={!!errors.name}
+              />
+            </FormField>
+            <FormField label="Severity" htmlFor="rule-severity">
+              <Select
+                id="rule-severity"
+                value={form.severity}
+                onValueChange={value => update('severity', value as AlertSeverity)}
+                options={SEVERITY_OPTIONS}
+              />
+            </FormField>
+          </div>
+
+          <FormField label="Description" htmlFor="rule-description">
+            <Input
+              id="rule-description"
+              value={form.description}
+              onChange={e => update('description', e.target.value)}
+              placeholder="Optional notes about this rule"
+            />
+          </FormField>
+
+          <div className="grid grid-cols-3 gap-4">
+            <FormField label="Metric" htmlFor="rule-metric">
+              <Select
+                id="rule-metric"
+                value={form.metric}
+                onValueChange={value => update('metric', value as AlertMetric)}
+                options={METRIC_OPTIONS}
+              />
+            </FormField>
+            <FormField label="Comparison" htmlFor="rule-comparison">
+              <Select
+                id="rule-comparison"
+                value={form.comparison}
+                onValueChange={value => update('comparison', value as AlertComparison)}
+                options={COMPARISON_OPTIONS}
+              />
+            </FormField>
+            <FormField label="Threshold" htmlFor="rule-threshold" error={errors.threshold} required>
+              <Input
+                id="rule-threshold"
+                type="number"
+                step="any"
+                value={form.threshold}
+                onChange={e => update('threshold', e.target.value)}
+                error={!!errors.threshold}
+              />
+            </FormField>
+          </div>
+
+          {form.metric === 'value' && (
+            <div className="space-y-1.5">
+              <fieldset>
+                <legend className="text-sm font-medium mb-1.5">
+                  Reading types
+                  <span className="text-destructive ml-0.5">*</span>
+                </legend>
+                <div className="grid grid-cols-3 gap-2">
+                  {READING_TYPE_OPTIONS.map(option => (
+                    <div key={option.value} className="flex items-center gap-2">
+                      <Checkbox
+                        id={`rule-type-${option.value}`}
+                        checked={form.types.includes(option.value)}
+                        onCheckedChange={checked => toggleType(option.value, checked === true)}
+                      />
+                      <Label
+                        htmlFor={`rule-type-${option.value}`}
+                        className="text-sm font-normal cursor-pointer"
+                      >
+                        {option.label}
+                      </Label>
+                    </div>
+                  ))}
+                </div>
+              </fieldset>
+              {errors.types && <p className="text-xs text-destructive">{errors.types}</p>}
+            </div>
+          )}
+
+          <div className="grid grid-cols-2 gap-4">
+            <FormField label="Duration (minutes)" htmlFor="rule-duration">
+              <Input
+                id="rule-duration"
+                type="number"
+                min={0}
+                value={form.durationMinutes}
+                onChange={e => update('durationMinutes', e.target.value)}
+              />
+            </FormField>
+            <FormField label="Cooldown (seconds)" htmlFor="rule-cooldown">
+              <Input
+                id="rule-cooldown"
+                type="number"
+                min={0}
+                value={form.cooldownSeconds}
+                onChange={e => update('cooldownSeconds', e.target.value)}
+              />
+            </FormField>
+          </div>
+
+          <div className="grid grid-cols-3 gap-4">
+            <FormField label="Building ID" htmlFor="rule-building">
+              <Input
+                id="rule-building"
+                value={form.buildingId}
+                onChange={e => update('buildingId', e.target.value)}
+                placeholder="Optional"
+              />
+            </FormField>
+            <FormField label="Floor" htmlFor="rule-floor">
+              <Input
+                id="rule-floor"
+                type="number"
+                value={form.floor}
+                onChange={e => update('floor', e.target.value)}
+                placeholder="Optional"
+              />
+            </FormField>
+            <FormField label="Zone" htmlFor="rule-zone">
+              <Input
+                id="rule-zone"
+                value={form.zone}
+                onChange={e => update('zone', e.target.value)}
+                placeholder="Optional"
+              />
+            </FormField>
+          </div>
+
+          <FormField label="Tags" htmlFor="rule-tags">
+            <TagInput
+              id="rule-tags"
+              value={form.tags}
+              onChange={tags => update('tags', tags)}
+              placeholder="Add tag and press Enter"
+            />
+          </FormField>
+
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="rule-enabled"
+              checked={form.enabled}
+              onCheckedChange={checked => update('enabled', checked === true)}
+            />
+            <Label htmlFor="rule-enabled" className="text-sm cursor-pointer">
+              Enabled
+            </Label>
+          </div>
+
+          <DialogFooter className="pt-4">
+            <Button type="button" variant="outline" onClick={onClose} disabled={createRule.isPending}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={createRule.isPending}>
+              {createRule.isPending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Creating...
+                </>
+              ) : (
+                'Create Rule'
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default CreateAlertRuleModal;

--- a/components/alerts/RealtimeStatusBanner.tsx
+++ b/components/alerts/RealtimeStatusBanner.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { WifiOff } from 'lucide-react';
+import { useRealtimeConnection } from '@/lib/pusher-context';
+
+/**
+ * Tells the viewer when live alert delivery is down.
+ *
+ * Exists because the failure it reports is invisible by construction: a dead
+ * Pusher socket and a genuinely quiet building both render "No open alerts."
+ * Terminal Pusher close codes (4004 quota exceeded, 4001 bad app key) never
+ * auto-reconnect, so a wall display can sit on that screen indefinitely with
+ * nothing on it suggesting anything is wrong.
+ *
+ * Renders nothing while healthy, and nothing during the ordinary
+ * connecting/handshaking window on page load — see `degraded` vs `connected` in
+ * lib/pusher-context.tsx. It is mounted in the root layout inside `<SignedIn>`,
+ * so every alert surface (the alerts list, device pages, the dashboard) is
+ * covered by one instance without any page having to opt in.
+ */
+export function RealtimeStatusBanner() {
+  const { degraded, message } = useRealtimeConnection();
+
+  if (!degraded) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="realtime-status-banner"
+      className="flex w-full items-center justify-center gap-2 border-b border-amber-500/30 bg-amber-500/10 px-4 py-2 text-sm text-amber-900 dark:text-amber-200"
+    >
+      <WifiOff className="h-4 w-4 shrink-0" aria-hidden="true" />
+      <span className="font-medium">Live updates unavailable.</span>
+      {message ? <span className="text-amber-800/90 dark:text-amber-200/80">{message}</span> : null}
+    </div>
+  );
+}
+
+export default RealtimeStatusBanner;

--- a/components/alerts/useAlertFilterParams.ts
+++ b/components/alerts/useAlertFilterParams.ts
@@ -1,0 +1,119 @@
+'use client';
+
+import { useCallback, useMemo } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import type { ListAlertsQueryParams } from '@/types/v2';
+
+const STATUS_VALUES = ['open', 'firing', 'acknowledged', 'resolved'] as const;
+const SEVERITY_VALUES = ['all', 'critical', 'warning', 'info'] as const;
+
+const DEFAULT_STATUS = 'open';
+const DEFAULT_SEVERITY = 'all';
+
+function isValidStatus(value: string): boolean {
+  return (STATUS_VALUES as readonly string[]).includes(value);
+}
+
+function isValidSeverity(value: string): boolean {
+  return (SEVERITY_VALUES as readonly string[]).includes(value);
+}
+
+interface UrlState {
+  status: string;
+  severity: string;
+  page: number;
+}
+
+export interface AlertFilterParams {
+  status: string; // 'open' (default) | 'firing' | 'acknowledged' | 'resolved'
+  severity: string; // 'all' (default) | 'critical' | 'warning' | 'info'
+  page: number; // 1-based
+  setStatus: (value: string) => void;
+  setSeverity: (value: string) => void;
+  setPage: (page: number) => void;
+}
+
+function buildQueryString({ status, severity, page }: UrlState): string {
+  const params = new URLSearchParams();
+
+  if (status !== DEFAULT_STATUS) params.set('status', status);
+  if (severity !== DEFAULT_SEVERITY) params.set('severity', severity);
+  if (page > 1) params.set('page', String(page));
+
+  return params.toString();
+}
+
+/**
+ * Keeps the alert list's status filter, severity filter, and page in the URL
+ * so a filtered view is a shareable link and browser back steps through
+ * filter changes — the same contract as
+ * app/devices/_components/useDeviceFilterParams.ts.
+ *
+ * The URL is the single source of truth — nothing writes derived state back
+ * into it, so there is no round-trip loop.
+ *
+ * `initialFilters` seeds only what the URL does not already specify; an
+ * explicit URL parameter always wins, or a shared link would not survive the
+ * first render.
+ */
+export function useAlertFilterParams(
+  initialFilters: Partial<ListAlertsQueryParams> = {}
+): AlertFilterParams {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const seedStatus =
+    typeof initialFilters.status === 'string' && isValidStatus(initialFilters.status)
+      ? initialFilters.status
+      : DEFAULT_STATUS;
+
+  const seedSeverity =
+    typeof initialFilters.severity === 'string' && isValidSeverity(initialFilters.severity)
+      ? initialFilters.severity
+      : DEFAULT_SEVERITY;
+
+  const status = useMemo(() => {
+    const raw = searchParams.get('status');
+    if (raw === null) return seedStatus;
+    return isValidStatus(raw) ? raw : DEFAULT_STATUS;
+  }, [searchParams, seedStatus]);
+
+  const severity = useMemo(() => {
+    const raw = searchParams.get('severity');
+    if (raw === null) return seedSeverity;
+    return isValidSeverity(raw) ? raw : DEFAULT_SEVERITY;
+  }, [searchParams, seedSeverity]);
+
+  const page = useMemo(() => {
+    const raw = Number(searchParams.get('page'));
+    return Number.isInteger(raw) && raw > 0 ? raw : 1;
+  }, [searchParams]);
+
+  const navigate = useCallback(
+    (next: UrlState) => {
+      const queryString = buildQueryString(next);
+      router.push(queryString ? `${pathname}?${queryString}` : pathname, { scroll: false });
+    },
+    [pathname, router]
+  );
+
+  const setStatus = useCallback(
+    (nextStatus: string) => navigate({ status: nextStatus, severity, page: 1 }),
+    [navigate, severity]
+  );
+
+  const setSeverity = useCallback(
+    (nextSeverity: string) => navigate({ status, severity: nextSeverity, page: 1 }),
+    [navigate, status]
+  );
+
+  const setPage = useCallback(
+    (nextPage: number) => navigate({ status, severity, page: nextPage }),
+    [navigate, status, severity]
+  );
+
+  return { status, severity, page, setStatus, setSeverity, setPage };
+}
+
+export default useAlertFilterParams;

--- a/components/dashboard/ActiveAlertsWidget.tsx
+++ b/components/dashboard/ActiveAlertsWidget.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import Link from 'next/link';
+import { Bell, CheckCircle2 } from 'lucide-react';
+import { useAlertsList } from '@/lib/query/hooks';
+import { AlertSeverityBadge } from '@/components/alerts/AlertSeverityBadge';
+import { AlertStatusBadge } from '@/components/alerts/AlertStatusBadge';
+import { formatRelativeTime } from '@/components/alerts/AlertList';
+
+/** Rows shown in the widget — a dashboard preview, not the full triage list at /alerts. */
+const WIDGET_ALERT_LIMIT = 5;
+
+/**
+ * Dashboard preview of currently-open alerts (firing + acknowledged), sorted
+ * critical-first by the server (the rank-based severity sort added in Task 12
+ * Step 0 — `$switch` on critical=3/warning=2/info=1 — replacing a lexical
+ * sort that put "critical" last).
+ *
+ * Built fresh against `GET /api/v2/alerts` rather than lifting AnomalyPanel's
+ * layout: alerts carry a status/acknowledgement/duration shape that anomaly
+ * rows don't have, so copying that panel would import assumptions that don't
+ * hold here.
+ */
+export function ActiveAlertsWidget() {
+  const { data: alerts, isLoading, error } = useAlertsList({
+    limit: WIDGET_ALERT_LIMIT,
+    sortBy: 'severity',
+    sortDirection: 'desc',
+  });
+
+  const isEmpty = !isLoading && !error && (alerts?.length ?? 0) === 0;
+  const hasRows = !isLoading && !error && (alerts?.length ?? 0) > 0;
+
+  return (
+    <div className="bg-card border border-border rounded-xl p-6 h-full flex flex-col">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
+          <Bell className="h-5 w-5" />
+          Open Alerts
+        </h3>
+        <Link
+          href="/alerts"
+          className="text-sm text-primary hover:text-primary/80 transition-colors"
+        >
+          View all alerts
+        </Link>
+      </div>
+
+      {isLoading && (
+        <div className="flex-1 space-y-3 animate-pulse">
+          <div className="h-12 bg-muted rounded-lg" />
+          <div className="h-12 bg-muted rounded-lg" />
+          <div className="h-12 bg-muted rounded-lg" />
+        </div>
+      )}
+
+      {!isLoading && error && (
+        <div className="flex-1 flex flex-col items-center justify-center text-center">
+          <p className="text-sm text-red-500">Failed to load alerts</p>
+        </div>
+      )}
+
+      {isEmpty && (
+        <div className="flex-1 flex flex-col items-center justify-center text-center text-muted-foreground">
+          <CheckCircle2 className="h-8 w-8 mb-2 opacity-50" />
+          <p className="text-sm">No active alerts</p>
+        </div>
+      )}
+
+      {hasRows && (
+        <ul className="flex-1 space-y-2 overflow-y-auto">
+          {alerts!.map(alert => (
+            <li
+              key={alert._id}
+              className="flex flex-wrap items-center gap-2 p-3 rounded-lg bg-muted/50 text-sm"
+            >
+              <AlertSeverityBadge severity={alert.severity} />
+              <AlertStatusBadge status={alert.status} />
+              <Link
+                href={`/alerts/${alert._id}`}
+                className="font-medium text-foreground hover:underline"
+              >
+                {alert.rule_name}
+              </Link>
+              <span className="text-muted-foreground">{alert.device_id}</span>
+              {/* fired_at is unset while an episode is pending; breached_since always exists. */}
+              <span className="ml-auto text-xs text-muted-foreground">
+                {formatRelativeTime(alert.fired_at ?? alert.breached_since)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export default ActiveAlertsWidget;

--- a/components/dashboard/ActiveAlertsWidget.tsx
+++ b/components/dashboard/ActiveAlertsWidget.tsx
@@ -83,7 +83,12 @@ export function ActiveAlertsWidget() {
                 {alert.rule_name}
               </Link>
               <span className="text-muted-foreground">{alert.device_id}</span>
-              {/* fired_at is unset while an episode is pending; breached_since always exists. */}
+              {/* fired_at is typed optional, but every alert this widget ever
+                  receives has one set: the list route never returns
+                  `pending` episodes — they are deleted rather than resolved,
+                  so they never reach a client (app/api/v2/alerts/route.ts).
+                  This is defensive against the type, not a real pending-row
+                  case; breached_since always exists regardless. */}
               <span className="ml-auto text-xs text-muted-foreground">
                 {formatRelativeTime(alert.fired_at ?? alert.breached_since)}
               </span>

--- a/components/dashboard/index.ts
+++ b/components/dashboard/index.ts
@@ -3,3 +3,4 @@ export { default as SystemHealthWidget } from './SystemHealthWidget';
 export { default as CriticalIssuesPanel } from './CriticalIssuesPanel';
 export { default as AnomalyDetectionChart } from './AnomalyDetectionChart';
 export { default as MaintenanceWidget } from './MaintenanceWidget';
+export { default as ActiveAlertsWidget } from './ActiveAlertsWidget';

--- a/components/devices/TagInput.tsx
+++ b/components/devices/TagInput.tsx
@@ -14,6 +14,8 @@ interface TagInputProps {
   maxTags?: number;
   className?: string;
   disabled?: boolean;
+  /** Forwarded to the underlying text input so a `<Label htmlFor>` can target it. */
+  id?: string;
 }
 
 export function TagInput({
@@ -23,6 +25,7 @@ export function TagInput({
   maxTags = 20,
   className,
   disabled = false,
+  id,
 }: TagInputProps) {
   const [inputValue, setInputValue] = React.useState('');
   const inputRef = React.useRef<HTMLInputElement>(null);
@@ -57,6 +60,7 @@ export function TagInput({
       <div className="flex gap-2">
         <Input
           ref={inputRef}
+          id={id}
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
           onKeyDown={handleKeyDown}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -24,6 +24,8 @@ export interface SelectProps {
   className?: string;
   /** Size variant */
   size?: 'sm' | 'md';
+  /** Forwarded to the trigger button so a `<Label htmlFor>` can target it. */
+  id?: string;
 }
 
 // ============================================================================
@@ -39,6 +41,7 @@ export function Select({
   disabled = false,
   className,
   size = 'sm',
+  id,
 }: SelectProps) {
   const [open, setOpen] = React.useState(false);
   const containerRef = React.useRef<HTMLDivElement>(null);
@@ -80,6 +83,7 @@ export function Select({
       {/* Trigger Button */}
       <button
         type="button"
+        id={id}
         onClick={() => !disabled && setOpen(!open)}
         disabled={disabled}
         aria-haspopup="listbox"

--- a/docs/PHASE_4_HANDOFF.md
+++ b/docs/PHASE_4_HANDOFF.md
@@ -1,0 +1,222 @@
+# Phase 4 Alerting — Handoff (INCOMPLETE)
+
+> **This branch is not finished and must not be merged.** 11 of 20 planned tasks are done.
+> The backend is complete and tested; **there is no user interface at all**, so the feature
+> is invisible to anyone using the app. See "What is left" below.
+
+**Branch:** `feat/phase-4-alerting`, cut from `main` at `539181d`.
+**Design:** `docs/superpowers/specs/2026-08-01-alerting-subsystem-design.md` (on `docs/phase-4-alerting-design`)
+**Plan:** `docs/superpowers/plans/2026-08-01-alerting-subsystem.md` (same branch — **read this before continuing**; it has the complete code for every remaining task)
+
+---
+
+## What works right now
+
+The alerting subsystem is live end-to-end on the server. Alerts are being created by real
+ingest and cron traffic, and all eight new endpoints respond.
+
+| Area | State |
+| --- | --- |
+| `AlertRuleV2` + `AlertV2` models, 8 indexes | done |
+| Zod validation + client-safe wire types | done |
+| Rule cache (60s, global key) + 4 Prometheus series | done |
+| Selector matching, metric accessors | done |
+| Evaluator (breach-aware, index-enforced dedup) | done |
+| Staleness sweep + failure-isolating wrappers | done |
+| Wired into **both** write paths | done |
+| `/api/v2/alerts` + `/api/v2/alerts/[id]` | done |
+| `/api/v2/alert-rules` + `/api/v2/alert-rules/[id]` | done |
+| **Any UI** | **not started** |
+| **Pusher delivery** | **not started** |
+| **Seeded rules** | **not started** |
+
+v2 API is now 33 endpoints (was 25). Test suite: **2362 passing** (was 2173 at branch point).
+
+## What is left — Tasks 12–20
+
+Work them in order; each has complete code in the plan. Dependencies:
+
+```
+Task 12 (API client + React Query hooks)  ─┐
+Task 13 (Pusher notify, bounded payload)  ─┴─→ Task 14 (usePusherAlerts + toasts)
+                                                      │
+                        Task 15 (badges, AlertList, /alerts) ←┘
+                                │
+                                ├── Task 16 (/alerts/[id] detail page)
+                                ├── Task 17 (/alerts/rules management UI)
+                                └── Task 18 (AnomalyPanel rename, dashboard widget, TopNav)
+                                             │
+                                 Task 19 (seed rules) → Task 20 (E2E)
+```
+
+Task 20 must be last — it needs a seeded database and every route in place.
+
+### Two things in the remaining work that are easy to get wrong
+
+- **Task 18 renames `components/AlertsPanel.tsx`, it does not delete it.** Issue #99 and the
+  parent design both call it orphaned. **That is stale.** It is imported at
+  `app/analytics/page.tsx:5` and rendered at `:84`. Deleting it breaks the build. Re-grep
+  before touching it.
+- **Task 14 deviates from the plan's "copy the existing hook shape verbatim" instruction, by
+  human ruling.** Both `usePusherAlerts` *and* the existing `usePusherReadings` must move their
+  ref assignment into a commit-phase effect. The existing shape is one of the baseline lint
+  errors (`lib/pusher-context.tsx | react-hooks/refs`); copying it would add a second instance.
+  Expect `lintcheck` to report **310** after Task 14, not 311.
+
+---
+
+## Environment notes for whoever picks this up
+
+### The two verification gates are NOT the raw commands
+
+`npx tsc --noEmit` and `pnpm lint` have **never** been clean on this repo. The branch starts
+with **39 pre-existing type errors** (all inside `__tests__/`, invisible to ts-jest because it
+runs `isolatedModules` and does not typecheck) and **311 pre-existing lint problems**.
+
+Use these instead — they diff against a recorded baseline and fail only on *additions*:
+
+```bash
+./.superpowers/sdd/2026-08-01-alerting-subsystem/tscheck
+./.superpowers/sdd/2026-08-01-alerting-subsystem/lintcheck
+```
+
+`tscheck` normalizes away line:column so the baseline does not drift when you shift lines in a
+file that already carries baseline errors. **Never edit the baseline files** — that is how a
+real regression gets hidden.
+
+If the `.superpowers/` directory is gone (it is git-ignored scratch, and `git clean -fdx`
+destroys it), regenerate:
+
+```bash
+npx tsc --noEmit 2>&1 | grep "error TS" | sed -E 's/\(([0-9]+),([0-9]+)\)//' | sort > tsc-baseline-sorted.txt
+```
+
+`pnpm build` and `pnpm test` **are** clean at baseline and stay strict — a failure there is
+genuinely yours.
+
+### Local database for Tasks 19–20
+
+Tasks 19 and 20 need a real database (`pnpm seed`, Playwright). A Docker container is running:
+
+```
+docker start infrasight-phase4-mongo     # mongo:7, replica set rs0, port 27018
+```
+
+The worktree's `.env.local` already points at it. `scripts/v2/seed-v2.ts` refuses to wipe a
+non-local target without `--force`, which is why the local container matters.
+
+Jest itself needs **no** external database — `__tests__/setup/globalSetup.ts` starts
+mongodb-memory-server and injects mock Pusher credentials.
+
+---
+
+## Open decision for a human
+
+**Ingest path evaluates readings that may not have persisted.** *(Task 9, Important,
+plan-mandated — parked, not fixed.)*
+
+`app/api/v2/readings/ingest/route.ts` builds `validReadings` **before** the batch-insert loop
+and never prunes it to the successfully-inserted subset. Evaluation is gated on
+`results.inserted > 0` — "at least one insert succeeded" — not "these specific readings
+succeeded". So on a partial batch failure, a reading that was never written can still fire an
+alert, and an operator investigating it would find no corresponding row in `readings_v2`.
+
+The plan's Task 9 code mandates exactly this, which is why it was parked rather than fixed.
+
+*Assessment:* real, but low severity. Zod validates upstream so partial `insertMany` failure is
+rare; timeseries collections have no unique constraints to collide on; and the consequence is a
+spurious alert that auto-resolves on the next in-bounds reading. The fix means zipping
+`validReadings` against `insertMany`'s acknowledged docs and `bulkError.insertedIds` across two
+existing failure branches — real complexity in a loop that already has two failure paths.
+
+**Recommendation: leave it.** But it is a judgment call, and it is recorded here so it is not
+silently lost.
+
+---
+
+## Deferred minor findings
+
+None block merge; the final whole-branch review should triage them.
+
+- `AlertRuleV2`: `pre('save')` branch untested; no negative test for an invalid `selector.types`.
+- `AlertV2`: `acknowledge()` redundantly `$set`s `is_open: true`; no `pre('findOneAndUpdate')`
+  hook, so a future direct update bypassing the statics would not bump `audit.updated_at`.
+- Validation: selector tag rules hand-duplicated rather than sharing an un-defaulted helper;
+  `typesRequiredForValueMetric` untested via the update path; atomic-group error always anchors
+  to `path: ['metric']`.
+- Cache/metrics: `clearAllCaches()` does not `del(alertRulesKey())` despite its docstring;
+  redundant `beforeEach`; the nested `alerts` metrics group lacks a JSDoc.
+- Selector: `compare()` uses `default: return false` rather than a `never` exhaustiveness guard.
+- Rule cache: no test asserts `ruleCount === rules.length` for a non-empty set.
+- Evaluator: `recordAlert('fired'/'resolved')` is incremented **before** `bulkWrite`, so it is
+  not reconciled against `failedIndices` — under a concurrent E11000 race both callers count a
+  fire though only one document is created. Persisted state and Pusher notifications *are*
+  correctly guarded; only counter precision is affected. Also, the readings/devices-empty early
+  return skips `recordAlertEvaluationDuration`.
+- Sweep: `STALE_AFTER_SECONDS` `parseInt` has no `NaN` guard — a malformed
+  `ALERT_STALE_AFTER_SECONDS` silently disables the staleness check (device-inactive detection
+  still works).
+- Task 9: `CronDevice` declares `metadata.department` required though the projection returns
+  only `tags`; ingest uses a double-`unknown` cast; no failure-injection test on the cron path.
+- Task 10: `if (note)` discards an explicit `note: ''` so a caller cannot clear a note;
+  `audit.updated_at` bumped twice when a note is supplied.
+- Task 11: PATCH sets `audit.updated_at` explicitly though the model hook already does;
+  atomic-group 400 test only covers `{ threshold }` alone.
+
+---
+
+## Notes to my future self
+
+**The plan had more defects than the implementations did.** Eleven tasks produced nine
+corrections to the plan, all committed to `docs/phase-4-alerting-design` as they were found, so
+the plan and the code have not drifted:
+
+| Commit | Defect |
+| --- | --- |
+| `65821fb` | Gates assumed a clean `tsc`/`lint` baseline; neither has ever been clean |
+| `b7dacde` | Mongoose gives array paths an implicit `[]` default — broke the fleet-wide rule |
+| `b7dacde` | `Types` imported as a value in two model files though only used as a type |
+| `77ca206` | `AlertInput.rule_id: unknown` collapses to `never` against Mongoose overloads |
+| `394efbc` | Generic `multiValue<T>` loses literal types under Zod 4 |
+| `8b7d21d` | An unanchored `sed` of mine corrupted a second task's test count |
+| `e3ac047` | **Sweep `deleteMany` race that could destroy a fired alert** |
+| `e3ac047` | Vacuous swallow test — short-circuited before reaching the mocked throw |
+| `5b519a6` | Vacuous isolation test — spied a re-export binding that never intercepted |
+| `5b48342` | Date range filtered `audit.created_at`, not the `fired_at` domain event |
+| `b61a265` | `readingTypeSchema` cast erased the literal union, breaking route compilation |
+
+**The recurring failure mode is tests that pass for the wrong reason.** Four shipped in this
+phase. Every one looked green forever:
+
+1. A short-circuit returned before the code under test was reached.
+2. A spy on a barrel re-export never intercepted a direct import binding.
+3. A payload omitted a required field, so validation rejected it before the feature ran.
+4. A filter shipped with no test at all.
+
+I started writing *"does this test fail for its stated reason?"* directly into every review
+prompt, with those four examples. The last three reviewers went and traced it independently —
+one dropped to compiled JS to prove a `jest.spyOn` on a re-exported symbol was genuinely live.
+**Keep doing this.** When adding a negative test, assert on the specific error `code`, not the
+status; a 403 that is really a 400 is indistinguishable otherwise.
+
+**Model tiering that worked.** Tasks whose plan text carries complete code are transcription:
+haiku did Tasks 5, 6 and 8 at roughly 50k tokens each versus sonnet's ~120k, and reviewers
+specifically asked to look for sloppiness found none. Anything with integration surface,
+prose-described steps, or subtle interacting logic (the evaluator, the route wiring) went to
+sonnet. Scoped re-reviews are cheap — haiku closes them in about three tool calls.
+
+**Carry observations across task boundaries in writing.** Task 7's reviewer noticed that an
+`updateOne` matching zero documents escapes the `writeErrors` filter and flagged it as a Task 8
+concern. I put it in the ledger and pasted it into Task 8's review prompt. That reviewer used
+it to confirm the resolve paths were tolerable *and* to find that the delete path was not — the
+data-loss bug in `e3ac047`. That chain only worked because the note survived two task
+boundaries on disk.
+
+**Two session limits hit mid-implementation** (Tasks 1 and 8), both during the implementer's
+run. The ledger made each recoverable as a precise resume — "these files landed, this one is
+missing, nothing is committed" — rather than a restart. Keep writing state down before it is
+needed.
+
+**Full detail** lives in `.superpowers/sdd/2026-08-01-alerting-subsystem/progress.md` (git-ignored,
+present in the worktree at `/home/yzel/github/infrasight-phase4`), including per-task commit
+ranges, every controller ruling, and the reasoning behind each parked finding.

--- a/docs/PHASE_4_HANDOFF.md
+++ b/docs/PHASE_4_HANDOFF.md
@@ -1,167 +1,63 @@
-# Phase 4 Alerting — Handoff (INCOMPLETE)
+# Phase 4 Alerting — Handoff & Retrospective
 
-> **This branch is not finished and must not be merged.** 11 of 20 planned tasks are done.
-> The backend is complete and tested; **there is no user interface at all**, so the feature
-> is invisible to anyone using the app. See "What is left" below.
+**Status: complete.** All 20 planned tasks are done. This document is a
+completion summary plus the retrospective notes accumulated during
+implementation — the retrospective is the part worth reading even after the
+phase itself is history, and is the main reason to keep this file at all.
 
 **Branch:** `feat/phase-4-alerting`, cut from `main` at `539181d`.
 **Design:** `docs/superpowers/specs/2026-08-01-alerting-subsystem-design.md` (on `docs/phase-4-alerting-design`)
-**Plan:** `docs/superpowers/plans/2026-08-01-alerting-subsystem.md` (same branch — **read this before continuing**; it has the complete code for every remaining task)
+**Plan:** `docs/superpowers/plans/2026-08-01-alerting-subsystem.md` (same branch)
 
 ---
 
-## What works right now
+## What shipped
 
-The alerting subsystem is live end-to-end on the server. Alerts are being created by real
-ingest and cron traffic, and all eight new endpoints respond.
+The alerting subsystem is live end-to-end: server-side evaluation, real-time
+delivery, and a full UI, all backed by real ingest and cron traffic.
 
 | Area | State |
 | --- | --- |
-| `AlertRuleV2` + `AlertV2` models, 8 indexes | done |
+| `AlertRuleV2` + `AlertV2` models, 8 indexes across the two collections | done |
 | Zod validation + client-safe wire types | done |
-| Rule cache (60s, global key) + 4 Prometheus series | done |
+| Rule cache (60s, global key) + Prometheus series | done |
 | Selector matching, metric accessors | done |
 | Evaluator (breach-aware, index-enforced dedup) | done |
 | Staleness sweep + failure-isolating wrappers | done |
-| Wired into **both** write paths | done |
-| `/api/v2/alerts` + `/api/v2/alerts/[id]` | done |
-| `/api/v2/alert-rules` + `/api/v2/alert-rules/[id]` | done |
-| **Any UI** | **not started** |
-| **Pusher delivery** | **not started** |
-| **Seeded rules** | **not started** |
+| Wired into both write paths (ingest, cron/simulate) | done |
+| `GET /api/v2/alerts` + `GET`/`PATCH /api/v2/alerts/[id]` | done |
+| `GET`/`POST /api/v2/alert-rules` + `GET`/`PATCH`/`DELETE /api/v2/alert-rules/[id]` | done |
+| Pusher real-time delivery (`lib/alerting/notify.ts`, `usePusherAlerts`, `AlertToaster`) | done |
+| `/alerts`, `/alerts/[id]`, `/alerts/rules` pages + nav badge | done |
+| Seeded alert rules (`scripts/v2/alert-rule-seeds.ts`) | done |
 
-v2 API is now 33 endpoints (was 25). Test suite: **2362 passing** (was 2173 at branch point).
+v2 API is now **33 endpoints** (was 25 at the branch point — the alerting
+subsystem added 8: `alerts` list/get/patch, `alert-rules` list/create/get/
+patch/delete).
 
-## What is left — Tasks 12–20
+Test suite: **2598 passing / 115 suites**.
 
-Work them in order; each has complete code in the plan. Dependencies:
-
-```
-Task 12 (API client + React Query hooks)  ─┐
-Task 13 (Pusher notify, bounded payload)  ─┴─→ Task 14 (usePusherAlerts + toasts)
-                                                      │
-                        Task 15 (badges, AlertList, /alerts) ←┘
-                                │
-                                ├── Task 16 (/alerts/[id] detail page)
-                                ├── Task 17 (/alerts/rules management UI)
-                                └── Task 18 (AnomalyPanel rename, dashboard widget, TopNav)
-                                             │
-                                 Task 19 (seed rules) → Task 20 (E2E)
-```
-
-Task 20 must be last — it needs a seeded database and every route in place.
-
-### Two things in the remaining work that are easy to get wrong
-
-- **Task 18 renames `components/AlertsPanel.tsx`, it does not delete it.** Issue #99 and the
-  parent design both call it orphaned. **That is stale.** It is imported at
-  `app/analytics/page.tsx:5` and rendered at `:84`. Deleting it breaks the build. Re-grep
-  before touching it.
-- **Task 14 deviates from the plan's "copy the existing hook shape verbatim" instruction, by
-  human ruling.** Both `usePusherAlerts` *and* the existing `usePusherReadings` must move their
-  ref assignment into a commit-phase effect. The existing shape is one of the baseline lint
-  errors (`lib/pusher-context.tsx | react-hooks/refs`); copying it would add a second instance.
-  Expect `lintcheck` to report **310** after Task 14, not 311.
+Gates are strict and clean: `npx tsc --noEmit` 0 errors, `pnpm lint` 0
+problems, `pnpm build` clean.
 
 ---
 
-## Environment notes for whoever picks this up
+## Environment notes
 
-### The two verification gates are NOT the raw commands
+Tests need no external database — `__tests__/setup/globalSetup.ts` starts
+`mongodb-memory-server` and injects mock Pusher credentials, so `pnpm test`
+runs standalone.
 
-`npx tsc --noEmit` and `pnpm lint` have **never** been clean on this repo. The branch starts
-with **39 pre-existing type errors** (all inside `__tests__/`, invisible to ts-jest because it
-runs `isolatedModules` and does not typecheck) and **311 pre-existing lint problems**.
-
-Use these instead — they diff against a recorded baseline and fail only on *additions*:
+For manual verification against a real database (`pnpm seed`, Playwright), a
+local MongoDB container works well:
 
 ```bash
-./.superpowers/sdd/2026-08-01-alerting-subsystem/tscheck
-./.superpowers/sdd/2026-08-01-alerting-subsystem/lintcheck
+docker run -d --name infrasight-mongo -p 27018:27017 mongo:7 --replSet rs0
 ```
 
-`tscheck` normalizes away line:column so the baseline does not drift when you shift lines in a
-file that already carries baseline errors. **Never edit the baseline files** — that is how a
-real regression gets hidden.
-
-If the `.superpowers/` directory is gone (it is git-ignored scratch, and `git clean -fdx`
-destroys it), regenerate:
-
-```bash
-npx tsc --noEmit 2>&1 | grep "error TS" | sed -E 's/\(([0-9]+),([0-9]+)\)//' | sort > tsc-baseline-sorted.txt
-```
-
-`pnpm build` and `pnpm test` **are** clean at baseline and stay strict — a failure there is
-genuinely yours.
-
-### Local database for Tasks 19–20
-
-Tasks 19 and 20 need a real database (`pnpm seed`, Playwright). A Docker container is running:
-
-```
-docker start infrasight-phase4-mongo     # mongo:7, replica set rs0, port 27018
-```
-
-The worktree's `.env.local` already points at it. `scripts/v2/seed-v2.ts` refuses to wipe a
-non-local target without `--force`, which is why the local container matters.
-
-Jest itself needs **no** external database — `__tests__/setup/globalSetup.ts` starts
-mongodb-memory-server and injects mock Pusher credentials.
-
----
-
-## Open decision for a human
-
-**Ingest path evaluates readings that may not have persisted.** *(Task 9, Important,
-plan-mandated — parked, not fixed.)*
-
-`app/api/v2/readings/ingest/route.ts` builds `validReadings` **before** the batch-insert loop
-and never prunes it to the successfully-inserted subset. Evaluation is gated on
-`results.inserted > 0` — "at least one insert succeeded" — not "these specific readings
-succeeded". So on a partial batch failure, a reading that was never written can still fire an
-alert, and an operator investigating it would find no corresponding row in `readings_v2`.
-
-The plan's Task 9 code mandates exactly this, which is why it was parked rather than fixed.
-
-*Assessment:* real, but low severity. Zod validates upstream so partial `insertMany` failure is
-rare; timeseries collections have no unique constraints to collide on; and the consequence is a
-spurious alert that auto-resolves on the next in-bounds reading. The fix means zipping
-`validReadings` against `insertMany`'s acknowledged docs and `bulkError.insertedIds` across two
-existing failure branches — real complexity in a loop that already has two failure paths.
-
-**Recommendation: leave it.** But it is a judgment call, and it is recorded here so it is not
-silently lost.
-
----
-
-## Deferred minor findings
-
-None block merge; the final whole-branch review should triage them.
-
-- `AlertRuleV2`: `pre('save')` branch untested; no negative test for an invalid `selector.types`.
-- `AlertV2`: `acknowledge()` redundantly `$set`s `is_open: true`; no `pre('findOneAndUpdate')`
-  hook, so a future direct update bypassing the statics would not bump `audit.updated_at`.
-- Validation: selector tag rules hand-duplicated rather than sharing an un-defaulted helper;
-  `typesRequiredForValueMetric` untested via the update path; atomic-group error always anchors
-  to `path: ['metric']`.
-- Cache/metrics: `clearAllCaches()` does not `del(alertRulesKey())` despite its docstring;
-  redundant `beforeEach`; the nested `alerts` metrics group lacks a JSDoc.
-- Selector: `compare()` uses `default: return false` rather than a `never` exhaustiveness guard.
-- Rule cache: no test asserts `ruleCount === rules.length` for a non-empty set.
-- Evaluator: `recordAlert('fired'/'resolved')` is incremented **before** `bulkWrite`, so it is
-  not reconciled against `failedIndices` — under a concurrent E11000 race both callers count a
-  fire though only one document is created. Persisted state and Pusher notifications *are*
-  correctly guarded; only counter precision is affected. Also, the readings/devices-empty early
-  return skips `recordAlertEvaluationDuration`.
-- Sweep: `STALE_AFTER_SECONDS` `parseInt` has no `NaN` guard — a malformed
-  `ALERT_STALE_AFTER_SECONDS` silently disables the staleness check (device-inactive detection
-  still works).
-- Task 9: `CronDevice` declares `metadata.department` required though the projection returns
-  only `tags`; ingest uses a double-`unknown` cast; no failure-injection test on the cron path.
-- Task 10: `if (note)` discards an explicit `note: ''` so a caller cannot clear a note;
-  `audit.updated_at` bumped twice when a note is supplied.
-- Task 11: PATCH sets `audit.updated_at` explicitly though the model hook already does;
-  atomic-group 400 test only covers `{ threshold }` alone.
+Point `.env.local`'s `MONGODB_URI` at it. `scripts/v2/seed-v2.ts` refuses to
+wipe a non-local target without `--force`, which is why a local container
+matters for iterating on seed data.
 
 ---
 
@@ -199,6 +95,14 @@ one dropped to compiled JS to prove a `jest.spyOn` on a re-exported symbol was g
 **Keep doing this.** When adding a negative test, assert on the specific error `code`, not the
 status; a 403 that is really a 400 is indistinguishable otherwise.
 
+> **Update from the final whole-branch review (2026-08-04):** the same failure mode kept
+> showing up at cross-cutting scale, not just per-task — nine tests across the phase shipped
+> green while asserting nothing real, adding a fifth pattern to the four above: assertions
+> reading stdout when the code under test wrote to stderr, and a test mocking the very hook it
+> claimed to exercise. The check that catches all five is the same one: delete the line the test
+> names, confirm the test goes red, then restore. If it doesn't go red, the test was never
+> testing that line.
+
 **Model tiering that worked.** Tasks whose plan text carries complete code are transcription:
 haiku did Tasks 5, 6 and 8 at roughly 50k tokens each versus sonnet's ~120k, and reviewers
 specifically asked to look for sloppiness found none. Anything with integration surface,
@@ -220,3 +124,29 @@ needed.
 **Full detail** lives in `.superpowers/sdd/2026-08-01-alerting-subsystem/progress.md` (git-ignored,
 present in the worktree at `/home/yzel/github/infrasight-phase4`), including per-task commit
 ranges, every controller ruling, and the reasoning behind each parked finding.
+
+---
+
+## Known deferred items
+
+A final whole-branch cross-cutting review (2026-08-04) covered every task in this phase together
+rather than in isolation, and fixed one Critical, six Important, and four Minor issues it found
+in the process — see that review's own report (in the same directory as this file) for detail,
+including which of the fixes needed a database migration or a seed-script change. It also
+explicitly triaged the following as fine to carry rather than fix:
+
+- The dead `forDurationSeconds` prop on `AlertDetailView`.
+- `clearAllCaches()` not clearing the alert-rules cache key.
+- The severity aggregation's lack of a supporting index.
+- The `rows.length < PAGE_SIZE` pagination heuristic.
+- 33 same-named wire/Zod type pairs with no conformance test — a separate, mechanical PR; a
+  conformance test would also surface pre-existing drift in `ListDevicesQuery`, expanding scope
+  unpredictably.
+- A known pre-existing intermittent flake in
+  `__tests__/integration/api/device-history.integration.test.ts` under heavy parallel load,
+  unrelated to this branch.
+
+Earlier per-task deferral notes written during individual task reviews are superseded by this
+list — several had already been fixed, reprioritized, or found to be inaccurate by the time the
+final review ran, so they are not reproduced here. Carrying a stale "known issues" list forward
+is the exact failure mode that made this file need rewriting in the first place.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -17,7 +17,6 @@ Complete guide for configuring environment variables and setting up the Infrasig
   - [Sentry Error Tracking](#sentry-error-tracking)
   - [Alerting](#alerting)
   - [Public Read-Only Demo](#public-read-only-demo)
-  - [API Authentication](#api-authentication)
   - [Development Options](#development-options)
 - [Environment-Specific Configuration](#environment-specific-configuration)
 - [Service Setup Guides](#service-setup-guides)
@@ -328,36 +327,6 @@ NEXT_PUBLIC_DEMO_MODE=true
 
 ---
 
-### API Authentication
-
-API key authentication is opt-in. Leave empty to disable (development mode).
-
-| Variable   | Description                         | Default         |
-| ---------- | ----------------------------------- | --------------- |
-| `API_KEYS` | Comma-separated API key definitions | None (disabled) |
-
-#### Format
-
-```
-name:key:role,name:key:role,...
-```
-
-#### Roles
-
-| Role       | Permissions                                     |
-| ---------- | ----------------------------------------------- |
-| `admin`    | Full access to all endpoints                    |
-| `operator` | Create, update, delete devices; ingest readings |
-| `viewer`   | Read-only access                                |
-
-#### Example Configuration
-
-```env
-API_KEYS=sensor-gateway:abc123xyz:operator,dashboard:xyz789abc:viewer,admin-cli:admin123:admin
-```
-
----
-
 ### Development Options
 
 | Variable              | Description                      | Default |
@@ -474,9 +443,6 @@ NEXT_PUBLIC_SENTRY_DSN=https://production@sentry.io/production
 SENTRY_ORG=my-org
 SENTRY_PROJECT=infrasight
 SENTRY_AUTH_TOKEN=sntrys_eyJ...
-
-# API Authentication
-API_KEYS=sensor-gateway-1:abc123:operator,sensor-gateway-2:def456:operator
 ```
 
 ---
@@ -746,7 +712,6 @@ Keep these values secret:
 - `PUSHER_PRIMARY_KEY`
 - `REDIS_URL` (contains password)
 - `SENTRY_AUTH_TOKEN`
-- `API_KEYS`
 
 ### Client-Side Exposure
 
@@ -845,11 +810,6 @@ NEXT_PUBLIC_SENTRY_DSN=
 SENTRY_ORG=
 SENTRY_PROJECT=
 SENTRY_AUTH_TOKEN=
-
-# -----------------------------------------------------------------------------
-# Optional: API Authentication
-# -----------------------------------------------------------------------------
-API_KEYS=
 
 # -----------------------------------------------------------------------------
 # Development Options

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -15,6 +15,8 @@ Complete guide for configuring environment variables and setting up the Infrasig
   - [Caching](#caching)
   - [Monitoring & Logging](#monitoring--logging)
   - [Sentry Error Tracking](#sentry-error-tracking)
+  - [Alerting](#alerting)
+  - [Public Read-Only Demo](#public-read-only-demo)
   - [API Authentication](#api-authentication)
   - [Development Options](#development-options)
 - [Environment-Specific Configuration](#environment-specific-configuration)
@@ -277,6 +279,51 @@ NEXT_PUBLIC_SENTRY_DSN=https://abc123@o123456.ingest.sentry.io/1234567
 SENTRY_ORG=my-org
 SENTRY_PROJECT=infrasight
 SENTRY_AUTH_TOKEN=sntrys_eyJ...
+```
+
+---
+
+### Alerting
+
+Threshold alerting (`alert_rules_v2` / `alerts_v2`) needs no configuration to run. One variable tunes the staleness sweep.
+
+| Variable                    | Description                                                            | Default |
+| --------------------------- | ---------------------------------------------------------------------- | ------- |
+| `ALERT_STALE_AFTER_SECONDS` | Seconds of silence after which an open alert is closed as `stale`      | `1800`  |
+
+An alert normally auto-resolves when a new reading shows the metric back within bounds — so a device that simply **stops reporting** would otherwise stay firing forever. The staleness sweep (`lib/alerting/sweep.ts`) closes those: any open episode whose `last_observed_at` is older than this cutoff is resolved with `resolution: 'stale'`, and any open episode for a device that did not report at all in the run is resolved with `resolution: 'device_inactive'`. Both are recorded distinctly from `'auto'` so history never claims a problem was fixed when the sensor merely went quiet.
+
+Three things to know:
+
+- **It runs on the cron path only.** `GET /api/v2/cron/simulate` calls the sweep; `POST /api/v2/readings/ingest` does not. On an ingest-only deployment nothing is ever closed as stale.
+- **Must be a positive integer.** A malformed or non-positive value logs a warning and falls back to `1800`. It is not ignored silently: a `NaN` would make the cutoff an Invalid Date and disable staleness detection entirely, which is the failure this guard exists to prevent.
+- **Read once at module load.** Changing it requires a restart, not just a new request.
+
+#### Example Configuration
+
+```env
+# 30 minutes (the default)
+ALERT_STALE_AFTER_SECONDS=1800
+```
+
+---
+
+### Public Read-Only Demo
+
+Lets anonymous visitors browse the app and read the GET APIs without signing in. **Both** variables must be `"true"` — leave them unset for a normal private deployment.
+
+| Variable                 | Description                                     | Default |
+| ------------------------ | ----------------------------------------------- | ------- |
+| `DEMO_MODE`              | Server-side switch for anonymous read access    | `false` |
+| `NEXT_PUBLIC_DEMO_MODE`  | Client-side switch (must have the public prefix) | `false` |
+
+Writes stay blocked: the synthetic demo context carries the `org:member` role and every mutation goes through `requireAdmin()`. Alert and alert-rule responses additionally have their audit actor fields replaced with "an administrator" for a demo reader (`lib/alerting/redact.ts`), because `audit.created_by` and friends hold a real administrator's email address.
+
+#### Example Configuration
+
+```env
+DEMO_MODE=true
+NEXT_PUBLIC_DEMO_MODE=true
 ```
 
 ---

--- a/e2e/alerts.spec.ts
+++ b/e2e/alerts.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * Alerts E2E Tests
+ *
+ * Requires a seeded database with alert rules (`pnpm seed`) and at least one
+ * successful `GET /api/v2/cron/simulate` call (bearer-authenticated with
+ * SEED_SECRET) so the evaluator has actually produced alert documents.
+ * Neither `pnpm seed` nor `scripts/v2/simulate.ts` triggers evaluation on its
+ * own -- see `.superpowers/sdd/2026-08-01-alerting-subsystem/task-20-report.md`
+ * for the exact commands used and the alert counts observed in the database
+ * at the time this suite was written.
+ *
+ * This suite deliberately does NOT `test.skip()` past missing alert data.
+ * Producing that data is this task's own responsibility, not an optional
+ * precondition, so a locator that comes back empty here is a real failure to
+ * surface, not something to quietly skip past.
+ */
+
+import { test, expect } from '@playwright/test';
+
+test.describe('Alerts', () => {
+  test('should render the active alerts page', async ({ page }) => {
+    await page.goto('/alerts');
+    await page.waitForLoadState('load');
+
+    await expect(page.getByRole('heading', { name: /alerts/i })).toBeVisible({ timeout: 15000 });
+  });
+
+  test('should reach alerts from the top navigation, with an open-alert count badge', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await page.waitForLoadState('load');
+
+    // The seeded database has open (firing) alerts, so the nav badge renders
+    // with an accessible name of the form "<n> open alerts" (components/TopNav.tsx).
+    const badge = page.locator('[aria-label$="open alerts"]').first();
+    await expect(badge).toBeVisible({ timeout: 15000 });
+    await expect(badge).toHaveAttribute('aria-label', /^\d+ open alerts$/);
+
+    await page
+      .getByRole('link', { name: /alerts/i })
+      .first()
+      .click();
+
+    await expect(page).toHaveURL(/\/alerts/);
+    await expect(page.getByRole('heading', { name: /alerts/i })).toBeVisible({ timeout: 15000 });
+  });
+
+  test('should switch to history via the status filter, reflected in the Select', async ({
+    page,
+  }) => {
+    await page.goto('/alerts?status=resolved');
+    await page.waitForLoadState('load');
+
+    await expect(page.getByRole('heading', { name: /alerts/i })).toBeVisible({ timeout: 15000 });
+
+    // Confirms the URL param actually drove the (non-native, custom) Select's
+    // displayed value, not just that the page rendered regardless of it.
+    await expect(page.getByText(/resolved \(history\)/i)).toBeVisible({ timeout: 15000 });
+  });
+
+  test('should survive a refresh on a deep-linked alert', async ({ page }) => {
+    await page.goto('/alerts');
+    await page.waitForLoadState('load');
+
+    // The seeded database has firing alerts (see task-20-report.md), so a row
+    // must be present here -- a real assertion, not a skip guard. Excludes the
+    // header's "Manage rules" link, which also matches `^="/alerts/"`.
+    const firstAlert = page.locator('a[href^="/alerts/"]:not([href="/alerts/rules"])').first();
+    await expect(firstAlert).toBeVisible({ timeout: 15000 });
+
+    await firstAlert.click();
+    await expect(page).toHaveURL(/\/alerts\/[0-9a-f]{24}/);
+
+    const url = page.url();
+    await page.reload();
+    await page.waitForLoadState('load');
+
+    expect(page.url()).toBe(url);
+    await expect(page.getByText(/breached since/i)).toBeVisible({ timeout: 15000 });
+  });
+
+  test('should render the styled 404 for an unknown alert id', async ({ page }) => {
+    await page.goto('/alerts/507f1f77bcf86cd799439011');
+    await page.waitForLoadState('load');
+
+    await expect(page.getByText(/not found|404/i).first()).toBeVisible({ timeout: 15000 });
+  });
+
+  test('should reach the rules page and show the seeded High temperature rule', async ({
+    page,
+  }) => {
+    await page.goto('/alerts');
+    await page.waitForLoadState('load');
+
+    await page.getByRole('link', { name: /manage rules/i }).click();
+
+    await expect(page).toHaveURL(/\/alerts\/rules/);
+    await expect(page.getByText(/high temperature/i)).toBeVisible({ timeout: 15000 });
+  });
+
+  test('should render acknowledge as a gated control -- visible, disabled, tooltipped -- rather than hiding it', async ({
+    page,
+  }) => {
+    await page.goto('/alerts');
+    await page.waitForLoadState('load');
+
+    // The seeded database has firing alerts, so an Acknowledge control must be
+    // present here -- a real assertion, not a skip guard.
+    const ack = page.getByRole('button', { name: /acknowledge/i }).first();
+    await expect(ack).toBeVisible({ timeout: 15000 });
+
+    // NEXT_PUBLIC_DEMO_MODE=true in .env.local, and this suite runs
+    // unauthenticated (E2E_TESTING bypasses Clerk in proxy.ts, and
+    // e2e/auth.setup.ts never actually signs in). useAdminAction() must
+    // therefore take the non-admin/demo-mode branch: visible + disabled +
+    // tooltip, never hidden -- see lib/auth/rbac-client.tsx.
+    await expect(ack).toBeDisabled();
+    await expect(ack).toHaveAttribute('title', /admin only/i);
+  });
+});

--- a/example.env
+++ b/example.env
@@ -87,6 +87,13 @@ NEXT_PUBLIC_CLERK_ALLOWED_ORG_SLUGS=users
 # Secret token for /api/v2/cron/simulate endpoint. Configure the same value in your scheduler (for example, n8n).
 SEED_SECRET=
 
+# Alerting (optional)
+# Seconds of silence after which an open alert is closed as stale because its
+# device stopped reporting (lib/alerting/sweep.ts). Must be a positive integer;
+# a malformed or non-positive value falls back to 1800 (30 minutes) and logs a
+# warning rather than silently disabling staleness detection.
+ALERT_STALE_AFTER_SECONDS=1800
+
 # Public Read-Only Demo (optional)
 # When "true", anonymous visitors may browse the app and read GET APIs without signing in.
 # Writes stay blocked: the synthetic demo context carries the org:member role, and every

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -4,6 +4,13 @@
  * This file is used to register instrumentation hooks.
  * It must export a register function that is called once when Next.js starts.
  * https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
+ *
+ * This is the ONLY production Sentry initialization path. The imported config
+ * files call `Sentry.init()` on the `@sentry/nextjs` module singleton;
+ * `lib/monitoring/sentry.ts` talks to that same singleton and deliberately does
+ * NOT depend on its own `initSentry()` helper, which nothing here calls. See
+ * that file's header for why gating capture helpers on a private
+ * initialization flag silently disabled every escalation in the app.
  */
 
 export async function register() {

--- a/lib/alerting/evaluate.ts
+++ b/lib/alerting/evaluate.ts
@@ -1,0 +1,414 @@
+/**
+ * Alert rule evaluation.
+ *
+ * Called by both write paths AFTER their insert has committed, so it can never
+ * roll back an insert. Owns no scheduler, no queue, and no second state store.
+ *
+ * COST: two queries, one bulk write, constant in batch size (plus a third query
+ * on a rule-cache miss). Whether the request carried 1 reading or 10,000, the
+ * number of round trips is identical. That is a structural property of the
+ * reduction below, not a benchmark.
+ *
+ * It is NOT constant in fleet size: work is linear in candidate (rule, device)
+ * pairs, which is the $in cardinality and the bulk operation count.
+ */
+
+import { Types, type AnyBulkWriteOperation } from 'mongoose';
+import AlertV2, { type IAlertV2 } from '@/models/v2/AlertV2';
+import { recordAlert, recordAlertEvaluationDuration } from '@/lib/monitoring';
+import { getRuleBuckets } from './rule-cache';
+import { METRIC_ACCESSORS, compare, matchesSelector } from './selector';
+import {
+  emptyEvaluationResult,
+  type CachedAlertRule,
+  type EvaluableDevice,
+  type EvaluableReading,
+  type EvaluationResult,
+} from './types';
+import type { FiredAlert, ResolvedAlert } from '@/types/v2/alert.types';
+
+const DUPLICATE_KEY_CODE = 11000;
+
+/** One (rule, device) pair's reduced state for this batch. */
+interface PairState {
+  rule: CachedAlertRule;
+  device: EvaluableDevice;
+  breaching: boolean;
+  /** Metric value of the EARLIEST breaching reading. */
+  triggerValue?: number;
+  /** Timestamp of the EARLIEST breaching reading. */
+  breachedSince?: Date;
+  /** Metric value of the LATEST reading overall, breaching or not. */
+  lastValue: number;
+  /** Timestamp of the LATEST reading overall. */
+  lastObservedAt: Date;
+}
+
+/** A notification queued against a bulk-write op index, dropped if that op failed. */
+type PendingNotification =
+  | { kind: 'fired'; alert: FiredAlert }
+  | { kind: 'resolved'; alert: ResolvedAlert }
+  | null;
+
+/**
+ * Normalize the driver's write errors.
+ *
+ * MongoBulkWriteError.writeErrors is typed OneOrMore<WriteError> — a single
+ * failure can arrive as a bare object rather than an array.
+ */
+export function extractWriteErrors(err: unknown): Array<{ index: number; code: number }> {
+  const raw = (err as { writeErrors?: unknown })?.writeErrors;
+  if (!raw) return [];
+  const list = Array.isArray(raw) ? raw : [raw];
+  return list.map(e => ({
+    index: Number((e as { index?: number }).index ?? -1),
+    code: Number((e as { code?: number }).code ?? 0),
+  }));
+}
+
+function toDate(value: unknown): Date {
+  return value instanceof Date ? value : new Date(value as string);
+}
+
+function toFiredAlert(
+  id: Types.ObjectId,
+  rule: CachedAlertRule,
+  device: EvaluableDevice,
+  state: PairState,
+  firedAt: Date
+): FiredAlert {
+  return {
+    _id: String(id),
+    rule_id: rule._id,
+    rule_name: rule.name,
+    device_id: String(device._id),
+    severity: rule.severity,
+    metric: rule.metric,
+    comparison: rule.comparison,
+    threshold: rule.threshold,
+    trigger_value: state.triggerValue ?? state.lastValue,
+    fired_at: firedAt.toISOString(),
+  };
+}
+
+export async function evaluateReadings(
+  readings: EvaluableReading[],
+  devices: EvaluableDevice[]
+): Promise<EvaluationResult> {
+  const started = Date.now();
+
+  if (readings.length === 0 || devices.length === 0) return emptyEvaluationResult();
+
+  const deviceById = new Map(devices.map(d => [String(d._id), d]));
+  const { byType } = await getRuleBuckets();
+
+  // ---- Steps 1-3: match and reduce to one decision per (rule, device) pair ----
+  //
+  // The reduction is BREACH-AWARE, not newest-wins. Alerting evaluates the
+  // aggregate state of each device per request; it is not a backfill engine and
+  // does not replay a batch as a timeline.
+  const pairs = new Map<string, PairState>();
+  let maxCooldownSeconds = 0;
+
+  for (const reading of readings) {
+    const deviceId = reading.metadata?.device_id;
+    const type = reading.metadata?.type;
+    if (!deviceId || !type) continue;
+
+    const device = deviceById.get(deviceId);
+    if (!device) continue;
+
+    const ts = toDate(reading.timestamp ?? new Date());
+    const rules = byType.get(type) ?? [];
+
+    for (const rule of rules) {
+      if (!matchesSelector(device, rule.selector)) continue;
+
+      const metricValue = METRIC_ACCESSORS[rule.metric](reading);
+      if (metricValue === undefined || metricValue === null || Number.isNaN(metricValue)) continue;
+
+      maxCooldownSeconds = Math.max(maxCooldownSeconds, rule.cooldown_seconds ?? 0);
+
+      const key = `${rule._id}::${deviceId}`;
+      const breaches = compare(metricValue, rule.comparison, rule.threshold);
+      const existing = pairs.get(key);
+
+      if (!existing) {
+        pairs.set(key, {
+          rule,
+          device,
+          breaching: breaches,
+          triggerValue: breaches ? metricValue : undefined,
+          breachedSince: breaches ? ts : undefined,
+          lastValue: metricValue,
+          lastObservedAt: ts,
+        });
+        continue;
+      }
+
+      if (breaches) {
+        existing.breaching = true;
+        if (!existing.breachedSince || ts < existing.breachedSince) {
+          existing.breachedSince = ts;
+          existing.triggerValue = metricValue;
+        }
+      }
+
+      if (ts >= existing.lastObservedAt) {
+        existing.lastValue = metricValue;
+        existing.lastObservedAt = ts;
+      }
+    }
+  }
+
+  if (pairs.size === 0) {
+    recordAlertEvaluationDuration(Date.now() - started);
+    return emptyEvaluationResult();
+  }
+
+  // ---- Steps 4-5: two queries ----
+  const ruleObjectIds = [...new Set([...pairs.values()].map(p => p.rule._id))].map(
+    id => new Types.ObjectId(id)
+  );
+  const deviceIds = [...new Set([...pairs.values()].map(p => String(p.device._id)))];
+
+  const openEpisodes = await AlertV2.find({
+    is_open: true,
+    rule_id: { $in: ruleObjectIds },
+    device_id: { $in: deviceIds },
+  }).lean<IAlertV2[]>();
+
+  const cooldownSince = new Date(Date.now() - maxCooldownSeconds * 1000);
+  const recentlyResolved =
+    maxCooldownSeconds > 0
+      ? await AlertV2.find({
+          rule_id: { $in: ruleObjectIds },
+          device_id: { $in: deviceIds },
+          'audit.resolved_at': { $gte: cooldownSince },
+        })
+          .select({ rule_id: 1, device_id: 1, 'audit.resolved_at': 1 })
+          .lean<IAlertV2[]>()
+      : [];
+
+  const openByPair = new Map(openEpisodes.map(a => [`${a.rule_id}::${a.device_id}`, a]));
+
+  const lastResolvedByPair = new Map<string, Date>();
+  for (const episode of recentlyResolved) {
+    const at = episode.audit?.resolved_at;
+    if (!at) continue;
+    const key = `${episode.rule_id}::${episode.device_id}`;
+    const prev = lastResolvedByPair.get(key);
+    if (!prev || toDate(at) > prev) lastResolvedByPair.set(key, toDate(at));
+  }
+
+  // ---- Step 6: decide every pair in memory ----
+  const now = new Date();
+  const ops: AnyBulkWriteOperation<IAlertV2>[] = [];
+  const notifications: PendingNotification[] = [];
+  let pendingOpened = 0;
+  let pendingCleared = 0;
+  let suppressed = 0;
+
+  const push = (op: AnyBulkWriteOperation<IAlertV2>, notification: PendingNotification = null) => {
+    ops.push(op);
+    notifications.push(notification);
+  };
+
+  for (const [key, state] of pairs) {
+    const existing = openByPair.get(key);
+    const { rule, device } = state;
+
+    // An out-of-order batch must never rewind state into the sweep's path.
+    if (existing && state.lastObservedAt <= toDate(existing.last_observed_at)) continue;
+
+    if (state.breaching) {
+      if (!existing) {
+        const lastResolved = lastResolvedByPair.get(key);
+        if (
+          lastResolved &&
+          (rule.cooldown_seconds ?? 0) > 0 &&
+          now.getTime() - lastResolved.getTime() < rule.cooldown_seconds * 1000
+        ) {
+          suppressed++;
+          continue;
+        }
+
+        const firesImmediately = (rule.for_duration_seconds ?? 0) === 0;
+        const _id = new Types.ObjectId();
+
+        push(
+          {
+            insertOne: {
+              document: {
+                _id,
+                rule_id: new Types.ObjectId(rule._id),
+                rule_name: rule.name,
+                device_id: String(device._id),
+                status: firesImmediately ? 'firing' : 'pending',
+                is_open: true,
+                severity: rule.severity,
+                metric: rule.metric,
+                comparison: rule.comparison,
+                threshold: rule.threshold,
+                trigger_value: state.triggerValue as number,
+                last_value: state.lastValue,
+                breached_since: state.breachedSince as Date,
+                last_observed_at: state.lastObservedAt,
+                ...(firesImmediately ? { fired_at: now } : {}),
+                audit: {
+                  created_at: now,
+                  created_by: 'system',
+                  updated_at: now,
+                  updated_by: 'system',
+                },
+              } as unknown as IAlertV2,
+            },
+          },
+          firesImmediately ? { kind: 'fired', alert: toFiredAlert(_id, rule, device, state, now) } : null
+        );
+
+        if (firesImmediately) recordAlert('fired', { severity: rule.severity });
+        else pendingOpened++;
+        continue;
+      }
+
+      if (existing.status === 'pending') {
+        const elapsedMs = state.lastObservedAt.getTime() - toDate(existing.breached_since).getTime();
+
+        if (elapsedMs >= (rule.for_duration_seconds ?? 0) * 1000) {
+          push(
+            {
+              updateOne: {
+                filter: {
+                  _id: existing._id,
+                  status: 'pending',
+                  last_observed_at: { $lt: state.lastObservedAt },
+                },
+                update: {
+                  $set: {
+                    status: 'firing',
+                    fired_at: now,
+                    last_value: state.lastValue,
+                    'audit.updated_at': now,
+                    'audit.updated_by': 'system',
+                  },
+                  $max: { last_observed_at: state.lastObservedAt },
+                },
+              },
+            },
+            { kind: 'fired', alert: toFiredAlert(existing._id, rule, device, state, now) }
+          );
+          recordAlert('fired', { severity: rule.severity });
+        } else
+          push({
+            updateOne: {
+              filter: { _id: existing._id, last_observed_at: { $lt: state.lastObservedAt } },
+              update: {
+                $set: { last_value: state.lastValue, 'audit.updated_at': now },
+                $max: { last_observed_at: state.lastObservedAt },
+              },
+            },
+          });
+        continue;
+      }
+
+      // firing or acknowledged: refresh the observation, do not re-fire.
+      push({
+        updateOne: {
+          filter: { _id: existing._id, last_observed_at: { $lt: state.lastObservedAt } },
+          update: {
+            $set: { last_value: state.lastValue, 'audit.updated_at': now },
+            $max: { last_observed_at: state.lastObservedAt },
+          },
+        },
+      });
+      continue;
+    }
+
+    // ---- not breaching ----
+    if (!existing) continue;
+
+    if (existing.status === 'pending') {
+      // An episode that never fired is not history, and keeping them would let a
+      // flapping sensor fill the collection.
+      push({ deleteOne: { filter: { _id: existing._id, status: 'pending' } } });
+      pendingCleared++;
+      continue;
+    }
+
+    push(
+      {
+        updateOne: {
+          filter: {
+            _id: existing._id,
+            is_open: true,
+            last_observed_at: { $lt: state.lastObservedAt },
+          },
+          update: {
+            $set: {
+              status: 'resolved',
+              is_open: false,
+              last_value: state.lastValue,
+              resolved_value: state.lastValue,
+              'audit.updated_at': now,
+              'audit.updated_by': 'system',
+              'audit.resolved_at': now,
+              'audit.resolved_by': 'system',
+              'audit.resolution': 'auto',
+            },
+            $max: { last_observed_at: state.lastObservedAt },
+          },
+        },
+      },
+      {
+        kind: 'resolved',
+        alert: {
+          _id: String(existing._id),
+          rule_id: String(existing.rule_id),
+          device_id: existing.device_id,
+          severity: existing.severity,
+          resolution: 'auto',
+          resolved_at: now.toISOString(),
+          actor: 'system',
+        },
+      }
+    );
+    recordAlert('resolved', { resolution: 'auto' });
+  }
+
+  // ---- Step 7: one bulk write ----
+  const failedIndices = new Set<number>();
+
+  if (ops.length > 0)
+    try {
+      await AlertV2.bulkWrite(ops, { ordered: false });
+    } catch (err) {
+      const writeErrors = extractWriteErrors(err);
+      const unexpected = writeErrors.filter(e => e.code !== DUPLICATE_KEY_CODE);
+
+      // Only E11000 is absorbed. Without this filter a genuine write failure
+      // would vanish into the same silent path as a benign race, and
+      // alert_evaluation_errors_total would stop being a trustworthy signal.
+      if (unexpected.length > 0 || writeErrors.length === 0) throw err;
+
+      // Every error was a duplicate open episode: another request won the race,
+      // which is the desired end state either way.
+      for (const e of writeErrors) failedIndices.add(e.index);
+    }
+
+  const result = emptyEvaluationResult();
+  result.pendingOpened = pendingOpened;
+  result.pendingCleared = pendingCleared;
+  result.suppressed = suppressed;
+  result.evaluatedPairs = pairs.size;
+
+  for (let i = 0; i < notifications.length; i++) {
+    const notification = notifications[i];
+    if (!notification || failedIndices.has(i)) continue;
+    if (notification.kind === 'fired') result.fired.push(notification.alert);
+    else result.resolved.push(notification.alert);
+  }
+
+  recordAlertEvaluationDuration(Date.now() - started);
+  return result;
+}

--- a/lib/alerting/evaluate.ts
+++ b/lib/alerting/evaluate.ts
@@ -325,7 +325,15 @@ export async function evaluateReadings(
             continue;
           }
 
-          const firesImmediately = (rule.for_duration_seconds ?? 0) === 0;
+          // Symmetric with the promotion branch below: a breach that already spans
+          // the required duration WITHIN this batch must fire immediately, not wait
+          // for a second request just because no pending episode exists yet.
+          // `state.breaching` is true here, so `state.breachedSince` is always set —
+          // same cast as `breached_since: state.breachedSince as Date` in the
+          // insertOne document just below.
+          const elapsedMs =
+            state.lastObservedAt.getTime() - (state.breachedSince as Date).getTime();
+          const firesImmediately = elapsedMs >= (rule.for_duration_seconds ?? 0) * 1000;
           const _id = new Types.ObjectId();
 
           push(

--- a/lib/alerting/evaluate.ts
+++ b/lib/alerting/evaluate.ts
@@ -336,6 +336,15 @@ export async function evaluateReadings(
           const firesImmediately = elapsedMs >= (rule.for_duration_seconds ?? 0) * 1000;
           const _id = new Types.ObjectId();
 
+          // NO `as unknown as IAlertV2` on this document. It used to carry one,
+          // which meant the single place that CREATES an alert episode was also
+          // the one place where nothing checked the fields it wrote — including
+          // `status`/`is_open`, whose agreement is what keeps the partial unique
+          // dedup index correct. The two narrow `as` casts below
+          // (`triggerValue`, `breachedSince`) are the real, local ones: both are
+          // `T | undefined` on PairState and both are provably set inside this
+          // `state.breaching` branch. Keeping the document itself unasserted is
+          // what makes those two casts readable as the exceptions they are.
           push(
             {
               insertOne: {
@@ -361,7 +370,7 @@ export async function evaluateReadings(
                     updated_at: now,
                     updated_by: 'system',
                   },
-                } as unknown as IAlertV2,
+                },
               },
             },
             firesImmediately
@@ -513,21 +522,39 @@ export async function evaluateReadings(
     // A guarded updateOne matching ZERO documents is a driver success, and
     // BulkWriteResult reports aggregate counts, not per-op match status.
     //
-    // House rule: a write-confirmation predicate must key on a field that
-    // ONLY the confirming operation sets. `audit.updated_at` fails that rule
-    // here — every op in this run stamps it, including the silent
-    // observation-refresh updates above (still-breaching-but-not-due-yet,
-    // and firing/acknowledged refresh) — and so does a CONCURRENT evaluator
-    // whose own `now` lands in the same millisecond. Two requests can read
-    // the same pending episode; the loser's guarded update then matches zero
-    // rows, but if its `now` happens to equal the winner's, confirming on
-    // `audit.updated_at` alone would still match and emit a second
-    // notification for one transition. A promotion writes `fired_at`; an
-    // auto-resolve writes `audit.resolved_at` — nothing else touches either
-    // field, so confirming each candidate kind against its own field proves
-    // ITS op landed rather than merely that SOME write touched the document
-    // at this instant. Mirrors sweep.ts's resolve reconciliation, which
-    // already confirms on `audit.resolved_at` alone for exactly this reason.
+    // House rule: a write-confirmation predicate must match a value-set that
+    // ONLY the confirming operation could have produced. `audit.updated_at`
+    // fails that rule here — every op in this run stamps it, including the
+    // silent observation-refresh updates above (still-breaching-but-not-due-
+    // yet, and firing/acknowledged refresh) — and so does a CONCURRENT
+    // evaluator whose own `now` lands in the same millisecond. Two requests
+    // can read the same pending episode; the loser's guarded update then
+    // matches zero rows, but if its `now` happens to equal the winner's,
+    // confirming on `audit.updated_at` alone would still match and emit a
+    // second notification for one transition.
+    //
+    // The two candidate kinds are NOT symmetric, and the predicates differ
+    // accordingly:
+    //
+    //  - A promotion writes `fired_at`, and this branch (evaluate.ts) is the
+    //    only writer of that field anywhere in the codebase. `fired_at: now`
+    //    is therefore already exclusive on its own.
+    //
+    //  - An auto-resolve writes `audit.resolved_at` — but so does the
+    //    staleness sweep (`lib/alerting/sweep.ts`) and so does
+    //    `AlertV2.resolve()`, which the manual PATCH /alerts/[id] path calls.
+    //    Those are genuinely concurrent request paths (ingest vs cron, and a
+    //    human clicking Resolve as a fresh reading lands), so a same-
+    //    millisecond collision would let this run confirm a transition it did
+    //    not cause and broadcast it as `resolution: 'auto'` while the stored
+    //    document says `manual` / `stale` / `device_inactive`. Matching
+    //    `audit.resolution: 'auto'` as well closes that: 'auto' is written by
+    //    the resolve op below and nowhere else — the sweep writes 'stale' or
+    //    'device_inactive', and the manual path passes 'manual'.
+    //
+    // Confirming each candidate kind against its own predicate proves ITS op
+    // landed rather than merely that SOME write touched the document at this
+    // instant.
     const promotedIds: Types.ObjectId[] = [];
     const resolvedIds: Types.ObjectId[] = [];
     for (const candidate of notificationCandidates) {
@@ -541,7 +568,11 @@ export async function evaluateReadings(
       const confirmOr: Record<string, unknown>[] = [];
       if (promotedIds.length > 0) confirmOr.push({ _id: { $in: promotedIds }, fired_at: now });
       if (resolvedIds.length > 0)
-        confirmOr.push({ _id: { $in: resolvedIds }, 'audit.resolved_at': now });
+        confirmOr.push({
+          _id: { $in: resolvedIds },
+          'audit.resolved_at': now,
+          'audit.resolution': 'auto',
+        });
 
       const confirmed = await AlertV2.find({ $or: confirmOr })
         .select({ _id: 1 })

--- a/lib/alerting/evaluate.ts
+++ b/lib/alerting/evaluate.ts
@@ -4,10 +4,11 @@
  * Called by both write paths AFTER their insert has committed, so it can never
  * roll back an insert. Owns no scheduler, no queue, and no second state store.
  *
- * COST: two queries, one bulk write, constant in batch size (plus a third query
- * on a rule-cache miss). Whether the request carried 1 reading or 10,000, the
- * number of round trips is identical. That is a structural property of the
- * reduction below, not a benchmark.
+ * COST: two `find`s and one bulk write, plus one reconciliation `find` when any
+ * update op carries a notification, plus one rule-load query on a cache miss.
+ * None of those scale with batch size: whether the request carried 1 reading or
+ * 10,000, the number of round trips is identical. That is a structural property
+ * of the reduction below, not a benchmark.
  *
  * It is NOT constant in fleet size: work is linear in candidate (rule, device)
  * pairs, which is the $in cardinality and the bulk operation count.
@@ -44,10 +45,19 @@ interface PairState {
   lastObservedAt: Date;
 }
 
-/** A notification queued against a bulk-write op index, dropped if that op failed. */
+/**
+ * A notification queued against a bulk-write op index — a candidate, not a
+ * confirmed outcome. Nothing here is emitted or counted until the write says so.
+ *
+ * How it is confirmed depends on the op. An `insertOne` either inserts or
+ * reports a write error, so its notification stands unless its index is in
+ * `failedIndices`. A guarded `updateOne` can match ZERO documents and still be
+ * a driver success, so it carries `confirmId` and is emitted only if the
+ * reconciliation query after the write proves it actually matched.
+ */
 type PendingNotification =
-  | { kind: 'fired'; alert: FiredAlert }
-  | { kind: 'resolved'; alert: ResolvedAlert }
+  | { kind: 'fired'; alert: FiredAlert; confirmId?: Types.ObjectId }
+  | { kind: 'resolved'; alert: ResolvedAlert; confirmId: Types.ObjectId }
   | null;
 
 /**
@@ -97,318 +107,371 @@ export async function evaluateReadings(
 ): Promise<EvaluationResult> {
   const started = Date.now();
 
-  if (readings.length === 0 || devices.length === 0) return emptyEvaluationResult();
+  try {
+    if (readings.length === 0 || devices.length === 0) return emptyEvaluationResult();
 
-  const deviceById = new Map(devices.map(d => [String(d._id), d]));
-  const { byType } = await getRuleBuckets();
+    const deviceById = new Map(devices.map(d => [String(d._id), d]));
+    const { byType } = await getRuleBuckets();
 
-  // ---- Steps 1-3: match and reduce to one decision per (rule, device) pair ----
-  //
-  // The reduction is BREACH-AWARE, not newest-wins. Alerting evaluates the
-  // aggregate state of each device per request; it is not a backfill engine and
-  // does not replay a batch as a timeline.
-  const pairs = new Map<string, PairState>();
-  let maxCooldownSeconds = 0;
+    // ---- Steps 1-3: match and reduce to one decision per (rule, device) pair ----
+    //
+    // The reduction is BREACH-AWARE, not newest-wins. Alerting evaluates the
+    // aggregate state of each device per request; it is not a backfill engine and
+    // does not replay a batch as a timeline.
+    const pairs = new Map<string, PairState>();
+    let maxCooldownSeconds = 0;
 
-  for (const reading of readings) {
-    const deviceId = reading.metadata?.device_id;
-    const type = reading.metadata?.type;
-    if (!deviceId || !type) continue;
+    for (const reading of readings) {
+      const deviceId = reading.metadata?.device_id;
+      const type = reading.metadata?.type;
+      if (!deviceId || !type) continue;
 
-    const device = deviceById.get(deviceId);
-    if (!device) continue;
+      const device = deviceById.get(deviceId);
+      if (!device) continue;
 
-    const ts = toDate(reading.timestamp ?? new Date());
-    const rules = byType.get(type) ?? [];
+      const ts = toDate(reading.timestamp ?? new Date());
+      const rules = byType.get(type) ?? [];
 
-    for (const rule of rules) {
-      if (!matchesSelector(device, rule.selector)) continue;
+      for (const rule of rules) {
+        if (!matchesSelector(device, rule.selector)) continue;
 
-      const metricValue = METRIC_ACCESSORS[rule.metric](reading);
-      if (metricValue === undefined || metricValue === null || Number.isNaN(metricValue)) continue;
+        const metricValue = METRIC_ACCESSORS[rule.metric](reading);
+        if (metricValue === undefined || metricValue === null || Number.isNaN(metricValue))
+          continue;
 
-      maxCooldownSeconds = Math.max(maxCooldownSeconds, rule.cooldown_seconds ?? 0);
+        maxCooldownSeconds = Math.max(maxCooldownSeconds, rule.cooldown_seconds ?? 0);
 
-      const key = `${rule._id}::${deviceId}`;
-      const breaches = compare(metricValue, rule.comparison, rule.threshold);
-      const existing = pairs.get(key);
+        const key = `${rule._id}::${deviceId}`;
+        const breaches = compare(metricValue, rule.comparison, rule.threshold);
+        const existing = pairs.get(key);
 
-      if (!existing) {
-        pairs.set(key, {
-          rule,
-          device,
-          breaching: breaches,
-          triggerValue: breaches ? metricValue : undefined,
-          breachedSince: breaches ? ts : undefined,
-          lastValue: metricValue,
-          lastObservedAt: ts,
+        if (!existing) {
+          pairs.set(key, {
+            rule,
+            device,
+            breaching: breaches,
+            triggerValue: breaches ? metricValue : undefined,
+            breachedSince: breaches ? ts : undefined,
+            lastValue: metricValue,
+            lastObservedAt: ts,
+          });
+          continue;
+        }
+
+        if (breaches) {
+          existing.breaching = true;
+          if (!existing.breachedSince || ts < existing.breachedSince) {
+            existing.breachedSince = ts;
+            existing.triggerValue = metricValue;
+          }
+        }
+
+        if (ts >= existing.lastObservedAt) {
+          existing.lastValue = metricValue;
+          existing.lastObservedAt = ts;
+        }
+      }
+    }
+
+    if (pairs.size === 0) return emptyEvaluationResult();
+
+    // ---- Steps 4-5: two queries ----
+    const ruleObjectIds = [...new Set([...pairs.values()].map(p => p.rule._id))].map(
+      id => new Types.ObjectId(id)
+    );
+    const deviceIds = [...new Set([...pairs.values()].map(p => String(p.device._id)))];
+
+    const openEpisodes = await AlertV2.find({
+      is_open: true,
+      rule_id: { $in: ruleObjectIds },
+      device_id: { $in: deviceIds },
+    }).lean<IAlertV2[]>();
+
+    const cooldownSince = new Date(Date.now() - maxCooldownSeconds * 1000);
+    const recentlyResolved =
+      maxCooldownSeconds > 0
+        ? await AlertV2.find({
+            rule_id: { $in: ruleObjectIds },
+            device_id: { $in: deviceIds },
+            'audit.resolved_at': { $gte: cooldownSince },
+          })
+            .select({ rule_id: 1, device_id: 1, 'audit.resolved_at': 1 })
+            .lean<IAlertV2[]>()
+        : [];
+
+    const openByPair = new Map(openEpisodes.map(a => [`${a.rule_id}::${a.device_id}`, a]));
+
+    const lastResolvedByPair = new Map<string, Date>();
+    for (const episode of recentlyResolved) {
+      const at = episode.audit?.resolved_at;
+      if (!at) continue;
+      const key = `${episode.rule_id}::${episode.device_id}`;
+      const prev = lastResolvedByPair.get(key);
+      if (!prev || toDate(at) > prev) lastResolvedByPair.set(key, toDate(at));
+    }
+
+    // ---- Step 6: decide every pair in memory ----
+    const now = new Date();
+    const ops: AnyBulkWriteOperation<IAlertV2>[] = [];
+    const notificationCandidates: PendingNotification[] = [];
+    let pendingOpened = 0;
+    let suppressed = 0;
+
+    const push = (
+      op: AnyBulkWriteOperation<IAlertV2>,
+      notification: PendingNotification = null
+    ) => {
+      ops.push(op);
+      notificationCandidates.push(notification);
+    };
+
+    for (const [key, state] of pairs) {
+      const existing = openByPair.get(key);
+      const { rule, device } = state;
+
+      // An out-of-order batch must never rewind state into the sweep's path.
+      if (existing && state.lastObservedAt <= toDate(existing.last_observed_at)) continue;
+
+      if (state.breaching) {
+        if (!existing) {
+          const lastResolved = lastResolvedByPair.get(key);
+          if (
+            lastResolved &&
+            (rule.cooldown_seconds ?? 0) > 0 &&
+            now.getTime() - lastResolved.getTime() < rule.cooldown_seconds * 1000
+          ) {
+            suppressed++;
+            continue;
+          }
+
+          const firesImmediately = (rule.for_duration_seconds ?? 0) === 0;
+          const _id = new Types.ObjectId();
+
+          push(
+            {
+              insertOne: {
+                document: {
+                  _id,
+                  rule_id: new Types.ObjectId(rule._id),
+                  rule_name: rule.name,
+                  device_id: String(device._id),
+                  status: firesImmediately ? 'firing' : 'pending',
+                  is_open: true,
+                  severity: rule.severity,
+                  metric: rule.metric,
+                  comparison: rule.comparison,
+                  threshold: rule.threshold,
+                  trigger_value: state.triggerValue as number,
+                  last_value: state.lastValue,
+                  breached_since: state.breachedSince as Date,
+                  last_observed_at: state.lastObservedAt,
+                  ...(firesImmediately ? { fired_at: now } : {}),
+                  audit: {
+                    created_at: now,
+                    created_by: 'system',
+                    updated_at: now,
+                    updated_by: 'system',
+                  },
+                } as unknown as IAlertV2,
+              },
+            },
+            firesImmediately
+              ? { kind: 'fired', alert: toFiredAlert(_id, rule, device, state, now) }
+              : null
+          );
+
+          if (!firesImmediately) pendingOpened++;
+          continue;
+        }
+
+        if (existing.status === 'pending') {
+          const elapsedMs =
+            state.lastObservedAt.getTime() - toDate(existing.breached_since).getTime();
+
+          if (elapsedMs >= (rule.for_duration_seconds ?? 0) * 1000)
+            push(
+              {
+                updateOne: {
+                  filter: {
+                    _id: existing._id,
+                    status: 'pending',
+                    last_observed_at: { $lt: state.lastObservedAt },
+                  },
+                  update: {
+                    $set: {
+                      status: 'firing',
+                      fired_at: now,
+                      last_value: state.lastValue,
+                      'audit.updated_at': now,
+                      'audit.updated_by': 'system',
+                    },
+                    $max: { last_observed_at: state.lastObservedAt },
+                  },
+                },
+              },
+              {
+                kind: 'fired',
+                alert: toFiredAlert(existing._id, rule, device, state, now),
+                confirmId: existing._id,
+              }
+            );
+          else
+            push({
+              updateOne: {
+                filter: { _id: existing._id, last_observed_at: { $lt: state.lastObservedAt } },
+                update: {
+                  $set: { last_value: state.lastValue, 'audit.updated_at': now },
+                  $max: { last_observed_at: state.lastObservedAt },
+                },
+              },
+            });
+          continue;
+        }
+
+        // firing or acknowledged: refresh the observation, do not re-fire.
+        push({
+          updateOne: {
+            filter: { _id: existing._id, last_observed_at: { $lt: state.lastObservedAt } },
+            update: {
+              $set: { last_value: state.lastValue, 'audit.updated_at': now },
+              $max: { last_observed_at: state.lastObservedAt },
+            },
+          },
         });
         continue;
       }
 
-      if (breaches) {
-        existing.breaching = true;
-        if (!existing.breachedSince || ts < existing.breachedSince) {
-          existing.breachedSince = ts;
-          existing.triggerValue = metricValue;
-        }
-      }
-
-      if (ts >= existing.lastObservedAt) {
-        existing.lastValue = metricValue;
-        existing.lastObservedAt = ts;
-      }
-    }
-  }
-
-  if (pairs.size === 0) {
-    recordAlertEvaluationDuration(Date.now() - started);
-    return emptyEvaluationResult();
-  }
-
-  // ---- Steps 4-5: two queries ----
-  const ruleObjectIds = [...new Set([...pairs.values()].map(p => p.rule._id))].map(
-    id => new Types.ObjectId(id)
-  );
-  const deviceIds = [...new Set([...pairs.values()].map(p => String(p.device._id)))];
-
-  const openEpisodes = await AlertV2.find({
-    is_open: true,
-    rule_id: { $in: ruleObjectIds },
-    device_id: { $in: deviceIds },
-  }).lean<IAlertV2[]>();
-
-  const cooldownSince = new Date(Date.now() - maxCooldownSeconds * 1000);
-  const recentlyResolved =
-    maxCooldownSeconds > 0
-      ? await AlertV2.find({
-          rule_id: { $in: ruleObjectIds },
-          device_id: { $in: deviceIds },
-          'audit.resolved_at': { $gte: cooldownSince },
-        })
-          .select({ rule_id: 1, device_id: 1, 'audit.resolved_at': 1 })
-          .lean<IAlertV2[]>()
-      : [];
-
-  const openByPair = new Map(openEpisodes.map(a => [`${a.rule_id}::${a.device_id}`, a]));
-
-  const lastResolvedByPair = new Map<string, Date>();
-  for (const episode of recentlyResolved) {
-    const at = episode.audit?.resolved_at;
-    if (!at) continue;
-    const key = `${episode.rule_id}::${episode.device_id}`;
-    const prev = lastResolvedByPair.get(key);
-    if (!prev || toDate(at) > prev) lastResolvedByPair.set(key, toDate(at));
-  }
-
-  // ---- Step 6: decide every pair in memory ----
-  const now = new Date();
-  const ops: AnyBulkWriteOperation<IAlertV2>[] = [];
-  const notifications: PendingNotification[] = [];
-  let pendingOpened = 0;
-  let pendingCleared = 0;
-  let suppressed = 0;
-
-  const push = (op: AnyBulkWriteOperation<IAlertV2>, notification: PendingNotification = null) => {
-    ops.push(op);
-    notifications.push(notification);
-  };
-
-  for (const [key, state] of pairs) {
-    const existing = openByPair.get(key);
-    const { rule, device } = state;
-
-    // An out-of-order batch must never rewind state into the sweep's path.
-    if (existing && state.lastObservedAt <= toDate(existing.last_observed_at)) continue;
-
-    if (state.breaching) {
-      if (!existing) {
-        const lastResolved = lastResolvedByPair.get(key);
-        if (
-          lastResolved &&
-          (rule.cooldown_seconds ?? 0) > 0 &&
-          now.getTime() - lastResolved.getTime() < rule.cooldown_seconds * 1000
-        ) {
-          suppressed++;
-          continue;
-        }
-
-        const firesImmediately = (rule.for_duration_seconds ?? 0) === 0;
-        const _id = new Types.ObjectId();
-
-        push(
-          {
-            insertOne: {
-              document: {
-                _id,
-                rule_id: new Types.ObjectId(rule._id),
-                rule_name: rule.name,
-                device_id: String(device._id),
-                status: firesImmediately ? 'firing' : 'pending',
-                is_open: true,
-                severity: rule.severity,
-                metric: rule.metric,
-                comparison: rule.comparison,
-                threshold: rule.threshold,
-                trigger_value: state.triggerValue as number,
-                last_value: state.lastValue,
-                breached_since: state.breachedSince as Date,
-                last_observed_at: state.lastObservedAt,
-                ...(firesImmediately ? { fired_at: now } : {}),
-                audit: {
-                  created_at: now,
-                  created_by: 'system',
-                  updated_at: now,
-                  updated_by: 'system',
-                },
-              } as unknown as IAlertV2,
-            },
-          },
-          firesImmediately ? { kind: 'fired', alert: toFiredAlert(_id, rule, device, state, now) } : null
-        );
-
-        if (firesImmediately) recordAlert('fired', { severity: rule.severity });
-        else pendingOpened++;
-        continue;
-      }
+      // ---- not breaching ----
+      if (!existing) continue;
 
       if (existing.status === 'pending') {
-        const elapsedMs = state.lastObservedAt.getTime() - toDate(existing.breached_since).getTime();
-
-        if (elapsedMs >= (rule.for_duration_seconds ?? 0) * 1000) {
-          push(
-            {
-              updateOne: {
-                filter: {
-                  _id: existing._id,
-                  status: 'pending',
-                  last_observed_at: { $lt: state.lastObservedAt },
-                },
-                update: {
-                  $set: {
-                    status: 'firing',
-                    fired_at: now,
-                    last_value: state.lastValue,
-                    'audit.updated_at': now,
-                    'audit.updated_by': 'system',
-                  },
-                  $max: { last_observed_at: state.lastObservedAt },
-                },
-              },
-            },
-            { kind: 'fired', alert: toFiredAlert(existing._id, rule, device, state, now) }
-          );
-          recordAlert('fired', { severity: rule.severity });
-        } else
-          push({
-            updateOne: {
-              filter: { _id: existing._id, last_observed_at: { $lt: state.lastObservedAt } },
-              update: {
-                $set: { last_value: state.lastValue, 'audit.updated_at': now },
-                $max: { last_observed_at: state.lastObservedAt },
-              },
-            },
-          });
+        // An episode that never fired is not history, and keeping them would let a
+        // flapping sensor fill the collection.
+        push({ deleteOne: { filter: { _id: existing._id, status: 'pending' } } });
         continue;
       }
 
-      // firing or acknowledged: refresh the observation, do not re-fire.
-      push({
-        updateOne: {
-          filter: { _id: existing._id, last_observed_at: { $lt: state.lastObservedAt } },
-          update: {
-            $set: { last_value: state.lastValue, 'audit.updated_at': now },
-            $max: { last_observed_at: state.lastObservedAt },
-          },
-        },
-      });
-      continue;
-    }
-
-    // ---- not breaching ----
-    if (!existing) continue;
-
-    if (existing.status === 'pending') {
-      // An episode that never fired is not history, and keeping them would let a
-      // flapping sensor fill the collection.
-      push({ deleteOne: { filter: { _id: existing._id, status: 'pending' } } });
-      pendingCleared++;
-      continue;
-    }
-
-    push(
-      {
-        updateOne: {
-          filter: {
-            _id: existing._id,
-            is_open: true,
-            last_observed_at: { $lt: state.lastObservedAt },
-          },
-          update: {
-            $set: {
-              status: 'resolved',
-              is_open: false,
-              last_value: state.lastValue,
-              resolved_value: state.lastValue,
-              'audit.updated_at': now,
-              'audit.updated_by': 'system',
-              'audit.resolved_at': now,
-              'audit.resolved_by': 'system',
-              'audit.resolution': 'auto',
+      push(
+        {
+          updateOne: {
+            filter: {
+              _id: existing._id,
+              is_open: true,
+              last_observed_at: { $lt: state.lastObservedAt },
             },
-            $max: { last_observed_at: state.lastObservedAt },
+            update: {
+              $set: {
+                status: 'resolved',
+                is_open: false,
+                last_value: state.lastValue,
+                resolved_value: state.lastValue,
+                'audit.updated_at': now,
+                'audit.updated_by': 'system',
+                'audit.resolved_at': now,
+                'audit.resolved_by': 'system',
+                'audit.resolution': 'auto',
+              },
+              $max: { last_observed_at: state.lastObservedAt },
+            },
           },
         },
-      },
-      {
-        kind: 'resolved',
-        alert: {
-          _id: String(existing._id),
-          rule_id: String(existing.rule_id),
-          device_id: existing.device_id,
-          severity: existing.severity,
-          resolution: 'auto',
-          resolved_at: now.toISOString(),
-          actor: 'system',
-        },
-      }
-    );
-    recordAlert('resolved', { resolution: 'auto' });
-  }
-
-  // ---- Step 7: one bulk write ----
-  const failedIndices = new Set<number>();
-
-  if (ops.length > 0)
-    try {
-      await AlertV2.bulkWrite(ops, { ordered: false });
-    } catch (err) {
-      const writeErrors = extractWriteErrors(err);
-      const unexpected = writeErrors.filter(e => e.code !== DUPLICATE_KEY_CODE);
-
-      // Only E11000 is absorbed. Without this filter a genuine write failure
-      // would vanish into the same silent path as a benign race, and
-      // alert_evaluation_errors_total would stop being a trustworthy signal.
-      if (unexpected.length > 0 || writeErrors.length === 0) throw err;
-
-      // Every error was a duplicate open episode: another request won the race,
-      // which is the desired end state either way.
-      for (const e of writeErrors) failedIndices.add(e.index);
+        {
+          kind: 'resolved',
+          alert: {
+            _id: String(existing._id),
+            rule_id: String(existing.rule_id),
+            device_id: existing.device_id,
+            severity: existing.severity,
+            resolution: 'auto',
+            resolved_at: now.toISOString(),
+            actor: 'system',
+          },
+          confirmId: existing._id,
+        }
+      );
     }
 
-  const result = emptyEvaluationResult();
-  result.pendingOpened = pendingOpened;
-  result.pendingCleared = pendingCleared;
-  result.suppressed = suppressed;
-  result.evaluatedPairs = pairs.size;
+    // ---- Step 7: one bulk write ----
+    const failedIndices = new Set<number>();
+    // The only deleteOne ops are pending clears, and each is guarded on
+    // `status: 'pending'` — fewer can delete than were queued, so the count comes
+    // from the driver rather than from the loop above.
+    let deletedCount = 0;
 
-  for (let i = 0; i < notifications.length; i++) {
-    const notification = notifications[i];
-    if (!notification || failedIndices.has(i)) continue;
-    if (notification.kind === 'fired') result.fired.push(notification.alert);
-    else result.resolved.push(notification.alert);
+    if (ops.length > 0)
+      try {
+        deletedCount = (await AlertV2.bulkWrite(ops, { ordered: false })).deletedCount;
+      } catch (err) {
+        const writeErrors = extractWriteErrors(err);
+        const unexpected = writeErrors.filter(e => e.code !== DUPLICATE_KEY_CODE);
+
+        // Only E11000 is absorbed. Without this filter a genuine write failure
+        // would vanish into the same silent path as a benign race, and
+        // alert_evaluation_errors_total would stop being a trustworthy signal.
+        if (unexpected.length > 0 || writeErrors.length === 0) throw err;
+
+        // Every error was a duplicate open episode: another request won the race,
+        // which is the desired end state either way.
+        for (const e of writeErrors) failedIndices.add(e.index);
+
+        // `ordered: false` still ran every other op, so deletes queued alongside
+        // the duplicate landed; the driver carries their count on the error.
+        deletedCount = (err as { deletedCount?: number }).deletedCount ?? 0;
+      }
+
+    // ---- Step 8: confirm the guarded updates against what actually matched ----
+    //
+    // A guarded updateOne matching ZERO documents is a driver success, and
+    // BulkWriteResult reports aggregate counts, not per-op match status. Every op
+    // in THIS run stamps `audit.updated_at` with the same `now`, so one follow-up
+    // query returns exactly the ops that matched. Silent refresh ops carry no
+    // notification and are left out of it — one extra query per evaluation, never
+    // one per pair.
+    const notifiedUpdateIds: Types.ObjectId[] = [];
+    for (const candidate of notificationCandidates)
+      if (candidate?.confirmId) notifiedUpdateIds.push(candidate.confirmId);
+
+    const confirmedUpdateIds = new Set<string>();
+    if (notifiedUpdateIds.length > 0) {
+      const confirmed = await AlertV2.find({
+        _id: { $in: notifiedUpdateIds },
+        'audit.updated_at': now,
+      })
+        .select({ _id: 1 })
+        .lean<{ _id: Types.ObjectId }[]>();
+      for (const doc of confirmed) confirmedUpdateIds.add(String(doc._id));
+    }
+
+    const result = emptyEvaluationResult();
+    result.pendingOpened = pendingOpened;
+    result.pendingCleared = deletedCount;
+    result.suppressed = suppressed;
+    result.evaluatedPairs = pairs.size;
+
+    // Notifications and their counters are emitted here, from confirmed outcomes
+    // only — an episode that did not transition must not page anyone.
+    for (let i = 0; i < notificationCandidates.length; i++) {
+      const candidate = notificationCandidates[i];
+      if (!candidate) continue;
+
+      const landed = candidate.confirmId
+        ? confirmedUpdateIds.has(String(candidate.confirmId))
+        : !failedIndices.has(i);
+      if (!landed) continue;
+
+      if (candidate.kind === 'fired') {
+        result.fired.push(candidate.alert);
+        recordAlert('fired', { severity: candidate.alert.severity });
+      } else {
+        result.resolved.push(candidate.alert);
+        recordAlert('resolved', { resolution: candidate.alert.resolution });
+      }
+    }
+
+    return result;
+  } finally {
+    // Every exit path: the early returns above, a normal return, and a rethrown
+    // bulk write error. An evaluation that threw still spent the time.
+    recordAlertEvaluationDuration(Date.now() - started);
   }
-
-  recordAlertEvaluationDuration(Date.now() - started);
-  return result;
 }

--- a/lib/alerting/evaluate.ts
+++ b/lib/alerting/evaluate.ts
@@ -511,21 +511,39 @@ export async function evaluateReadings(
     // ---- Step 8: confirm the guarded updates against what actually matched ----
     //
     // A guarded updateOne matching ZERO documents is a driver success, and
-    // BulkWriteResult reports aggregate counts, not per-op match status. Every op
-    // in THIS run stamps `audit.updated_at` with the same `now`, so one follow-up
-    // query returns exactly the ops that matched. Silent refresh ops carry no
-    // notification and are left out of it — one extra query per evaluation, never
-    // one per pair.
-    const notifiedUpdateIds: Types.ObjectId[] = [];
-    for (const candidate of notificationCandidates)
-      if (candidate?.confirmId) notifiedUpdateIds.push(candidate.confirmId);
+    // BulkWriteResult reports aggregate counts, not per-op match status.
+    //
+    // House rule: a write-confirmation predicate must key on a field that
+    // ONLY the confirming operation sets. `audit.updated_at` fails that rule
+    // here — every op in this run stamps it, including the silent
+    // observation-refresh updates above (still-breaching-but-not-due-yet,
+    // and firing/acknowledged refresh) — and so does a CONCURRENT evaluator
+    // whose own `now` lands in the same millisecond. Two requests can read
+    // the same pending episode; the loser's guarded update then matches zero
+    // rows, but if its `now` happens to equal the winner's, confirming on
+    // `audit.updated_at` alone would still match and emit a second
+    // notification for one transition. A promotion writes `fired_at`; an
+    // auto-resolve writes `audit.resolved_at` — nothing else touches either
+    // field, so confirming each candidate kind against its own field proves
+    // ITS op landed rather than merely that SOME write touched the document
+    // at this instant. Mirrors sweep.ts's resolve reconciliation, which
+    // already confirms on `audit.resolved_at` alone for exactly this reason.
+    const promotedIds: Types.ObjectId[] = [];
+    const resolvedIds: Types.ObjectId[] = [];
+    for (const candidate of notificationCandidates) {
+      if (!candidate?.confirmId) continue;
+      if (candidate.kind === 'fired') promotedIds.push(candidate.confirmId);
+      else resolvedIds.push(candidate.confirmId);
+    }
 
     const confirmedUpdateIds = new Set<string>();
-    if (notifiedUpdateIds.length > 0) {
-      const confirmed = await AlertV2.find({
-        _id: { $in: notifiedUpdateIds },
-        'audit.updated_at': now,
-      })
+    if (promotedIds.length > 0 || resolvedIds.length > 0) {
+      const confirmOr: Record<string, unknown>[] = [];
+      if (promotedIds.length > 0) confirmOr.push({ _id: { $in: promotedIds }, fired_at: now });
+      if (resolvedIds.length > 0)
+        confirmOr.push({ _id: { $in: resolvedIds }, 'audit.resolved_at': now });
+
+      const confirmed = await AlertV2.find({ $or: confirmOr })
         .select({ _id: 1 })
         .lean<{ _id: Types.ObjectId }[]>();
       for (const doc of confirmed) confirmedUpdateIds.add(String(doc._id));

--- a/lib/alerting/evaluate.ts
+++ b/lib/alerting/evaluate.ts
@@ -193,7 +193,31 @@ export async function evaluateReadings(
       if (!device) continue;
 
       const ts = toDate(reading.timestamp ?? new Date());
-      const rules = byType.get(type) ?? [];
+
+      // NOT `byType.get(type) ?? []`. Every legal reading type has a bucket
+      // (possibly empty), guaranteed at compile time by the exhaustiveness
+      // assertions on `READING_TYPES` in models/v2/AlertRuleV2.ts. So a MISS
+      // here does not mean "no rules for this type" — it means the reading's
+      // stored type is not a legal reading type at all: bad data, a stale
+      // cache entry, a hand-edited document. The `?? []` turned that into zero
+      // rules with no error, no log and no metric, so every rule that should
+      // have covered the reading silently did not run. Same dedup set as
+      // `skipRule`, keyed by the type rather than a rule id (rule ids are
+      // 24-hex, so the `type::` prefix cannot collide): a bad type on every
+      // reading of a 10,000-reading batch is one log line, not 10,000.
+      const rules = byType.get(type);
+      if (!rules) {
+        const skipKey = `type::${type}`;
+        if (!reportedSkips.has(skipKey)) {
+          reportedSkips.add(skipKey);
+          recordAlertRuleSkipped('unexpected_error');
+          logger.warn('Readings skipped: no alert rule bucket for reading type', {
+            type: String(type),
+            deviceId,
+          });
+        }
+        continue;
+      }
 
       for (const rule of rules) {
         const validation = validateRule(rule);

--- a/lib/alerting/evaluate.ts
+++ b/lib/alerting/evaluate.ts
@@ -16,7 +16,13 @@
 
 import { Types, type AnyBulkWriteOperation } from 'mongoose';
 import AlertV2, { type IAlertV2 } from '@/models/v2/AlertV2';
-import { recordAlert, recordAlertEvaluationDuration } from '@/lib/monitoring';
+import {
+  logger,
+  recordAlert,
+  recordAlertEvaluationDuration,
+  recordAlertRuleSkipped,
+  type AlertRuleSkipReason,
+} from '@/lib/monitoring';
 import { getRuleBuckets } from './rule-cache';
 import { METRIC_ACCESSORS, compare, matchesSelector } from './selector';
 import {
@@ -34,6 +40,8 @@ const DUPLICATE_KEY_CODE = 11000;
 interface PairState {
   rule: CachedAlertRule;
   device: EvaluableDevice;
+  /** `rule._id` pre-parsed at pair-creation time, once the rule has passed validation. */
+  ruleObjectId: Types.ObjectId;
   breaching: boolean;
   /** Metric value of the EARLIEST breaching reading. */
   triggerValue?: number;
@@ -43,6 +51,12 @@ interface PairState {
   lastValue: number;
   /** Timestamp of the LATEST reading overall. */
   lastObservedAt: Date;
+}
+
+/** What a rule needs to resolve to before it can be matched or written. */
+interface RuleValidation {
+  accessor: (r: EvaluableReading) => number | undefined;
+  ruleObjectId: Types.ObjectId;
 }
 
 /**
@@ -121,6 +135,55 @@ export async function evaluateReadings(
     const pairs = new Map<string, PairState>();
     let maxCooldownSeconds = 0;
 
+    // A rule reaches this call from a `.lean()` read or a Redis JSON round trip,
+    // neither of which re-validates: `rule.metric` can be any string, and
+    // `rule._id` can be anything a seed script, migration, or stale cache entry
+    // wrote. Two per-call caches, both keyed by rule id, keep a bad rule from
+    // costing every other rule its share of the batch without flooding the log:
+    //   - `ruleValidationCache` memoizes the metric-accessor and rule-id checks,
+    //     so a rule bucketed under several reading types is validated once, not
+    //     once per type.
+    //   - `reportedSkips` gates `skipRule` itself. This is the one that actually
+    //     caps logging/counting at once per call — it also covers a rule that
+    //     PASSES validateRule but whose matching throws on every reading (e.g. a
+    //     malformed selector), which `ruleValidationCache` has no opinion on.
+    const ruleValidationCache = new Map<string, RuleValidation | null>();
+    const reportedSkips = new Set<string>();
+
+    const skipRule = (rule: CachedAlertRule, error: unknown, reason: AlertRuleSkipReason) => {
+      if (reportedSkips.has(rule._id)) return; // already logged and counted this call
+      reportedSkips.add(rule._id);
+      recordAlertRuleSkipped(reason);
+      logger.error('Alert rule skipped during evaluation', {
+        ruleId: rule._id,
+        ruleName: rule.name,
+        metric: rule.metric,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    };
+
+    const validateRule = (rule: CachedAlertRule): RuleValidation | null => {
+      const cached = ruleValidationCache.get(rule._id);
+      if (cached !== undefined) return cached;
+
+      const accessor = METRIC_ACCESSORS[rule.metric];
+      if (typeof accessor !== 'function') {
+        skipRule(rule, new Error(`Unknown alert metric "${rule.metric}"`), 'unknown_metric');
+        ruleValidationCache.set(rule._id, null);
+        return null;
+      }
+
+      if (!Types.ObjectId.isValid(rule._id)) {
+        skipRule(rule, new Error(`Invalid alert rule id "${rule._id}"`), 'invalid_rule_id');
+        ruleValidationCache.set(rule._id, null);
+        return null;
+      }
+
+      const result: RuleValidation = { accessor, ruleObjectId: new Types.ObjectId(rule._id) };
+      ruleValidationCache.set(rule._id, result);
+      return result;
+    };
+
     for (const reading of readings) {
       const deviceId = reading.metadata?.device_id;
       const type = reading.metadata?.type;
@@ -133,9 +196,21 @@ export async function evaluateReadings(
       const rules = byType.get(type) ?? [];
 
       for (const rule of rules) {
-        if (!matchesSelector(device, rule.selector)) continue;
+        const validation = validateRule(rule);
+        if (!validation) continue;
 
-        const metricValue = METRIC_ACCESSORS[rule.metric](reading);
+        // Matching or metric extraction on a validated rule can still throw —
+        // e.g. a malformed `selector.tags` written outside the Zod layer. One
+        // bad rule must not cost every other rule its share of this batch.
+        let metricValue: number | undefined;
+        try {
+          if (!matchesSelector(device, rule.selector)) continue;
+          metricValue = validation.accessor(reading);
+        } catch (error) {
+          skipRule(rule, error, 'unexpected_error');
+          continue;
+        }
+
         if (metricValue === undefined || metricValue === null || Number.isNaN(metricValue))
           continue;
 
@@ -149,6 +224,7 @@ export async function evaluateReadings(
           pairs.set(key, {
             rule,
             device,
+            ruleObjectId: validation.ruleObjectId,
             breaching: breaches,
             triggerValue: breaches ? metricValue : undefined,
             breachedSince: breaches ? ts : undefined,
@@ -176,9 +252,14 @@ export async function evaluateReadings(
     if (pairs.size === 0) return emptyEvaluationResult();
 
     // ---- Steps 4-5: two queries ----
-    const ruleObjectIds = [...new Set([...pairs.values()].map(p => p.rule._id))].map(
-      id => new Types.ObjectId(id)
-    );
+    //
+    // Every pair's rule already passed validateRule, so its ruleObjectId is
+    // known-good — reuse it here (and at the insertOne below) rather than
+    // re-parsing rule._id, which is where a malformed rule id used to throw and
+    // take the whole batch down with it.
+    const ruleObjectIds = [
+      ...new Map([...pairs.values()].map(p => [p.rule._id, p.ruleObjectId])).values(),
+    ];
     const deviceIds = [...new Set([...pairs.values()].map(p => String(p.device._id)))];
 
     const openEpisodes = await AlertV2.find({
@@ -252,7 +333,7 @@ export async function evaluateReadings(
               insertOne: {
                 document: {
                   _id,
-                  rule_id: new Types.ObjectId(rule._id),
+                  rule_id: state.ruleObjectId,
                   rule_name: rule.name,
                   device_id: String(device._id),
                   status: firesImmediately ? 'firing' : 'pending',

--- a/lib/alerting/index.ts
+++ b/lib/alerting/index.ts
@@ -16,7 +16,7 @@
  * This mirrors the existing treatment of the Pusher trigger in the simulate route.
  */
 
-import { logger, recordAlert } from '@/lib/monitoring';
+import { logger, recordAlert, captureException } from '@/lib/monitoring';
 import { evaluateReadings } from './evaluate';
 import { sweepStaleAlerts, type SweepResult } from './sweep';
 import { emptyEvaluationResult, type EvaluableDevice, type EvaluableReading, type EvaluationResult } from './types';
@@ -26,6 +26,29 @@ export { sweepStaleAlerts, STALE_AFTER_SECONDS, type SweepResult } from './sweep
 export { matchesSelector, compare, METRIC_ACCESSORS } from './selector';
 export { getRuleBuckets, loadActiveRules, buildRuleBuckets } from './rule-cache';
 export type { EvaluableDevice, EvaluableReading, EvaluationResult, CachedAlertRule } from './types';
+
+/**
+ * Forward a swallowed alerting failure to Sentry. `logger.error` only ever
+ * reaches a console line (see lib/monitoring/logger.ts), and the
+ * `evaluation_error` counter these callers also record (see recordAlert
+ * below) resets on every serverless cold start — this call is what actually
+ * makes a silently broken evaluator visible in production.
+ *
+ * Guarded on its own: captureException() is a no-op when Sentry isn't
+ * configured (see lib/monitoring/sentry.ts), but this function must tolerate
+ * it throwing anyway — a misbehaving Sentry SDK must never turn an
+ * already-handled evaluator error into an unhandled one and defeat the very
+ * isolation these callers provide.
+ */
+function reportToSentry(error: unknown): void {
+  try {
+    captureException(error instanceof Error ? error : new Error(String(error)), {
+      tags: { subsystem: 'alerting' },
+    });
+  } catch {
+    // Deliberately swallowed — see doc comment above.
+  }
+}
 
 export async function safeEvaluateReadings(
   readings: EvaluableReading[],
@@ -41,6 +64,7 @@ export async function safeEvaluateReadings(
       error: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     });
+    reportToSentry(error);
     return emptyEvaluationResult();
   }
 }
@@ -56,6 +80,7 @@ export async function safeSweepStaleAlerts(
       reportingDeviceCount: reportingDeviceIds.size,
       error: error instanceof Error ? error.message : String(error),
     });
+    reportToSentry(error);
     return { deleted: 0, resolved: [] };
   }
 }

--- a/lib/alerting/index.ts
+++ b/lib/alerting/index.ts
@@ -14,6 +14,17 @@
  *      their contract.
  *
  * This mirrors the existing treatment of the Pusher trigger in the simulate route.
+ *
+ * The Pusher broadcast (publishAlertEvents, Task 13) runs AFTER
+ * evaluateReadings()/sweepStaleAlerts() inside (2)'s try, but in its OWN nested
+ * try/catch — never (2)'s catch clause. A throw from the broadcast path
+ * (envelope math, or a Pusher failure notify.ts's own internal try/catch didn't
+ * already absorb) is swallowed right where it happens. If it shared (2)'s catch,
+ * it would reach `recordAlert('evaluation_error')` and mislabel a successful
+ * evaluation as failed, and `return emptyEvaluationResult()` /
+ * `return { deleted: 0, resolved: [] }` would discard a fired/resolved result
+ * that had already committed to the database — exactly the failure mode (2)
+ * exists to prevent, just for the broadcast instead of the DB write.
  */
 
 import { logger, recordAlert, captureException } from '@/lib/monitoring';
@@ -61,7 +72,13 @@ export async function safeEvaluateReadings(
 ): Promise<EvaluationResult> {
   try {
     const result = await evaluateReadings(readings, devices);
-    await publishAlertEvents(result.fired, result.resolved);
+    try {
+      await publishAlertEvents(result.fired, result.resolved);
+    } catch {
+      // trigger() already logs internally; this is belt-and-suspenders so a
+      // broadcast fault can never discard a committed evaluation result or
+      // reach the catch below, which would mislabel it as evaluation_error.
+    }
     return result;
   } catch (error) {
     recordAlert('evaluation_error');
@@ -81,7 +98,13 @@ export async function safeSweepStaleAlerts(
 ): Promise<SweepResult> {
   try {
     const result = await sweepStaleAlerts(reportingDeviceIds);
-    await publishAlertEvents([], result.resolved);
+    try {
+      await publishAlertEvents([], result.resolved);
+    } catch {
+      // trigger() already logs internally; this is belt-and-suspenders so a
+      // broadcast fault can never discard a committed sweep result or reach
+      // the catch below, which would mislabel it as evaluation_error.
+    }
     return result;
   } catch (error) {
     recordAlert('evaluation_error');

--- a/lib/alerting/index.ts
+++ b/lib/alerting/index.ts
@@ -18,6 +18,7 @@
 
 import { logger, recordAlert, captureException } from '@/lib/monitoring';
 import { evaluateReadings } from './evaluate';
+import { publishAlertEvents } from './notify';
 import { sweepStaleAlerts, type SweepResult } from './sweep';
 import { emptyEvaluationResult, type EvaluableDevice, type EvaluableReading, type EvaluationResult } from './types';
 
@@ -25,6 +26,7 @@ export { evaluateReadings } from './evaluate';
 export { sweepStaleAlerts, STALE_AFTER_SECONDS, type SweepResult } from './sweep';
 export { matchesSelector, compare, METRIC_ACCESSORS } from './selector';
 export { getRuleBuckets, loadActiveRules, buildRuleBuckets } from './rule-cache';
+export { publishAlertEvents, ALERT_EVENT_NAME, ALERT_EVENT_MAX, ALERT_EVENT_MAX_BYTES } from './notify';
 export type { EvaluableDevice, EvaluableReading, EvaluationResult, CachedAlertRule } from './types';
 
 /**
@@ -58,7 +60,9 @@ export async function safeEvaluateReadings(
   devices: EvaluableDevice[]
 ): Promise<EvaluationResult> {
   try {
-    return await evaluateReadings(readings, devices);
+    const result = await evaluateReadings(readings, devices);
+    await publishAlertEvents(result.fired, result.resolved);
+    return result;
   } catch (error) {
     recordAlert('evaluation_error');
     logger.error('Alert evaluation failed after a committed write', {
@@ -76,7 +80,9 @@ export async function safeSweepStaleAlerts(
   reportingDeviceIds: Set<string>
 ): Promise<SweepResult> {
   try {
-    return await sweepStaleAlerts(reportingDeviceIds);
+    const result = await sweepStaleAlerts(reportingDeviceIds);
+    await publishAlertEvents([], result.resolved);
+    return result;
   } catch (error) {
     recordAlert('evaluation_error');
     logger.error('Alert staleness sweep failed', {

--- a/lib/alerting/index.ts
+++ b/lib/alerting/index.ts
@@ -38,7 +38,13 @@ export { sweepStaleAlerts, STALE_AFTER_SECONDS, type SweepResult } from './sweep
 export { matchesSelector, compare, METRIC_ACCESSORS } from './selector';
 export { getRuleBuckets, loadActiveRules, buildRuleBuckets } from './rule-cache';
 export { publishAlertEvents, ALERT_EVENT_NAME, ALERT_EVENT_MAX, ALERT_EVENT_MAX_BYTES } from './notify';
-export { redactAuditForDemo } from './redact';
+export {
+  redactAuditForDemo,
+  jsonRedacted,
+  jsonRedactedPaginated,
+  extendRedacted,
+  type Redacted,
+} from './redact';
 export type { EvaluableDevice, EvaluableReading, EvaluationResult, CachedAlertRule } from './types';
 
 /**

--- a/lib/alerting/index.ts
+++ b/lib/alerting/index.ts
@@ -1,0 +1,61 @@
+/**
+ * Public alerting surface.
+ *
+ * Both write paths call the `safe*` wrappers, never the raw functions. Issue #97
+ * requires that evaluation failures never drop readings; three properties
+ * guarantee it:
+ *
+ *   1. Evaluation runs strictly AFTER insertMany has committed. There is no path
+ *      by which it can roll back an insert.
+ *   2. The call is wrapped here in its own try/catch. Errors are logged and
+ *      counted; they never propagate to withErrorHandler and never change the
+ *      response status.
+ *   3. Route response bodies report insert results only. Alerting is not part of
+ *      their contract.
+ *
+ * This mirrors the existing treatment of the Pusher trigger in the simulate route.
+ */
+
+import { logger, recordAlert } from '@/lib/monitoring';
+import { evaluateReadings } from './evaluate';
+import { sweepStaleAlerts, type SweepResult } from './sweep';
+import { emptyEvaluationResult, type EvaluableDevice, type EvaluableReading, type EvaluationResult } from './types';
+
+export { evaluateReadings } from './evaluate';
+export { sweepStaleAlerts, STALE_AFTER_SECONDS, type SweepResult } from './sweep';
+export { matchesSelector, compare, METRIC_ACCESSORS } from './selector';
+export { getRuleBuckets, loadActiveRules, buildRuleBuckets } from './rule-cache';
+export type { EvaluableDevice, EvaluableReading, EvaluationResult, CachedAlertRule } from './types';
+
+export async function safeEvaluateReadings(
+  readings: EvaluableReading[],
+  devices: EvaluableDevice[]
+): Promise<EvaluationResult> {
+  try {
+    return await evaluateReadings(readings, devices);
+  } catch (error) {
+    recordAlert('evaluation_error');
+    logger.error('Alert evaluation failed after a committed write', {
+      readingsCount: readings.length,
+      deviceCount: devices.length,
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    return emptyEvaluationResult();
+  }
+}
+
+export async function safeSweepStaleAlerts(
+  reportingDeviceIds: Set<string>
+): Promise<SweepResult> {
+  try {
+    return await sweepStaleAlerts(reportingDeviceIds);
+  } catch (error) {
+    recordAlert('evaluation_error');
+    logger.error('Alert staleness sweep failed', {
+      reportingDeviceCount: reportingDeviceIds.size,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { deleted: 0, resolved: [] };
+  }
+}

--- a/lib/alerting/index.ts
+++ b/lib/alerting/index.ts
@@ -44,11 +44,20 @@ export type { EvaluableDevice, EvaluableReading, EvaluationResult, CachedAlertRu
 /**
  * Forward a swallowed alerting failure to Sentry. `logger.error` only ever
  * reaches a console line (see lib/monitoring/logger.ts), and the
- * `evaluation_error` counter these callers also record (see recordAlert
- * below) resets on every serverless cold start — this call is what actually
- * makes a silently broken evaluator visible in production.
+ * `evaluation_error` counter these callers also record (see recordAlert in
+ * lib/monitoring/metrics.ts) is per-process memory that resets on every
+ * serverless cold start and is only readable through an admin-gated metrics
+ * endpoint — this call is what actually makes a silently broken evaluator
+ * visible in production.
  *
- * Guarded on its own: captureException() is a no-op when Sentry isn't
+ * That last sentence is load-bearing and was once false: captureException()
+ * used to be gated on a module-local flag set only by an initSentry() that
+ * production never called, so this escalation was dead code. It now routes to
+ * the `@sentry/nextjs` singleton that instrumentation.ts initializes, gated on
+ * SENTRY_DSN alone. If you ever make capturing depend on shim state again, this
+ * comment goes back to being a lie.
+ *
+ * Guarded on its own: captureException() is still a no-op when Sentry isn't
  * configured (see lib/monitoring/sentry.ts), but this function must tolerate
  * it throwing anyway — a misbehaving Sentry SDK must never turn an
  * already-handled evaluator error into an unhandled one and defeat the very

--- a/lib/alerting/index.ts
+++ b/lib/alerting/index.ts
@@ -74,10 +74,13 @@ export async function safeEvaluateReadings(
     const result = await evaluateReadings(readings, devices);
     try {
       await publishAlertEvents(result.fired, result.resolved);
-    } catch {
-      // trigger() already logs internally; this is belt-and-suspenders so a
-      // broadcast fault can never discard a committed evaluation result or
-      // reach the catch below, which would mislabel it as evaluation_error.
+    } catch (error) {
+      // Never let a broadcast fault discard an evaluation the DB already
+      // committed — but never let it vanish silently either.
+      logger.error('Alert broadcast failed after a committed write', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      reportToSentry(error);
     }
     return result;
   } catch (error) {
@@ -100,10 +103,13 @@ export async function safeSweepStaleAlerts(
     const result = await sweepStaleAlerts(reportingDeviceIds);
     try {
       await publishAlertEvents([], result.resolved);
-    } catch {
-      // trigger() already logs internally; this is belt-and-suspenders so a
-      // broadcast fault can never discard a committed sweep result or reach
-      // the catch below, which would mislabel it as evaluation_error.
+    } catch (error) {
+      // Never let a broadcast fault discard an evaluation the DB already
+      // committed — but never let it vanish silently either.
+      logger.error('Alert broadcast failed after a committed write', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      reportToSentry(error);
     }
     return result;
   } catch (error) {

--- a/lib/alerting/index.ts
+++ b/lib/alerting/index.ts
@@ -42,8 +42,11 @@ export type { EvaluableDevice, EvaluableReading, EvaluationResult, CachedAlertRu
  */
 function reportToSentry(error: unknown): void {
   try {
-    captureException(error instanceof Error ? error : new Error(String(error)), {
-      tags: { subsystem: 'alerting' },
+    // `{ subsystem: 'alerting' }` goes in the THIRD argument (Sentry tags — an
+    // indexed, filterable facet), not the second (context/"Additional Data").
+    // Passing it as context would silently stop working as a triage classifier.
+    captureException(error instanceof Error ? error : new Error(String(error)), undefined, {
+      subsystem: 'alerting',
     });
   } catch {
     // Deliberately swallowed — see doc comment above.

--- a/lib/alerting/index.ts
+++ b/lib/alerting/index.ts
@@ -38,6 +38,7 @@ export { sweepStaleAlerts, STALE_AFTER_SECONDS, type SweepResult } from './sweep
 export { matchesSelector, compare, METRIC_ACCESSORS } from './selector';
 export { getRuleBuckets, loadActiveRules, buildRuleBuckets } from './rule-cache';
 export { publishAlertEvents, ALERT_EVENT_NAME, ALERT_EVENT_MAX, ALERT_EVENT_MAX_BYTES } from './notify';
+export { redactAuditForDemo } from './redact';
 export type { EvaluableDevice, EvaluableReading, EvaluationResult, CachedAlertRule } from './types';
 
 /**

--- a/lib/alerting/notify.ts
+++ b/lib/alerting/notify.ts
@@ -38,7 +38,7 @@ function timestampOf(alert: TimestampedAlert): string {
   return 'fired_at' in alert ? alert.fired_at : alert.resolved_at;
 }
 
-function stormEnvelope(alerts: TimestampedAlert[]): AlertEvent {
+function stormEnvelope(alerts: TimestampedAlert[], of: 'fired' | 'resolved'): AlertEvent {
   const by_severity: Record<AlertSeverity, number> = { info: 0, warning: 0, critical: 0 };
   for (const alert of alerts) by_severity[alert.severity]++;
 
@@ -46,24 +46,28 @@ function stormEnvelope(alerts: TimestampedAlert[]): AlertEvent {
     .map(timestampOf)
     .reduce((earliest, ts) => (ts < earliest ? ts : earliest), timestampOf(alerts[0]));
 
-  return { kind: 'storm', count: alerts.length, by_severity, since };
+  return { kind: 'storm', of, count: alerts.length, by_severity, since };
 }
 
-function bound(envelope: AlertEvent, alerts: TimestampedAlert[]): AlertEvent {
-  if (alerts.length > ALERT_EVENT_MAX) return stormEnvelope(alerts);
+function bound(
+  envelope: AlertEvent,
+  alerts: TimestampedAlert[],
+  of: 'fired' | 'resolved'
+): AlertEvent {
+  if (alerts.length > ALERT_EVENT_MAX) return stormEnvelope(alerts, of);
   if (Buffer.byteLength(JSON.stringify(envelope), 'utf8') > ALERT_EVENT_MAX_BYTES)
-    return stormEnvelope(alerts);
+    return stormEnvelope(alerts, of);
   return envelope;
 }
 
 export function buildFiredEnvelope(alerts: FiredAlert[]): AlertEvent | null {
   if (alerts.length === 0) return null;
-  return bound({ kind: 'fired', alerts }, alerts as unknown as TimestampedAlert[]);
+  return bound({ kind: 'fired', alerts }, alerts as unknown as TimestampedAlert[], 'fired');
 }
 
 export function buildResolvedEnvelope(alerts: ResolvedAlert[]): AlertEvent | null {
   if (alerts.length === 0) return null;
-  return bound({ kind: 'resolved', alerts }, alerts as unknown as TimestampedAlert[]);
+  return bound({ kind: 'resolved', alerts }, alerts as unknown as TimestampedAlert[], 'resolved');
 }
 
 async function trigger(envelope: AlertEvent | null): Promise<void> {

--- a/lib/alerting/notify.ts
+++ b/lib/alerting/notify.ts
@@ -13,9 +13,20 @@
 
 import { pusherServer } from '@/lib/pusher';
 import { logger } from '@/lib/monitoring';
+import { ALERT_CHANNEL } from '@/lib/pusher-channels';
 import type { AlertEvent, AlertSeverity, FiredAlert, ResolvedAlert } from '@/types/v2/alert.types';
 
-export const ALERT_CHANNEL = 'InfraSight';
+/**
+ * Re-exported so existing importers keep working. The name itself is defined in
+ * `lib/pusher-channels.ts` because the browser subscriber needs it too and
+ * cannot import this module (it reaches `lib/pusher`, which requires
+ * PUSHER_SECRET).
+ *
+ * Alerts do NOT share the readings channel. They are private: an alert payload
+ * names a rule, a device and the value that tripped it, which is exactly the
+ * operational detail an unauthenticated visitor must not receive.
+ */
+export { ALERT_CHANNEL };
 export const ALERT_EVENT_NAME = 'alert-event';
 
 /** Above this many alerts in one evaluation, degrade to an aggregate summary. */

--- a/lib/alerting/notify.ts
+++ b/lib/alerting/notify.ts
@@ -1,0 +1,90 @@
+/**
+ * Real-time alert delivery.
+ *
+ * All alert traffic arrives on ONE Pusher event name carrying a tagged envelope.
+ * PusherContext holds one callback set bound to one event name, so a subscriber
+ * receiving a bare array could not tell which event produced it — the tag lives
+ * in the payload rather than in a second event name.
+ *
+ * The payload is bounded twice, both required: Pusher caps a single event at
+ * 10 KB, and this module swallows Pusher failures, so an unbounded payload would
+ * mean the UI silently misses the single most dramatic event it exists to display.
+ */
+
+import { pusherServer } from '@/lib/pusher';
+import { logger } from '@/lib/monitoring';
+import type { AlertEvent, AlertSeverity, FiredAlert, ResolvedAlert } from '@/types/v2/alert.types';
+
+export const ALERT_CHANNEL = 'InfraSight';
+export const ALERT_EVENT_NAME = 'alert-event';
+
+/** Above this many alerts in one evaluation, degrade to an aggregate summary. */
+export const ALERT_EVENT_MAX = 20;
+
+/**
+ * Measured fallback. 20 alerts at roughly 200 bytes each is ~4 KB, inside
+ * Pusher's 10 KB limit with margin — but a long rule name can blow that, so the
+ * serialized body is measured before sending. Anything still over falls back to
+ * the storm event rather than being split, so ordering never matters.
+ */
+export const ALERT_EVENT_MAX_BYTES = 8 * 1024;
+
+type TimestampedAlert = { severity: AlertSeverity } & (
+  | { fired_at: string }
+  | { resolved_at: string }
+);
+
+function timestampOf(alert: TimestampedAlert): string {
+  return 'fired_at' in alert ? alert.fired_at : alert.resolved_at;
+}
+
+function stormEnvelope(alerts: TimestampedAlert[]): AlertEvent {
+  const by_severity: Record<AlertSeverity, number> = { info: 0, warning: 0, critical: 0 };
+  for (const alert of alerts) by_severity[alert.severity]++;
+
+  const since = alerts
+    .map(timestampOf)
+    .reduce((earliest, ts) => (ts < earliest ? ts : earliest), timestampOf(alerts[0]));
+
+  return { kind: 'storm', count: alerts.length, by_severity, since };
+}
+
+function bound(envelope: AlertEvent, alerts: TimestampedAlert[]): AlertEvent {
+  if (alerts.length > ALERT_EVENT_MAX) return stormEnvelope(alerts);
+  if (Buffer.byteLength(JSON.stringify(envelope), 'utf8') > ALERT_EVENT_MAX_BYTES)
+    return stormEnvelope(alerts);
+  return envelope;
+}
+
+export function buildFiredEnvelope(alerts: FiredAlert[]): AlertEvent | null {
+  if (alerts.length === 0) return null;
+  return bound({ kind: 'fired', alerts }, alerts as unknown as TimestampedAlert[]);
+}
+
+export function buildResolvedEnvelope(alerts: ResolvedAlert[]): AlertEvent | null {
+  if (alerts.length === 0) return null;
+  return bound({ kind: 'resolved', alerts }, alerts as unknown as TimestampedAlert[]);
+}
+
+async function trigger(envelope: AlertEvent | null): Promise<void> {
+  if (!envelope) return;
+
+  try {
+    await pusherServer.trigger(ALERT_CHANNEL, ALERT_EVENT_NAME, envelope);
+  } catch (error) {
+    // Never fail a committed write on a broadcast failure. Mirrors the existing
+    // treatment of the Pusher trigger in the simulate route.
+    logger.error('Pusher alert-event trigger failed', {
+      kind: envelope.kind,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export async function publishAlertEvents(
+  fired: FiredAlert[],
+  resolved: ResolvedAlert[]
+): Promise<void> {
+  await trigger(buildFiredEnvelope(fired));
+  await trigger(buildResolvedEnvelope(resolved));
+}

--- a/lib/alerting/redact.ts
+++ b/lib/alerting/redact.ts
@@ -1,0 +1,76 @@
+/**
+ * Demo-mode redaction for alert / alert-rule audit trails.
+ *
+ * `audit.created_by` / `updated_by` / `acknowledged_by` / `resolved_by` /
+ * `deleted_by` are written by `getAuditUser()` (lib/auth/index.ts), which
+ * resolves to the acting admin's Clerk EMAIL whenever one is on file — never
+ * just their user id. `requireOrgMembership()` grants an anonymous demo-mode
+ * visitor (see `isDemoCaller` in lib/auth) the same read access as a real org
+ * member, so without this step every GET on alerts/alert-rules would hand a
+ * stranger a real administrator's email address.
+ *
+ * This is deliberately narrower than the pre-existing fact that every other
+ * v2 GET also returns `audit.created_by` (etc.) to a demo reader — that is
+ * tracked separately and out of scope here. This module only covers the
+ * alert / alert-rule audit shape (see IAlertAudit / IAlertRuleAudit).
+ */
+
+const AUDIT_ACTOR_FIELDS = [
+  'created_by',
+  'updated_by',
+  'acknowledged_by',
+  'resolved_by',
+  'deleted_by',
+] as const;
+
+/** Stand-in that still tells a demo visitor a human acted, without naming one. */
+const REDACTED_ACTOR = 'an administrator';
+
+// Deliberately `object`, not `Record<string, unknown>`: the callers' real
+// audit types (IAlertAudit, IAlertRuleAudit) are concrete interfaces with no
+// index signature, so they are not structurally assignable to
+// `Record<string, unknown>` — that would make every call site fail to
+// type-check. `object` accepts them; the field-by-field access below is cast
+// internally instead, which is safe because it only ever replaces an
+// existing STRING field with another string.
+type WithAudit = { audit?: object | null };
+
+function redactAuditRecord<T extends WithAudit>(record: T): T {
+  if (!record?.audit) return record;
+
+  const audit: Record<string, unknown> = { ...(record.audit as Record<string, unknown>) };
+  let changed = false;
+  for (const field of AUDIT_ACTOR_FIELDS) {
+    const value = audit[field];
+    // 'system' (auto-fired, auto-resolved, or swept) never carries a real
+    // person's identity — leave it as-is so a demo visitor can still tell an
+    // event was automatic rather than performed by an admin.
+    if (typeof value === 'string' && value !== 'system') {
+      audit[field] = REDACTED_ACTOR;
+      changed = true;
+    }
+  }
+
+  // Preserve reference equality when nothing needed redacting, matching the
+  // "pass through untouched for a real caller" contract callers rely on.
+  // The cast back to T is safe: only existing string-valued fields were
+  // replaced with another string, so the concrete audit shape still holds.
+  return changed ? ({ ...record, audit } as T) : record;
+}
+
+/**
+ * Redact every actor field on one alert/alert-rule record — or every record
+ * in a list — whenever `isDemoCaller` is true. A no-op for a genuinely
+ * authenticated caller, returning the exact input reference unchanged.
+ */
+export function redactAuditForDemo<T extends WithAudit>(record: T, isDemoCaller: boolean): T;
+export function redactAuditForDemo<T extends WithAudit>(records: T[], isDemoCaller: boolean): T[];
+export function redactAuditForDemo<T extends WithAudit>(
+  recordOrRecords: T | T[],
+  isDemoCaller: boolean
+): T | T[] {
+  if (!isDemoCaller) return recordOrRecords;
+  return Array.isArray(recordOrRecords)
+    ? recordOrRecords.map(redactAuditRecord)
+    : redactAuditRecord(recordOrRecords);
+}

--- a/lib/alerting/redact.ts
+++ b/lib/alerting/redact.ts
@@ -15,6 +15,41 @@
  * alert / alert-rule audit shape (see IAlertAudit / IAlertRuleAudit).
  */
 
+import { jsonSuccess, jsonPaginated, type PaginationInfo } from '@/lib/api/response';
+
+// ============================================================================
+// THE MARKER — why redaction is a TYPE and not just a call
+// ============================================================================
+
+/**
+ * `redactAuditForDemo` used to be identity-typed: input type === output type,
+ * so a route that simply never called it looked exactly like a route that did.
+ * That is not hypothetical — within this PR `POST /alert-rules` and
+ * `PATCH /alert-rules` shipped without it while their siblings had it, and
+ * nothing but review caught the asymmetry.
+ *
+ * `Redacted<T>` is a phantom brand: it exists only in the type system (no
+ * runtime property is ever written, so serialization is untouched) and it is
+ * REQUIRED, not optional — an optional brand would make every `T` assignable
+ * to `Redacted<T>` and buy nothing. `Redacted<T>` stays assignable TO `T`, so
+ * downstream code that reads fields off a redacted record is unaffected.
+ *
+ * The enforcement point is `jsonRedacted` / `jsonRedactedPaginated` below: the
+ * four alert / alert-rule routes return through those instead of
+ * `jsonSuccess` / `jsonPaginated`, so skipping the redaction call is a compile
+ * error rather than a silent leak of an administrator's email address.
+ *
+ * Caveat worth knowing before you trust it blindly: `Redacted<any>` collapses
+ * to `any`. Both list endpoints have an `AlertV2.aggregate(...)` branch that is
+ * typed `any[]`, so on that one path the marker is inert. It still holds for
+ * every `.lean()` / `.toObject()` result, which is every single-record
+ * response and every mutation response.
+ */
+declare const RedactedBrand: unique symbol;
+
+/** A value that has been through `redactAuditForDemo`. See the note above. */
+export type Redacted<T> = T & { readonly [RedactedBrand]: true };
+
 const AUDIT_ACTOR_FIELDS = [
   'created_by',
   'updated_by',
@@ -62,15 +97,77 @@ function redactAuditRecord<T extends WithAudit>(record: T): T {
  * Redact every actor field on one alert/alert-rule record — or every record
  * in a list — whenever `isDemoCaller` is true. A no-op for a genuinely
  * authenticated caller, returning the exact input reference unchanged.
+ *
+ * Returns `Redacted<…>`, which is a compile-time marker only: the runtime
+ * value is byte-identical to what this function returned before the marker
+ * existed, reference equality included.
  */
-export function redactAuditForDemo<T extends WithAudit>(record: T, isDemoCaller: boolean): T;
-export function redactAuditForDemo<T extends WithAudit>(records: T[], isDemoCaller: boolean): T[];
+export function redactAuditForDemo<T extends WithAudit>(
+  record: T,
+  isDemoCaller: boolean
+): Redacted<T>;
+export function redactAuditForDemo<T extends WithAudit>(
+  records: T[],
+  isDemoCaller: boolean
+): Redacted<T[]>;
 export function redactAuditForDemo<T extends WithAudit>(
   recordOrRecords: T | T[],
   isDemoCaller: boolean
-): T | T[] {
-  if (!isDemoCaller) return recordOrRecords;
-  return Array.isArray(recordOrRecords)
-    ? recordOrRecords.map(redactAuditRecord)
-    : redactAuditRecord(recordOrRecords);
+): Redacted<T> | Redacted<T[]> {
+  if (!isDemoCaller) return recordOrRecords as Redacted<T> | Redacted<T[]>;
+  return (
+    Array.isArray(recordOrRecords)
+      ? recordOrRecords.map(redactAuditRecord)
+      : redactAuditRecord(recordOrRecords)
+  ) as Redacted<T> | Redacted<T[]>;
+}
+
+// ============================================================================
+// RESPONSE HELPERS THAT DEMAND THE MARKER
+// ============================================================================
+
+/**
+ * `jsonSuccess`, but it will only accept a record that went through
+ * `redactAuditForDemo`.
+ *
+ * Deliberately non-generic. `jsonRedacted<T>(data: Redacted<T>)` would ask
+ * TypeScript to infer `T` out of an intersection, which is exactly the kind of
+ * inference that quietly degrades to `unknown` and stops rejecting anything.
+ * The parameter type here is just "carries the brand", which is the whole
+ * property being enforced — the body is serialized, so nothing downstream
+ * needs the element type.
+ */
+export function jsonRedacted(data: Redacted<unknown>, message?: string, status = 200): Response {
+  return jsonSuccess(data, message, status);
+}
+
+/** `jsonPaginated`, but it will only accept a list that went through `redactAuditForDemo`. */
+export function jsonRedactedPaginated(
+  data: Redacted<unknown[]>,
+  pagination: PaginationInfo,
+  status = 200
+): Response {
+  return jsonPaginated(data, pagination, status);
+}
+
+/**
+ * Attach extra, non-audit fields to an already-redacted record, keeping the
+ * marker.
+ *
+ * Needed by `GET /api/v2/alerts/[id]?include_device=true`, which returns the
+ * alert plus a device projection. A bare `{ ...alert, device }` would be
+ * correct at runtime but the annotation the old code used
+ * (`Record<string, unknown>`) erased the marker, so `jsonRedacted` could not
+ * tell the difference between "redacted, then extended" and "never redacted".
+ *
+ * The `extra` object must not contain audit actor fields — this function does
+ * not redact, it only carries the marker forward. Today's one caller adds a
+ * device projection (`_id`, `serial_number`, `type`, `location`), none of
+ * which names a person.
+ */
+export function extendRedacted<T extends Redacted<unknown>, E extends object>(
+  record: T,
+  extra: E
+): Redacted<T & E> {
+  return { ...record, ...extra } as Redacted<T & E>;
 }

--- a/lib/alerting/rule-cache.ts
+++ b/lib/alerting/rule-cache.ts
@@ -1,0 +1,80 @@
+/**
+ * Active alert rule loading, caching, and type bucketing.
+ *
+ * The rule set is read on every write path and changes almost never, so it is
+ * cached with a short TTL and invalidated explicitly on every rule mutation.
+ */
+
+import AlertRuleV2, { READING_TYPES } from '@/models/v2/AlertRuleV2';
+import type { ReadingType } from '@/models/v2/ReadingV2';
+import { getOrSet } from '@/lib/cache/cache';
+import { alertRulesKey } from '@/lib/cache/keys';
+import type { CachedAlertRule } from './types';
+
+export const ALERT_RULE_CACHE_TTL_SECONDS = 60;
+
+export interface RuleBuckets {
+  /** Every one of the 15 reading types is present, possibly with an empty array. */
+  byType: Map<ReadingType, CachedAlertRule[]>;
+  /** The longest cooldown across all active rules — bounds the cooldown lookback. */
+  maxCooldownSeconds: number;
+  ruleCount: number;
+}
+
+/**
+ * Force `_id` to a string.
+ *
+ * MANDATORY. `getOrSet` stores through JSON.stringify, so a cache HIT yields a
+ * string `_id` while a cache MISS yields an ObjectId. Writing that straight into
+ * `AlertV2.rule_id` would produce documents whose `rule_id` type depends on cache
+ * state, and the partial unique index would silently stop deduplicating. The
+ * evaluator converts back with `new Types.ObjectId(rule._id)` at write time.
+ */
+export function normalizeRule(raw: unknown): CachedAlertRule {
+  const rule = raw as CachedAlertRule & { _id: unknown };
+  return { ...rule, _id: String(rule._id) };
+}
+
+export async function loadActiveRules(): Promise<CachedAlertRule[]> {
+  const rules = await getOrSet<unknown[]>(
+    alertRulesKey(),
+    async () =>
+      AlertRuleV2.find({
+        enabled: true,
+        'audit.deleted_at': { $exists: false },
+      }).lean(),
+    { ttl: ALERT_RULE_CACHE_TTL_SECONDS }
+  );
+
+  return rules.map(normalizeRule);
+}
+
+/**
+ * Group rules by the reading type they apply to.
+ *
+ * A type-less rule is appended to every bucket ONCE, at build time, so matching
+ * at evaluation stays O(readings x rules-for-that-type) rather than
+ * O(readings x all-rules).
+ */
+export function buildRuleBuckets(rules: CachedAlertRule[]): RuleBuckets {
+  const byType = new Map<ReadingType, CachedAlertRule[]>();
+  for (const type of READING_TYPES) byType.set(type as ReadingType, []);
+
+  let maxCooldownSeconds = 0;
+
+  for (const rule of rules) {
+    const targets = rule.selector?.types?.length
+      ? rule.selector.types
+      : (READING_TYPES as unknown as ReadingType[]);
+
+    for (const type of targets) byType.get(type as ReadingType)?.push(rule);
+
+    maxCooldownSeconds = Math.max(maxCooldownSeconds, rule.cooldown_seconds ?? 0);
+  }
+
+  return { byType, maxCooldownSeconds, ruleCount: rules.length };
+}
+
+export async function getRuleBuckets(): Promise<RuleBuckets> {
+  return buildRuleBuckets(await loadActiveRules());
+}

--- a/lib/alerting/rule-cache.ts
+++ b/lib/alerting/rule-cache.ts
@@ -22,10 +22,15 @@ import type { CachedAlertRule } from './types';
 export const ALERT_RULE_CACHE_TTL_SECONDS = 60;
 
 export interface RuleBuckets {
-  /** Every one of the 15 reading types is present, possibly with an empty array. */
+  /**
+   * Every one of the 15 reading types is present, possibly with an empty array.
+   *
+   * "Every one" is guaranteed by the exhaustiveness assertions on
+   * `READING_TYPES` (models/v2/AlertRuleV2.ts): a reading type added to
+   * `ReadingType` but not to that list is a `tsc` error, because a missing
+   * bucket here is invisible at runtime — see `bucketFor` below.
+   */
   byType: Map<ReadingType, CachedAlertRule[]>;
-  /** The longest cooldown across all active rules — bounds the cooldown lookback. */
-  maxCooldownSeconds: number;
   ruleCount: number;
 }
 
@@ -157,19 +162,34 @@ export function buildRuleBuckets(rules: CachedAlertRule[]): RuleBuckets {
   const byType = new Map<ReadingType, CachedAlertRule[]>();
   for (const type of READING_TYPES) byType.set(type as ReadingType, []);
 
-  let maxCooldownSeconds = 0;
-
   for (const rule of rules) {
     const targets = rule.selector?.types?.length
       ? rule.selector.types
       : (READING_TYPES as unknown as ReadingType[]);
 
-    for (const type of targets) byType.get(type as ReadingType)?.push(rule);
-
-    maxCooldownSeconds = Math.max(maxCooldownSeconds, rule.cooldown_seconds ?? 0);
+    for (const type of targets) {
+      // NOT `byType.get(type)?.push(rule)`. That optional chain dropped the
+      // rule for that type with no error, no metric and no log — the rule
+      // stayed Enabled in the UI and simply never fired. Reaching this branch
+      // means `selector.types` named a type that `READING_TYPES` has no bucket
+      // for, which `alertRuleSelectorSchema` (applied in `normalizeRule`)
+      // should already have rejected; if it ever happens the cause is a
+      // divergence between the two, and the operator needs to hear about it.
+      const bucket = byType.get(type as ReadingType);
+      if (!bucket) {
+        recordAlertRuleSkipped('unexpected_error');
+        logger.warn('Alert rule not bucketed: unknown reading type in selector.types', {
+          ruleId: rule._id,
+          ruleName: rule.name,
+          type: String(type),
+        });
+        continue;
+      }
+      bucket.push(rule);
+    }
   }
 
-  return { byType, maxCooldownSeconds, ruleCount: rules.length };
+  return { byType, ruleCount: rules.length };
 }
 
 export async function getRuleBuckets(): Promise<RuleBuckets> {

--- a/lib/alerting/rule-cache.ts
+++ b/lib/alerting/rule-cache.ts
@@ -5,10 +5,18 @@
  * cached with a short TTL and invalidated explicitly on every rule mutation.
  */
 
+import { z } from 'zod';
 import AlertRuleV2, { READING_TYPES } from '@/models/v2/AlertRuleV2';
 import type { ReadingType } from '@/models/v2/ReadingV2';
 import { getOrSet } from '@/lib/cache/cache';
 import { alertRulesKey } from '@/lib/cache/keys';
+import { logger, recordAlertRuleSkipped, type AlertRuleSkipReason } from '@/lib/monitoring';
+import {
+  alertComparisonSchema,
+  alertMetricSchema,
+  alertRuleSelectorSchema,
+  alertSeveritySchema,
+} from '@/lib/validations/v2/alert-rule.validation';
 import type { CachedAlertRule } from './types';
 
 export const ALERT_RULE_CACHE_TTL_SECONDS = 60;
@@ -22,17 +30,101 @@ export interface RuleBuckets {
 }
 
 /**
- * Force `_id` to a string.
+ * The shape the evaluator actually consumes, validated rather than asserted.
  *
- * MANDATORY. `getOrSet` stores through JSON.stringify, so a cache HIT yields a
- * string `_id` while a cache MISS yields an ObjectId. Writing that straight into
- * `AlertV2.rule_id` would produce documents whose `rule_id` type depends on cache
- * state, and the partial unique index would silently stop deduplicating. The
- * evaluator converts back with `new Types.ObjectId(rule._id)` at write time.
+ * Every field the evaluator reads off a rule is here, and nothing else: the
+ * point is not to re-validate a rule document, it is to establish that THIS
+ * object can be used to evaluate readings and to write an AlertV2. The
+ * enum/selector pieces are imported from the API's own schemas
+ * (`lib/validations/v2/alert-rule.validation.ts`) rather than restated, so the
+ * edge and the cache cannot drift apart on what a legal value is.
+ *
+ * `for_duration_seconds` and `cooldown_seconds` are optional because the
+ * evaluator reads them as `?? 0` — but they must be NUMBERS when present, since
+ * a stringified `"300"` would silently corrupt the duration arithmetic instead
+ * of failing.
  */
-export function normalizeRule(raw: unknown): CachedAlertRule {
+const cachedAlertRuleSchema = z.object({
+  _id: z
+    .string()
+    .regex(/^[0-9a-fA-F]{24}$/, 'Rule _id must be a 24-character hex ObjectId string'),
+  name: z.string().min(1, 'Rule name is required').max(200),
+  selector: alertRuleSelectorSchema.optional(),
+  metric: alertMetricSchema,
+  comparison: alertComparisonSchema,
+  threshold: z.number(),
+  for_duration_seconds: z.number().int().min(0).max(86400).optional(),
+  severity: alertSeveritySchema,
+  cooldown_seconds: z.number().int().min(0).max(86400).optional(),
+});
+
+/**
+ * Map a validation failure onto one of the three skip reasons the metrics
+ * surface already knows. `_id` and `metric` keep the labels the evaluator's own
+ * per-rule guard uses for the same two problems, so one dashboard query covers
+ * a rule rejected at cache-load time and one rejected at evaluation time.
+ */
+function skipReasonFor(issues: readonly { path: PropertyKey[] }[]): AlertRuleSkipReason {
+  const fields = new Set(issues.map(issue => String(issue.path[0])));
+  if (fields.has('_id')) return 'invalid_rule_id';
+  if (fields.has('metric')) return 'unknown_metric';
+  return 'unexpected_error';
+}
+
+/**
+ * Validate one cached/lean rule and force its `_id` to a string.
+ *
+ * TWO jobs, both mandatory, and neither is optional politeness:
+ *
+ * 1. `_id` normalization. `getOrSet` stores through JSON.stringify, so a cache
+ *    HIT yields a string `_id` while a cache MISS yields an ObjectId. Writing
+ *    that straight into `AlertV2.rule_id` would produce documents whose
+ *    `rule_id` type depends on cache state, and the partial unique index would
+ *    silently stop deduplicating. The evaluator converts back with
+ *    `new Types.ObjectId(rule._id)` at write time.
+ *
+ * 2. Shape validation. Nothing between Mongo and here re-validates: a `.lean()`
+ *    read returns whatever a seed script or migration wrote, and a Redis entry
+ *    returns whatever was cached before the last schema change. Asserting the
+ *    type instead of checking it produced two silent failures — a bad
+ *    `comparison` fell through `compare()`'s `default: return false` and simply
+ *    never fired, and a bad `severity` produced a non-E11000 write error that
+ *    cost the ENTIRE evaluation batch rather than just that rule.
+ *
+ * Returns null for a rule that cannot be used, after counting and logging it.
+ * The side effect lives here, not in the caller, so a rule can never be dropped
+ * without the drop being observable.
+ */
+export function normalizeRule(raw: unknown): CachedAlertRule | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    recordAlertRuleSkipped('unexpected_error');
+    logger.warn('Alert rule skipped: cached entry is not an object', {
+      received: raw === null ? 'null' : typeof raw,
+    });
+    return null;
+  }
+
   const rule = raw as CachedAlertRule & { _id: unknown };
-  return { ...rule, _id: String(rule._id) };
+  const normalized = { ...rule, _id: String(rule._id) };
+
+  const parsed = cachedAlertRuleSchema.safeParse(normalized);
+  if (!parsed.success) {
+    const reason = skipReasonFor(parsed.error.issues);
+    recordAlertRuleSkipped(reason);
+    logger.warn('Alert rule skipped: cached rule failed validation', {
+      ruleId: normalized._id,
+      ruleName: typeof rule.name === 'string' ? rule.name : undefined,
+      reason,
+      issues: parsed.error.issues.map(i => `${i.path.join('.') || '<root>'}: ${i.message}`),
+    });
+    return null;
+  }
+
+  // The ORIGINAL object is returned, not `parsed.data`: validation here is a
+  // gate, not a transform. Returning the parsed output would silently drop
+  // fields the schema does not list (`audit`, `enabled`, `description`) and
+  // apply the edge schemas' coercions to data that is already stored.
+  return normalized;
 }
 
 export async function loadActiveRules(): Promise<CachedAlertRule[]> {
@@ -46,7 +138,12 @@ export async function loadActiveRules(): Promise<CachedAlertRule[]> {
     { ttl: ALERT_RULE_CACHE_TTL_SECONDS }
   );
 
-  return rules.map(normalizeRule);
+  // One unusable rule costs only itself. It must not reach the evaluator, where
+  // it would either never fire (bad comparison) or fail the whole bulk write
+  // and take every other rule's alerts down with it (bad severity).
+  return rules
+    .map(normalizeRule)
+    .filter((rule): rule is CachedAlertRule => rule !== null);
 }
 
 /**

--- a/lib/alerting/selector.ts
+++ b/lib/alerting/selector.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure alerting predicates. No I/O, no database, no cache.
+ *
+ * NOTE ON THE TYPE DIMENSION: `matchesSelector` deliberately ignores
+ * `selector.types`. The type dimension is handled by rule *bucketing* in
+ * `rule-cache.ts`, which indexes rules by the reading type they apply to and
+ * appends type-less rules to every bucket. Checking it here as well would mean
+ * two places could disagree about a reading whose `metadata.type` differs from
+ * its device's `type`.
+ */
+
+import type { AlertComparison, AlertMetric, IAlertRuleSelector } from '@/models/v2/AlertRuleV2';
+import type { EvaluableDevice, EvaluableReading } from './types';
+
+/**
+ * Each metric is a direct field read off the reading being evaluated — no
+ * derived quantities, no lookback windows. Adding a fourth is one line.
+ *
+ * Returns `undefined` (never 0) when the field is absent, so a reading missing
+ * the metric is skipped rather than treated as a breach of a `lt` rule.
+ */
+export const METRIC_ACCESSORS: Record<AlertMetric, (r: EvaluableReading) => number | undefined> = {
+  value: r => r.value,
+  anomaly_score: r => r.quality?.anomaly_score,
+  battery_level: r => r.context?.battery_level,
+};
+
+export function compare(
+  value: number,
+  comparison: AlertComparison,
+  threshold: number
+): boolean {
+  switch (comparison) {
+    case 'gt':
+      return value > threshold;
+    case 'gte':
+      return value >= threshold;
+    case 'lt':
+      return value < threshold;
+    case 'lte':
+      return value <= threshold;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Does this device fall inside the rule's selector?
+ *
+ * A device must satisfy EVERY present dimension, and for `tags` must carry ALL
+ * listed tags (not any). An absent dimension is no constraint.
+ */
+export function matchesSelector(
+  device: EvaluableDevice,
+  selector: IAlertRuleSelector | undefined
+): boolean {
+  if (!selector) return true;
+
+  if (selector.building_id !== undefined && device.location?.building_id !== selector.building_id)
+    return false;
+
+  if (selector.floor !== undefined && device.location?.floor !== selector.floor) return false;
+
+  if (selector.zone !== undefined && device.location?.zone !== selector.zone) return false;
+
+  if (selector.tags?.length) {
+    const deviceTags = new Set(device.metadata?.tags ?? []);
+    if (!selector.tags.every(tag => deviceTags.has(tag))) return false;
+  }
+
+  return true;
+}

--- a/lib/alerting/sweep.ts
+++ b/lib/alerting/sweep.ts
@@ -94,8 +94,14 @@ export async function sweepStaleAlerts(reportingDeviceIds: Set<string>): Promise
     // function's snapshot read and its bulk write, a concurrent
     // evaluateReadings() on the ingest path can record a fresh breaching
     // observation, and without the cutoff predicate this op would close an
-    // alert that is actively breaching again. Mirrors evaluate.ts's
-    // `last_observed_at: { $lt: … }` guard on its own resolve op (evaluate.ts:345).
+    // alert that is actively breaching again.
+    //
+    // Mirrors the `last_observed_at: { $lt: … }` predicate on the auto-resolve
+    // updateOne in evaluateReadings() (lib/alerting/evaluate.ts) — the one in
+    // its "not breaching / existing episode has fired" branch, alongside
+    // `is_open: true`. Named by function and predicate rather than by line
+    // number on purpose: the previous version of this comment cited a line that
+    // had since drifted onto an unrelated field of the insertOne document.
     ops.push({
       updateOne: {
         filter:
@@ -145,14 +151,60 @@ export async function sweepStaleAlerts(reportingDeviceIds: Set<string>): Promise
 
   // BulkWriteResult exposes aggregate counts, not per-op match status, so the
   // resolve set is confirmed with one follow-up query rather than assumed from
-  // resolveCandidates. Every resolve op in THIS run stamps audit.resolved_at
-  // with the same `now`, which makes the query's result exactly the confirmed
-  // set — one extra query per sweep, not a per-alert findOneAndUpdate loop.
+  // resolveCandidates — one extra query per sweep, not a per-alert
+  // findOneAndUpdate loop.
+  //
+  // House rule (shared with evaluateReadings' Step 8): a write-confirmation
+  // predicate must match a value-set that ONLY the confirming operation could
+  // have produced. `audit.resolved_at: now` alone does NOT satisfy it. Three
+  // other code paths write that field, and each is genuinely concurrent with a
+  // cron sweep:
+  //
+  //   - evaluateReadings' auto-resolve on the ingest path, which writes
+  //     `audit.resolution: 'auto'`;
+  //   - AlertV2.resolve(), which PATCH /api/v2/alerts/[id] calls with 'manual'
+  //     when a human clicks Resolve;
+  //   - PATCH /api/v2/alert-rules/[id], which closes episodes orphaned by a
+  //     condition change, also with 'manual'.
+  //
+  // A collision to the millisecond with any of them would make this sweep
+  // confirm — and broadcast, and count — a resolution it did not cause, labelled
+  // 'stale' or 'device_inactive' while the stored document says 'auto' or
+  // 'manual'. So the predicate additionally matches the resolution THIS
+  // candidate's own op wrote. That value is carried on the candidate rather than
+  // re-derived, so the predicate cannot drift from the write it is confirming.
+  //
+  // Why that is exclusive: 'stale' and 'device_inactive' are written by this
+  // function and nowhere else in the codebase (verified by grep) — the evaluator
+  // only ever writes 'auto', and both manual paths only ever write 'manual'.
+  // The two predicates are mutually exclusive by construction, so neither the
+  // sweep nor the evaluator can confirm the other's write.
+  //
+  // One residual, stated rather than papered over: two OVERLAPPING sweeps whose
+  // `now` collides would both confirm the same document, since a sweep is not
+  // distinguishable from another sweep by the values it writes. The `is_open:
+  // true` guard means only one write lands, so the outcome is a duplicate
+  // notification carrying the CORRECT label — not the mislabelling fixed above.
+  // evaluateReadings carries the identical residual for two concurrent
+  // evaluators. Closing it would need a per-run token in the document.
+  //
+  // Grouped by resolution so this stays ONE query regardless of how many
+  // candidates each branch produced.
   let resolved: ResolvedAlert[] = [];
   if (resolveCandidates.length > 0) {
+    const idsByResolution = new Map<ResolvedAlert['resolution'], Types.ObjectId[]>();
+    for (const candidate of resolveCandidates) {
+      const ids = idsByResolution.get(candidate.alert.resolution);
+      if (ids) ids.push(candidate.id);
+      else idsByResolution.set(candidate.alert.resolution, [candidate.id]);
+    }
+
     const confirmed = await AlertV2.find({
-      _id: { $in: resolveCandidates.map(c => c.id) },
-      'audit.resolved_at': now,
+      $or: [...idsByResolution].map(([resolution, ids]) => ({
+        _id: { $in: ids },
+        'audit.resolved_at': now,
+        'audit.resolution': resolution,
+      })),
     })
       .select({ _id: 1 })
       .lean<{ _id: Types.ObjectId }[]>();

--- a/lib/alerting/sweep.ts
+++ b/lib/alerting/sweep.ts
@@ -84,7 +84,14 @@ export async function sweepStaleAlerts(reportingDeviceIds: Set<string>): Promise
     recordAlert('resolved', { resolution });
   }
 
-  if (toDelete.length > 0) ops.push({ deleteMany: { filter: { _id: { $in: toDelete } } } });
+  // The `status: 'pending'` guard is NOT optional. Between this function's
+  // snapshot read and its bulk write, a concurrent evaluateReadings() on the
+  // ingest path can promote one of these episodes to `firing` via its own
+  // status-guarded updateOne. Deleting by _id alone would then destroy a
+  // legitimately-fired alert's history instead of leaving it to resolve
+  // normally. Mirrors the `is_open: true` guard on the resolve op above.
+  if (toDelete.length > 0)
+    ops.push({ deleteMany: { filter: { _id: { $in: toDelete }, status: 'pending' } } });
 
   if (ops.length > 0) await AlertV2.bulkWrite(ops, { ordered: false });
 

--- a/lib/alerting/sweep.ts
+++ b/lib/alerting/sweep.ts
@@ -8,8 +8,10 @@
  * or silent because it broke.
  *
  * Runs on the cron path only — one query per cron invocation, not per ingest.
- * The caller passes the device ids it just emitted readings for, so this stays at
- * one query plus one bulk write and needs no device lookup of its own.
+ * The caller passes the device ids it just emitted readings for, so this needs no
+ * device lookup of its own: one snapshot read, one bulk write, and — only when
+ * there is at least one resolution to confirm — one reconciliation query (see
+ * below for why the reconciliation query is required).
  */
 
 import type { AnyBulkWriteOperation, Types } from 'mongoose';
@@ -30,7 +32,9 @@ export interface SweepResult {
 }
 
 export async function sweepStaleAlerts(reportingDeviceIds: Set<string>): Promise<SweepResult> {
-  const openAlerts = await AlertV2.find({ is_open: true }).lean<IAlertV2[]>();
+  const openAlerts = await AlertV2.find({ is_open: true })
+    .select({ _id: 1, rule_id: 1, device_id: 1, status: 1, severity: 1, last_observed_at: 1 })
+    .lean<IAlertV2[]>();
   if (openAlerts.length === 0) return { deleted: 0, resolved: [] };
 
   const now = new Date();
@@ -38,7 +42,11 @@ export async function sweepStaleAlerts(reportingDeviceIds: Set<string>): Promise
 
   const toDelete: Types.ObjectId[] = [];
   const ops: AnyBulkWriteOperation<IAlertV2>[] = [];
-  const resolved: ResolvedAlert[] = [];
+  // Candidates, not confirmed outcomes: every op below carries a guard that can
+  // legitimately match zero documents (see the reconciliation step after the
+  // bulk write). `resolved[]` and the `recordAlert('resolved', …)` calls are
+  // derived from these AFTER the write confirms which ones actually landed.
+  const resolveCandidates: { id: Types.ObjectId; alert: ResolvedAlert }[] = [];
 
   for (const alert of openAlerts) {
     const deviceInactive = !reportingDeviceIds.has(alert.device_id);
@@ -54,9 +62,20 @@ export async function sweepStaleAlerts(reportingDeviceIds: Set<string>): Promise
     // when the sensor merely went quiet.
     const resolution = deviceInactive ? 'device_inactive' : 'stale';
 
+    // A device absent from reportingDeviceIds has no fresh observation by
+    // definition, so 'device_inactive' keeps the unguarded { is_open: true }
+    // filter. 'stale' additionally guards on last_observed_at: between this
+    // function's snapshot read and its bulk write, a concurrent
+    // evaluateReadings() on the ingest path can record a fresh breaching
+    // observation, and without the cutoff predicate this op would close an
+    // alert that is actively breaching again. Mirrors evaluate.ts's
+    // `last_observed_at: { $lt: … }` guard on its own resolve op (evaluate.ts:345).
     ops.push({
       updateOne: {
-        filter: { _id: alert._id, is_open: true },
+        filter:
+          resolution === 'stale'
+            ? { _id: alert._id, is_open: true, last_observed_at: { $lt: cutoff } }
+            : { _id: alert._id, is_open: true },
         update: {
           $set: {
             status: 'resolved',
@@ -71,17 +90,18 @@ export async function sweepStaleAlerts(reportingDeviceIds: Set<string>): Promise
       },
     });
 
-    resolved.push({
-      _id: String(alert._id),
-      rule_id: String(alert.rule_id),
-      device_id: alert.device_id,
-      severity: alert.severity,
-      resolution,
-      resolved_at: now.toISOString(),
-      actor: 'system',
+    resolveCandidates.push({
+      id: alert._id,
+      alert: {
+        _id: String(alert._id),
+        rule_id: String(alert.rule_id),
+        device_id: alert.device_id,
+        severity: alert.severity,
+        resolution,
+        resolved_at: now.toISOString(),
+        actor: 'system',
+      },
     });
-
-    recordAlert('resolved', { resolution });
   }
 
   // The `status: 'pending'` guard is NOT optional. Between this function's
@@ -93,7 +113,30 @@ export async function sweepStaleAlerts(reportingDeviceIds: Set<string>): Promise
   if (toDelete.length > 0)
     ops.push({ deleteMany: { filter: { _id: { $in: toDelete }, status: 'pending' } } });
 
-  if (ops.length > 0) await AlertV2.bulkWrite(ops, { ordered: false });
+  if (ops.length === 0) return { deleted: 0, resolved: [] };
 
-  return { deleted: toDelete.length, resolved };
+  const bulkResult = await AlertV2.bulkWrite(ops, { ordered: false });
+
+  // BulkWriteResult exposes aggregate counts, not per-op match status, so the
+  // resolve set is confirmed with one follow-up query rather than assumed from
+  // resolveCandidates. Every resolve op in THIS run stamps audit.resolved_at
+  // with the same `now`, which makes the query's result exactly the confirmed
+  // set — one extra query per sweep, not a per-alert findOneAndUpdate loop.
+  let resolved: ResolvedAlert[] = [];
+  if (resolveCandidates.length > 0) {
+    const confirmed = await AlertV2.find({
+      _id: { $in: resolveCandidates.map(c => c.id) },
+      'audit.resolved_at': now,
+    })
+      .select({ _id: 1 })
+      .lean<{ _id: Types.ObjectId }[]>();
+    const confirmedIds = new Set(confirmed.map(doc => String(doc._id)));
+
+    resolved = resolveCandidates.filter(c => confirmedIds.has(String(c.id))).map(c => c.alert);
+    for (const alert of resolved) recordAlert('resolved', { resolution: alert.resolution });
+  }
+
+  // deletedCount is the driver's actual count, not toDelete.length — the
+  // status-guarded deleteMany below can match fewer documents than candidates.
+  return { deleted: bulkResult.deletedCount, resolved };
 }

--- a/lib/alerting/sweep.ts
+++ b/lib/alerting/sweep.ts
@@ -16,13 +16,39 @@
 
 import type { AnyBulkWriteOperation, Types } from 'mongoose';
 import AlertV2, { type IAlertV2 } from '@/models/v2/AlertV2';
-import { recordAlert } from '@/lib/monitoring';
+import { logger, recordAlert } from '@/lib/monitoring';
 import type { ResolvedAlert } from '@/types/v2/alert.types';
 
-export const STALE_AFTER_SECONDS = parseInt(
-  process.env.ALERT_STALE_AFTER_SECONDS || '1800',
-  10
-);
+const DEFAULT_STALE_AFTER_SECONDS = 1800;
+
+/**
+ * A malformed `ALERT_STALE_AFTER_SECONDS` (non-numeric, or parseInt's
+ * partial-parse leaving a NaN) used to silently disable staleness detection
+ * entirely: `new Date(NaN)` is an Invalid Date, so `last_observed_at <
+ * cutoff` is always false and the branch below stops firing — permanently
+ * and silently, with `device_inactive` still working to mask it. Guard with
+ * Number.isFinite (parseInt itself never throws) and fall back to the
+ * documented default, logging so the misconfiguration is visible instead of
+ * merely inert. A non-positive value is equally nonsensical for "seconds
+ * after which to consider stale" and is rejected the same way.
+ */
+function parseStaleAfterSeconds(): number {
+  const raw = process.env.ALERT_STALE_AFTER_SECONDS;
+  if (!raw) return DEFAULT_STALE_AFTER_SECONDS;
+
+  const parsed = parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    logger.warn(
+      `Malformed ALERT_STALE_AFTER_SECONDS "${raw}"; falling back to ${DEFAULT_STALE_AFTER_SECONDS}s. Staleness detection would otherwise be silently disabled.`,
+      { value: raw }
+    );
+    return DEFAULT_STALE_AFTER_SECONDS;
+  }
+
+  return parsed;
+}
+
+export const STALE_AFTER_SECONDS = parseStaleAfterSeconds();
 
 export interface SweepResult {
   /** Pending episodes deleted — an episode that never fired is not history. */

--- a/lib/alerting/sweep.ts
+++ b/lib/alerting/sweep.ts
@@ -1,0 +1,92 @@
+/**
+ * Staleness sweep.
+ *
+ * An episode auto-resolves when a NEW reading shows the metric back within
+ * bounds, so a device that stops reporting would otherwise stay firing forever.
+ * The simulate cron emits a reading for every active device on every run, so the
+ * real gap is a device that leaves the active set: decommissioned, soft-deleted,
+ * or silent because it broke.
+ *
+ * Runs on the cron path only — one query per cron invocation, not per ingest.
+ * The caller passes the device ids it just emitted readings for, so this stays at
+ * one query plus one bulk write and needs no device lookup of its own.
+ */
+
+import type { AnyBulkWriteOperation, Types } from 'mongoose';
+import AlertV2, { type IAlertV2 } from '@/models/v2/AlertV2';
+import { recordAlert } from '@/lib/monitoring';
+import type { ResolvedAlert } from '@/types/v2/alert.types';
+
+export const STALE_AFTER_SECONDS = parseInt(
+  process.env.ALERT_STALE_AFTER_SECONDS || '1800',
+  10
+);
+
+export interface SweepResult {
+  /** Pending episodes deleted — an episode that never fired is not history. */
+  deleted: number;
+  /** Firing/acknowledged episodes resolved — they did fire, so the history is real. */
+  resolved: ResolvedAlert[];
+}
+
+export async function sweepStaleAlerts(reportingDeviceIds: Set<string>): Promise<SweepResult> {
+  const openAlerts = await AlertV2.find({ is_open: true }).lean<IAlertV2[]>();
+  if (openAlerts.length === 0) return { deleted: 0, resolved: [] };
+
+  const now = new Date();
+  const cutoff = new Date(now.getTime() - STALE_AFTER_SECONDS * 1000);
+
+  const toDelete: Types.ObjectId[] = [];
+  const ops: AnyBulkWriteOperation<IAlertV2>[] = [];
+  const resolved: ResolvedAlert[] = [];
+
+  for (const alert of openAlerts) {
+    const deviceInactive = !reportingDeviceIds.has(alert.device_id);
+    const observationStale = new Date(alert.last_observed_at) < cutoff;
+    if (!deviceInactive && !observationStale) continue;
+
+    if (alert.status === 'pending') {
+      toDelete.push(alert._id);
+      continue;
+    }
+
+    // Recorded distinctly from 'auto' so history never claims a problem was fixed
+    // when the sensor merely went quiet.
+    const resolution = deviceInactive ? 'device_inactive' : 'stale';
+
+    ops.push({
+      updateOne: {
+        filter: { _id: alert._id, is_open: true },
+        update: {
+          $set: {
+            status: 'resolved',
+            is_open: false,
+            'audit.updated_at': now,
+            'audit.updated_by': 'system',
+            'audit.resolved_at': now,
+            'audit.resolved_by': 'system',
+            'audit.resolution': resolution,
+          },
+        },
+      },
+    });
+
+    resolved.push({
+      _id: String(alert._id),
+      rule_id: String(alert.rule_id),
+      device_id: alert.device_id,
+      severity: alert.severity,
+      resolution,
+      resolved_at: now.toISOString(),
+      actor: 'system',
+    });
+
+    recordAlert('resolved', { resolution });
+  }
+
+  if (toDelete.length > 0) ops.push({ deleteMany: { filter: { _id: { $in: toDelete } } } });
+
+  if (ops.length > 0) await AlertV2.bulkWrite(ops, { ordered: false });
+
+  return { deleted: toDelete.length, resolved };
+}

--- a/lib/alerting/types.ts
+++ b/lib/alerting/types.ts
@@ -1,0 +1,54 @@
+/**
+ * Server-internal alerting types.
+ *
+ * Wire types that cross to the browser live in `types/v2/alert.types.ts` —
+ * this file imports from models and is server-only.
+ */
+
+import type { IDeviceV2 } from '@/models/v2/DeviceV2';
+import type { IReadingV2 } from '@/models/v2/ReadingV2';
+import type { IAlertRuleV2 } from '@/models/v2/AlertRuleV2';
+import type { FiredAlert, ResolvedAlert } from '@/types/v2/alert.types';
+
+/**
+ * The device projection evaluation needs. Callers pass the documents they have
+ * already loaded, so evaluation adds no device query to either write path.
+ */
+export type EvaluableDevice = Pick<IDeviceV2, '_id' | 'type' | 'location' | 'metadata'>;
+
+/** A reading as it exists just after insert — a partial document. */
+export type EvaluableReading = Partial<IReadingV2>;
+
+/**
+ * A rule after a Redis JSON round trip: `_id` is a string, not an ObjectId.
+ * See `lib/alerting/rule-cache.ts` for why this normalization is mandatory.
+ */
+export interface CachedAlertRule extends Omit<IAlertRuleV2, '_id'> {
+  _id: string;
+}
+
+export interface EvaluationResult {
+  /** Episodes that started firing in this evaluation. */
+  fired: FiredAlert[];
+  /** Episodes that auto-resolved in this evaluation. */
+  resolved: ResolvedAlert[];
+  /** Pending episodes opened (breach seen, duration not yet elapsed). */
+  pendingOpened: number;
+  /** Pending episodes deleted because the condition cleared first. */
+  pendingCleared: number;
+  /** New episodes suppressed by a rule's cooldown. */
+  suppressed: number;
+  /** Number of (rule, device) pairs considered. */
+  evaluatedPairs: number;
+}
+
+export function emptyEvaluationResult(): EvaluationResult {
+  return {
+    fired: [],
+    resolved: [],
+    pendingOpened: 0,
+    pendingCleared: 0,
+    suppressed: 0,
+    evaluatedPairs: 0,
+  };
+}

--- a/lib/api/v2-client.ts
+++ b/lib/api/v2-client.ts
@@ -27,6 +27,12 @@ import type {
   CreateScheduleInput,
   UpdateScheduleInput,
   BulkCreateScheduleResponse,
+  AlertV2Response,
+  AlertRuleV2Response,
+  ListAlertsQueryParams,
+  ListAlertRulesQueryParams,
+  CreateAlertRuleBody,
+  UpdateAlertRuleBody,
 } from '@/types/v2';
 
 // ============================================================================
@@ -823,6 +829,87 @@ export const reportsApi = {
 };
 
 // ============================================================================
+// ALERTS API
+// ============================================================================
+
+export const alertsApi = {
+  /**
+   * List alerts. Defaults server-side to open alerts (firing + acknowledged);
+   * `pending` is internal and is never returned.
+   */
+  async list(query: ListAlertsQueryParams = {}): Promise<PaginatedResponse<AlertV2Response>> {
+    const queryString = buildQueryString(query as Record<string, unknown>);
+    return apiCall(`/api/v2/alerts${queryString}`);
+  },
+
+  async getById(
+    id: string,
+    options: { include_device?: boolean } = {}
+  ): Promise<ApiSuccessResponse<AlertV2Response>> {
+    const queryString = buildQueryString(options as Record<string, unknown>);
+    return apiCall(`/api/v2/alerts/${id}${queryString}`);
+  },
+
+  async acknowledge(id: string, note?: string): Promise<ApiSuccessResponse<AlertV2Response>> {
+    return apiCall(`/api/v2/alerts/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'acknowledged', ...(note ? { note } : {}) }),
+    });
+  },
+
+  async resolve(id: string, note?: string): Promise<ApiSuccessResponse<AlertV2Response>> {
+    return apiCall(`/api/v2/alerts/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'resolved', ...(note ? { note } : {}) }),
+    });
+  },
+};
+
+// ============================================================================
+// ALERT RULES API
+// ============================================================================
+
+export const alertRulesApi = {
+  async list(
+    query: ListAlertRulesQueryParams = {}
+  ): Promise<PaginatedResponse<AlertRuleV2Response>> {
+    const queryString = buildQueryString(query as Record<string, unknown>);
+    return apiCall(`/api/v2/alert-rules${queryString}`);
+  },
+
+  async getById(id: string): Promise<ApiSuccessResponse<AlertRuleV2Response>> {
+    return apiCall(`/api/v2/alert-rules/${id}`);
+  },
+
+  async create(data: CreateAlertRuleBody): Promise<ApiSuccessResponse<AlertRuleV2Response>> {
+    return apiCall('/api/v2/alert-rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+  },
+
+  async update(
+    id: string,
+    data: UpdateAlertRuleBody
+  ): Promise<ApiSuccessResponse<AlertRuleV2Response>> {
+    return apiCall(`/api/v2/alert-rules/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+  },
+
+  async delete(
+    id: string
+  ): Promise<ApiSuccessResponse<{ _id: string; deleted: boolean; deleted_at?: string }>> {
+    return apiCall(`/api/v2/alert-rules/${id}`, { method: 'DELETE' });
+  },
+};
+
+// ============================================================================
 // EXPORTS
 // ============================================================================
 
@@ -837,6 +924,8 @@ export const v2Api = {
   audit: auditApi,
   reports: reportsApi,
   schedules: schedulesApi,
+  alerts: alertsApi,
+  alertRules: alertRulesApi,
 };
 
 export default v2Api;

--- a/lib/auth/index.ts
+++ b/lib/auth/index.ts
@@ -93,6 +93,19 @@ function createDemoAuthContext(): AuthContext {
   };
 }
 
+/**
+ * Whether an auth context is the anonymous demo-mode visitor
+ * (`createDemoAuthContext()`), as opposed to a genuinely authenticated user.
+ *
+ * Route handlers use this to decide when to redact fields — like
+ * `audit.*_by`, which can carry a real admin's email via `getAuditUser()` —
+ * that must never reach an anonymous caller. Keyed on `DEMO_USER.userId`
+ * rather than a hardcoded `'demo'` literal so the sentinel is defined once.
+ */
+export function isDemoCaller(context: Pick<AuthContext, 'userId'>): boolean {
+  return context.userId === DEMO_USER.userId;
+}
+
 // ============================================================================
 // RBAC HELPERS
 // ============================================================================

--- a/lib/cache/cache.ts
+++ b/lib/cache/cache.ts
@@ -46,6 +46,233 @@ export const CACHE_TTL = {
 } as const;
 
 // ============================================================================
+// STALE-WRITE GUARD, LAYER 1 OF 2: in-process invalidation generation
+// ============================================================================
+
+/**
+ * `getOrSet` populates the cache AFTER awaiting its fetch, so without a guard
+ * an invalidation landing in between is silently undone: a read that missed
+ * just before a mutation repopulates the PRE-mutation value after the `del`
+ * has already run, under a fresh full TTL, with no self-correction short of
+ * that TTL expiring. On the alert rule cache (60s TTL, invalidated on every
+ * rule create/update/delete) that is a disabled rule that keeps firing for up
+ * to a minute after an operator switched it off.
+ *
+ * Every invalidation bumps a monotonic generation and records WHICH keys it
+ * covered. `getOrSet` snapshots the generation before it reads and drops its
+ * write if anything covering its key happened since.
+ *
+ * This layer is process-local, and it is the FAST path rather than the whole
+ * answer. It costs no Redis round trip, and it is the only layer that can
+ * catch a PATTERN invalidation for a key that was absent from Redis at scan
+ * time (see the epoch section below for why that case is invisible there).
+ *
+ * It is not sufficient on its own: this app deploys to Vercel serverless, so
+ * the PATCH that disables a rule and the ingest request that repopulates the
+ * rule cache normally run on DIFFERENT function instances. Alone, this layer
+ * would close the case that barely happens and leave the case that does.
+ * Layer 2 covers that.
+ */
+interface InvalidationEvent {
+  generation: number;
+  /** True when this invalidation would have removed `key`. */
+  covers: (key: string) => boolean;
+}
+
+let invalidationGeneration = 0;
+const invalidationLog: InvalidationEvent[] = [];
+
+/**
+ * Highest generation whose event has been dropped from the bounded log. A
+ * snapshot older than this predates an invalidation we can no longer inspect,
+ * so it is treated as invalidated — the conservative direction (a skipped
+ * cache write costs one extra fetch; a stale one serves wrong data for a TTL).
+ * 0 means "nothing dropped yet".
+ */
+let truncatedThrough = 0;
+
+/** Bounds memory on a long-lived process. Far above any realistic in-flight count. */
+const INVALIDATION_LOG_LIMIT = 256;
+
+function recordInvalidation(covers: (key: string) => boolean): void {
+  invalidationGeneration += 1;
+  invalidationLog.push({ generation: invalidationGeneration, covers });
+
+  while (invalidationLog.length > INVALIDATION_LOG_LIMIT)
+    truncatedThrough = invalidationLog.shift()!.generation;
+}
+
+function wasInvalidatedSince(key: string, snapshot: number): boolean {
+  if (snapshot < truncatedThrough) return true;
+  return invalidationLog.some(event => event.generation > snapshot && event.covers(key));
+}
+
+/**
+ * Translate a Redis glob (`*`, `?`) into a key matcher, so a pattern
+ * invalidation cancels in-flight writes for keys it would have deleted — and
+ * only those. A pattern delete cannot simply consult its own SCAN results
+ * here: the racing key is precisely the one absent from Redis at that moment.
+ */
+function globMatcher(pattern: string): (key: string) => boolean {
+  const source = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*')
+    .replace(/\?/g, '.');
+  const regex = new RegExp(`^${source}$`);
+  return key => regex.test(key);
+}
+
+// ============================================================================
+// STALE-WRITE GUARD, LAYER 2 OF 2: Redis per-key epoch
+// ============================================================================
+
+/**
+ * Layer 1 cannot see across process boundaries, and on serverless the two
+ * halves of the race are normally in different function instances. So the
+ * version counter also lives in Redis, where both halves can see it:
+ *
+ *   - every invalidation INCRs `<key>::epoch` (best effort, see `bumpEpochs`)
+ *   - `getOrSet` reads that epoch after its cache miss and before its fetch
+ *   - the write commits through a Lua CAS that re-reads the epoch server-side
+ *     and only SETEXes if it is byte-for-byte what the caller observed
+ *
+ * The CAS is what makes the stale write a genuine no-op rather than a narrowed
+ * window: the compare and the write are one atomic Redis command, so no
+ * invalidation can land between them.
+ *
+ * WHY LUA AND NOT WATCH/MULTI. `lib/redis/client.ts` hands every caller the
+ * same ioredis singleton, and WATCH is per-CONNECTION state. Two concurrent
+ * `getOrSet` calls sharing that connection would clobber each other's watch
+ * set, and correctness would depend on request concurrency. Making it safe
+ * would mean a dedicated connection per commit, which defeats the singleton on
+ * a platform where connection count is the scarce resource. A single EVAL is
+ * atomic server-side and connection-agnostic. Ioredis exposes `eval` directly,
+ * so this needs nothing added to the client.
+ *
+ * REQUIRED ORDERING, relied on by every caller in `lib/cache/invalidation.ts`:
+ * the epoch must be bumped AFTER the database mutation has committed. Given
+ * that, a fetch which starts after the bump necessarily reads post-mutation
+ * data and is safe to cache, which is what makes it correct to read the epoch
+ * after the cache miss rather than before it.
+ */
+
+/**
+ * How long an epoch outlives its last bump. Must comfortably exceed
+ * (longest cache TTL + longest plausible fetch), so an epoch cannot expire
+ * and restart at 1 underneath a snapshot old enough to match it again. The
+ * longest TTL here is METADATA at 10 minutes.
+ */
+const EPOCH_TTL_SECONDS = 3600;
+
+/** `''` means "no epoch recorded". INCR's first value is `1`, so they cannot collide. */
+const EPOCH_ABSENT = '';
+
+/**
+ * Returned when the epoch could not be read. Contains a NUL byte, so it can
+ * never equal a value INCR produced — the CAS therefore fails closed and the
+ * write is skipped. An unreadable epoch must not be allowed to look like
+ * "never invalidated".
+ */
+const EPOCH_UNREADABLE = '\u0000unreadable';
+
+function epochKey(key: string): string {
+  return `${key}::epoch`;
+}
+
+/** KEYS: [value key, epoch key]. ARGV: [ttl, serialized value, observed epoch]. */
+const COMMIT_IF_EPOCH_UNCHANGED = `
+local observed = ARGV[3]
+local current = redis.call('GET', KEYS[2])
+if current == false then current = '' end
+if current ~= observed then return 0 end
+redis.call('SETEX', KEYS[1], ARGV[1], ARGV[2])
+return 1
+`;
+
+/**
+ * Bump the epoch of every key an invalidation covers.
+ *
+ * BEST EFFORT, and deliberately so: it degrades exactly like the rest of this
+ * module. `del()` already returns 0 and logs a warning when Redis misbehaves —
+ * invalidation here has always been best-effort — so a failed bump must not
+ * stop the DEL itself from being attempted, and must never throw into a
+ * request. When it does fail, layer 1 is still in place within the instance.
+ */
+async function bumpEpochs(redis: NonNullable<ReturnType<typeof getRedisClient>>, keys: string[]) {
+  if (keys.length === 0) return;
+
+  try {
+    const pipeline = redis.pipeline();
+    for (const key of keys) {
+      pipeline.incr(epochKey(key));
+      pipeline.expire(epochKey(key), EPOCH_TTL_SECONDS);
+    }
+    await pipeline.exec();
+  } catch (error) {
+    logger.warn('Cache epoch bump failed; cross-process guard degraded for these keys', {
+      keys,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/** Read the epoch a `getOrSet` must still see at commit time. Never throws. */
+async function readEpoch(key: string): Promise<string> {
+  const redis = getRedisClient();
+  // No Redis means no cache write either (`commitIfEpochUnchanged` returns
+  // false below), so the value here is moot — behave exactly as before.
+  if (!redis || !isRedisAvailable()) return EPOCH_ABSENT;
+
+  try {
+    return (await redis.get(epochKey(key))) ?? EPOCH_ABSENT;
+  } catch (error) {
+    logger.warn('Cache epoch read failed', { key }, error as Error);
+    return EPOCH_UNREADABLE;
+  }
+}
+
+/**
+ * Commit a `getOrSet` write only if nothing invalidated the key since
+ * `observedEpoch` was read. Same graceful-degradation contract as `set()`:
+ * returns false and logs on any failure, never throws into a request.
+ */
+async function commitIfEpochUnchanged<T>(
+  key: string,
+  value: T,
+  options: CacheOptions,
+  observedEpoch: string
+): Promise<boolean> {
+  if (!isCacheEnabled()) return false;
+
+  const redis = getRedisClient();
+  if (!redis || !isRedisAvailable()) return false;
+
+  try {
+    const committed = await redis.eval(
+      COMMIT_IF_EPOCH_UNCHANGED,
+      2,
+      key,
+      epochKey(key),
+      String(options.ttl),
+      JSON.stringify(value),
+      observedEpoch
+    );
+
+    if (committed !== 1) {
+      logger.debug('Cache write skipped: the key was invalidated in another process', { key });
+      return false;
+    }
+
+    logger.cache('set', key);
+    recordCacheEvent('set');
+    return true;
+  } catch (error) {
+    logger.warn('Cache set failed', { key }, error as Error);
+    return false;
+  }
+}
+
+// ============================================================================
 // CACHE OPERATIONS
 // ============================================================================
 
@@ -119,8 +346,21 @@ export async function set<T>(key: string, value: T, options: CacheOptions): Prom
 export async function del(...keys: string[]): Promise<number> {
   if (!isCacheEnabled() || keys.length === 0) return 0;
 
+  // Recorded BEFORE the DEL is issued, and before the Redis availability
+  // check, so an in-flight `getOrSet` is cancelled even if the DEL itself
+  // never reaches Redis. Cancelling a write that did not need cancelling
+  // costs one extra fetch; missing one serves pre-mutation data for a TTL.
+  const invalidated = new Set(keys);
+  recordInvalidation(key => invalidated.has(key));
+
   const redis = getRedisClient();
   if (!redis || !isRedisAvailable()) return 0;
+
+  // Layer 2, and BEFORE the DEL for the same reason layer 1 is recorded first:
+  // a `getOrSet` in another process that reads the epoch from here on must see
+  // the bumped value. Self-contained failure handling, so a Redis fault here
+  // cannot stop the DEL below from being attempted.
+  await bumpEpochs(redis, keys);
 
   try {
     const deleted = await redis.del(...keys);
@@ -142,6 +382,9 @@ export async function del(...keys: string[]): Promise<number> {
 export async function delPattern(pattern: string): Promise<number> {
   if (!isCacheEnabled()) return 0;
 
+  // Same ordering rationale as del() above.
+  recordInvalidation(globMatcher(pattern));
+
   const redis = getRedisClient();
   if (!redis || !isRedisAvailable()) return 0;
 
@@ -154,7 +397,17 @@ export async function delPattern(pattern: string): Promise<number> {
       const [newCursor, keys] = await redis.scan(cursor, 'MATCH', pattern, 'COUNT', 100);
       cursor = newCursor;
 
-      if (keys.length > 0) totalDeleted += await redis.del(...keys);
+      if (keys.length > 0) {
+        // Cross-process cover for the keys this pattern actually matched.
+        // RESIDUAL, by construction: a key ABSENT from Redis at scan time
+        // cannot be enumerated here, and that is exactly the key a racing
+        // `getOrSet` missed on. Layer 1's glob matcher is what covers that
+        // case, and only within the instance — so a pattern invalidation is
+        // strictly weaker cross-process than an exact-key `del`. Alert rules,
+        // the subject of this guard, use `del(alertRulesKey())`.
+        await bumpEpochs(redis, keys);
+        totalDeleted += await redis.del(...keys);
+      }
     } while (cursor !== '0');
 
     if (totalDeleted > 0) {
@@ -186,15 +439,37 @@ export async function getOrSet<T>(
   fetchFn: () => Promise<T>,
   options: CacheOptions
 ): Promise<T> {
+  // Layer 1 snapshot, BEFORE the read: any invalidation from this point on
+  // describes a mutation that `fresh` below may not contain.
+  const snapshot = invalidationGeneration;
+
   // Try cache first
   const cached = await get<T>(key);
   if (cached !== null) return cached;
 
+  // Layer 2 snapshot. Taken only on a MISS — a hit never writes, so the hot
+  // path pays nothing — but before the fetch, so every invalidation this fetch
+  // could fail to observe is one that lands after this read. That ordering is
+  // sound because invalidations run AFTER their database mutation commits (see
+  // the layer 2 header): a fetch starting after a bump reads post-mutation data.
+  const observedEpoch = await readEpoch(key);
+
   // Fetch fresh data
   const fresh = await fetchFn();
 
-  // Cache the result (non-blocking)
-  set(key, fresh, options).catch((err) => {
+  // The value is now known to predate any invalidation recorded since the
+  // snapshot — writing it would resurrect the pre-mutation state under a fresh
+  // TTL. Return it to THIS caller (it is what the fetch produced and the caller
+  // is already committed to it) but do not publish it to everyone else.
+  if (wasInvalidatedSince(key, snapshot)) {
+    logger.debug('Cache write skipped: invalidated while the fetch was in flight', { key });
+    return fresh;
+  }
+
+  // Cache the result (non-blocking). The epoch check is re-done inside the CAS
+  // server-side, so unlike layer 1 this does not depend on the check and the
+  // write sharing a synchronous turn — nothing can land between them at all.
+  commitIfEpochUnchanged(key, fresh, options, observedEpoch).catch((err) => {
     logger.warn('Cache set failed in getOrSet', { key, error: err instanceof Error ? err.message : String(err) });
   });
 

--- a/lib/cache/index.ts
+++ b/lib/cache/index.ts
@@ -26,6 +26,7 @@ export {
   healthPattern,
   readingsPattern,
   analyticsPattern,
+  alertRulesKey,
 } from './keys';
 
 export {
@@ -37,4 +38,5 @@ export {
   invalidateHealthCache,
   invalidateMetadata,
   clearAllCaches,
+  invalidateAlertRules,
 } from './invalidation';

--- a/lib/cache/invalidation.ts
+++ b/lib/cache/invalidation.ts
@@ -12,6 +12,7 @@ import {
   metadataPattern,
   healthPattern,
   readingsPattern,
+  alertRulesKey,
 } from './keys';
 import { logger } from '../monitoring/logger';
 
@@ -151,6 +152,23 @@ export async function invalidateMetadata(orgId: string): Promise<void> {
     logger.debug('Metadata cache invalidated', { orgId });
   } catch (error) {
     logger.warn('Metadata cache invalidation failed', { orgId }, error as Error);
+  }
+}
+
+// ============================================================================
+// ALERT RULE INVALIDATION
+// ============================================================================
+
+/**
+ * Invalidate the active alert rule cache.
+ * Called after every rule create, update, and delete.
+ */
+export async function invalidateAlertRules(): Promise<void> {
+  try {
+    await del(alertRulesKey());
+    logger.debug('Alert rules cache invalidated');
+  } catch (error) {
+    logger.warn('Alert rules cache invalidation failed', {}, error as Error);
   }
 }
 

--- a/lib/cache/keys.ts
+++ b/lib/cache/keys.ts
@@ -12,6 +12,7 @@ export const CACHE_PREFIXES = {
   HEALTH: 'health',
   READINGS_LATEST: 'readings:latest',
   ANALYTICS: 'analytics',
+  ALERT_RULES: 'alert:rules',
 } as const;
 
 /**
@@ -124,4 +125,28 @@ export function readingsPattern(orgId: string): string {
  */
 export function analyticsPattern(orgId: string): string {
   return `${orgPrefix(orgId)}:${CACHE_PREFIXES.ANALYTICS}:*`;
+}
+
+// ============================================================================
+// ALERT RULES
+// ============================================================================
+
+/**
+ * Generate the cache key for the active alert rule set.
+ *
+ * Deliberately GLOBAL — no orgPrefix, unlike every other generator in this file.
+ * Three facts force it:
+ *   1. No v2 model carries an org dimension. `orgId` is a Clerk session property
+ *      used for cache partitioning, never a stored field, so rules have nothing
+ *      to be keyed by.
+ *   2. `/api/v2/cron/simulate` authenticates with SEED_SECRET and establishes no
+ *      Clerk context at all. On the path that carries every reading in the
+ *      deployment, there is no orgId to compute.
+ *   3. Multi-tenancy is out of scope; CLERK_ALLOWED_ORG_SLUGS defaults to one org.
+ *
+ * Giving AlertRuleV2 an org field instead would mean inventing multi-tenancy to
+ * serve a cache key.
+ */
+export function alertRulesKey(): string {
+  return `${CACHE_PREFIXES.ALERT_RULES}:active`;
 }

--- a/lib/errors/errorCodes.ts
+++ b/lib/errors/errorCodes.ts
@@ -77,6 +77,13 @@ export const ErrorCodes = {
   INVALID_SCHEDULED_DATE: 'INVALID_SCHEDULED_DATE',
   INVALID_SCHEDULE_STATUS_TRANSITION: 'INVALID_SCHEDULE_STATUS_TRANSITION',
 
+  // ---- Alert Errors (404, 422) ----
+  ALERT_NOT_FOUND: 'ALERT_NOT_FOUND',
+  ALERT_RULE_NOT_FOUND: 'ALERT_RULE_NOT_FOUND',
+  ALERT_ALREADY_ACKNOWLEDGED: 'ALERT_ALREADY_ACKNOWLEDGED',
+  ALERT_ALREADY_RESOLVED: 'ALERT_ALREADY_RESOLVED',
+  INVALID_ALERT_STATUS_TRANSITION: 'INVALID_ALERT_STATUS_TRANSITION',
+
   // ---- Rate Limiting (429) ----
   RATE_LIMIT_EXCEEDED: 'RATE_LIMIT_EXCEEDED',
   TOO_MANY_REQUESTS: 'TOO_MANY_REQUESTS',
@@ -306,6 +313,33 @@ export const ErrorCodeRegistry: Record<ErrorCode, ErrorCodeDefinition> = {
     code: ErrorCodes.INVALID_SCHEDULE_STATUS_TRANSITION,
     statusCode: 422,
     description: 'Invalid schedule status transition',
+  },
+
+  // ---- Alert Errors ----
+  [ErrorCodes.ALERT_NOT_FOUND]: {
+    code: ErrorCodes.ALERT_NOT_FOUND,
+    statusCode: 404,
+    description: 'The specified alert was not found',
+  },
+  [ErrorCodes.ALERT_RULE_NOT_FOUND]: {
+    code: ErrorCodes.ALERT_RULE_NOT_FOUND,
+    statusCode: 404,
+    description: 'The specified alert rule was not found',
+  },
+  [ErrorCodes.ALERT_ALREADY_ACKNOWLEDGED]: {
+    code: ErrorCodes.ALERT_ALREADY_ACKNOWLEDGED,
+    statusCode: 422,
+    description: 'The alert has already been acknowledged',
+  },
+  [ErrorCodes.ALERT_ALREADY_RESOLVED]: {
+    code: ErrorCodes.ALERT_ALREADY_RESOLVED,
+    statusCode: 422,
+    description: 'The alert has already been resolved and cannot be modified',
+  },
+  [ErrorCodes.INVALID_ALERT_STATUS_TRANSITION]: {
+    code: ErrorCodes.INVALID_ALERT_STATUS_TRANSITION,
+    statusCode: 422,
+    description: 'Invalid alert status transition',
   },
 
   // ---- Rate Limiting ----

--- a/lib/monitoring/index.ts
+++ b/lib/monitoring/index.ts
@@ -12,7 +12,9 @@ export {
   resetMetrics,
   recordAlert,
   recordAlertEvaluationDuration,
+  recordAlertRuleSkipped,
   type AlertSeverityLabel,
+  type AlertRuleSkipReason,
 } from './metrics';
 
 export {

--- a/lib/monitoring/index.ts
+++ b/lib/monitoring/index.ts
@@ -10,6 +10,9 @@ export {
   getMetricsSnapshot,
   getPrometheusMetrics,
   resetMetrics,
+  recordAlert,
+  recordAlertEvaluationDuration,
+  type AlertSeverityLabel,
 } from './metrics';
 
 export {

--- a/lib/monitoring/metrics.ts
+++ b/lib/monitoring/metrics.ts
@@ -57,6 +57,13 @@ interface MetricsStore {
     slowQueries: number;
     totalQueryTime: number;
   };
+  /** Alert counters keyed by label value */
+  alertsFired: Map<string, CounterEntry>;
+  alertsResolved: Map<string, CounterEntry>;
+  alerts: {
+    evaluationErrors: number;
+    evaluationDuration: HistogramEntry;
+  };
 }
 
 // ============================================================================
@@ -71,6 +78,12 @@ const metrics: MetricsStore = {
   cache: { hits: 0, misses: 0, sets: 0, invalidations: 0 },
   ingestion: { total: 0, errors: 0, lastBatchSize: 0, lastBatchTime: 0 },
   database: { queryCount: 0, slowQueries: 0, totalQueryTime: 0 },
+  alertsFired: new Map(),
+  alertsResolved: new Map(),
+  alerts: {
+    evaluationErrors: 0,
+    evaluationDuration: { count: 0, sum: 0, min: Infinity, max: -Infinity, lastUpdated: 0 },
+  },
 };
 
 // ============================================================================
@@ -164,6 +177,46 @@ export function recordIngestion(batchSize: number, errorCount: number): void {
   metrics.ingestion.lastBatchTime = Date.now();
 }
 
+export type AlertSeverityLabel = 'info' | 'warning' | 'critical';
+
+/**
+ * Record an alerting lifecycle event.
+ *
+ * `evaluation_error` matters most: evaluation failures are swallowed by design so
+ * they cannot drop readings, which makes this counter the only signal that
+ * alerting has silently stopped working.
+ */
+export function recordAlert(
+  event: 'fired' | 'resolved' | 'evaluation_error',
+  labels: { severity?: AlertSeverityLabel; resolution?: string } = {}
+): void {
+  const now = Date.now();
+
+  if (event === 'evaluation_error') {
+    metrics.alerts.evaluationErrors++;
+    return;
+  }
+
+  const target = event === 'fired' ? metrics.alertsFired : metrics.alertsResolved;
+  const label = event === 'fired' ? (labels.severity ?? 'unknown') : (labels.resolution ?? 'unknown');
+  const entry = target.get(label) || { value: 0, lastUpdated: 0 };
+  entry.value++;
+  entry.lastUpdated = now;
+  target.set(label, entry);
+}
+
+/**
+ * Record how long one evaluateReadings() call took.
+ */
+export function recordAlertEvaluationDuration(durationMs: number): void {
+  const h = metrics.alerts.evaluationDuration;
+  h.count++;
+  h.sum += durationMs;
+  h.min = Math.min(h.min, durationMs);
+  h.max = Math.max(h.max, durationMs);
+  h.lastUpdated = Date.now();
+}
+
 /**
  * Record database query
  */
@@ -218,6 +271,16 @@ export function getMetricsSnapshot(): Record<string, unknown> {
       ? Math.round(metrics.database.totalQueryTime / metrics.database.queryCount)
       : 0;
 
+  const alertsFiredCounts: Record<string, number> = {};
+  for (const [key, entry] of metrics.alertsFired) alertsFiredCounts[key] = entry.value;
+
+  const alertsResolvedCounts: Record<string, number> = {};
+  for (const [key, entry] of metrics.alertsResolved) alertsResolvedCounts[key] = entry.value;
+
+  const alertEvalDuration = metrics.alerts.evaluationDuration;
+  const avgAlertEvaluationDuration =
+    alertEvalDuration.count > 0 ? Math.round(alertEvalDuration.sum / alertEvalDuration.count) : 0;
+
   return {
     requests: {
       latency: requestStats,
@@ -238,6 +301,12 @@ export function getMetricsSnapshot(): Record<string, unknown> {
     database: {
       ...metrics.database,
       avgQueryTime,
+    },
+    alerts: {
+      fired: alertsFiredCounts,
+      resolved: alertsResolvedCounts,
+      evaluationErrors: metrics.alerts.evaluationErrors,
+      avgEvaluationDuration: avgAlertEvaluationDuration,
     },
     timestamp: new Date().toISOString(),
   };
@@ -304,6 +373,26 @@ export function getPrometheusMetrics(): string {
   lines.push('# TYPE db_slow_queries_total counter');
   lines.push(`db_slow_queries_total ${metrics.database.slowQueries}`);
 
+  // Alerting metrics
+  lines.push('# HELP alerts_fired_total Total alerts that started firing');
+  lines.push('# TYPE alerts_fired_total counter');
+  for (const [severity, entry] of metrics.alertsFired)
+    lines.push(`alerts_fired_total{severity="${severity}"} ${entry.value}`);
+
+  lines.push('# HELP alerts_resolved_total Total alerts resolved, by resolution kind');
+  lines.push('# TYPE alerts_resolved_total counter');
+  for (const [resolution, entry] of metrics.alertsResolved)
+    lines.push(`alerts_resolved_total{resolution="${resolution}"} ${entry.value}`);
+
+  lines.push('# HELP alert_evaluation_duration_ms Alert rule evaluation latency');
+  lines.push('# TYPE alert_evaluation_duration_ms histogram');
+  lines.push(`alert_evaluation_duration_ms_count ${metrics.alerts.evaluationDuration.count}`);
+  lines.push(`alert_evaluation_duration_ms_sum ${metrics.alerts.evaluationDuration.sum}`);
+
+  lines.push('# HELP alert_evaluation_errors_total Alert evaluations that threw');
+  lines.push('# TYPE alert_evaluation_errors_total counter');
+  lines.push(`alert_evaluation_errors_total ${metrics.alerts.evaluationErrors}`);
+
   return lines.join('\n');
 }
 
@@ -318,4 +407,10 @@ export function resetMetrics(): void {
   metrics.cache = { hits: 0, misses: 0, sets: 0, invalidations: 0 };
   metrics.ingestion = { total: 0, errors: 0, lastBatchSize: 0, lastBatchTime: 0 };
   metrics.database = { queryCount: 0, slowQueries: 0, totalQueryTime: 0 };
+  metrics.alertsFired.clear();
+  metrics.alertsResolved.clear();
+  metrics.alerts = {
+    evaluationErrors: 0,
+    evaluationDuration: { count: 0, sum: 0, min: Infinity, max: -Infinity, lastUpdated: 0 },
+  };
 }

--- a/lib/monitoring/metrics.ts
+++ b/lib/monitoring/metrics.ts
@@ -185,9 +185,18 @@ export type AlertSeverityLabel = 'info' | 'warning' | 'critical';
 /**
  * Record an alerting lifecycle event.
  *
- * `evaluation_error` matters most: evaluation failures are swallowed by design so
- * they cannot drop readings, which makes this counter the only signal that
- * alerting has silently stopped working.
+ * `evaluation_error` matters most: evaluation failures are swallowed by design
+ * so they cannot drop readings, which means nothing about the request tells you
+ * the evaluator broke.
+ *
+ * This counter is the cheap in-process rate signal for that — how OFTEN it is
+ * failing, at a glance, with no per-failure detail. It complements rather than
+ * replaces the real escalation: `lib/alerting/index.ts`'s `reportToSentry()`
+ * forwards each swallowed failure to Sentry with stack and context. Two reasons
+ * this counter cannot stand alone: it is per-process memory that resets on every
+ * serverless cold start, and reading it means `GET /api/v2/metrics`, which sits
+ * behind `requireAdmin()` and `ENABLE_METRICS` (shipped `false` in
+ * `example.env`). Treat a nonzero value as a prompt to go look in Sentry.
  */
 export function recordAlert(
   event: 'fired' | 'resolved' | 'evaluation_error',

--- a/lib/monitoring/metrics.ts
+++ b/lib/monitoring/metrics.ts
@@ -60,6 +60,8 @@ interface MetricsStore {
   /** Alert counters keyed by label value */
   alertsFired: Map<string, CounterEntry>;
   alertsResolved: Map<string, CounterEntry>;
+  /** Rules skipped during evaluation, keyed by skip reason */
+  alertRulesSkipped: Map<string, CounterEntry>;
   alerts: {
     evaluationErrors: number;
     evaluationDuration: HistogramEntry;
@@ -80,6 +82,7 @@ const metrics: MetricsStore = {
   database: { queryCount: 0, slowQueries: 0, totalQueryTime: 0 },
   alertsFired: new Map(),
   alertsResolved: new Map(),
+  alertRulesSkipped: new Map(),
   alerts: {
     evaluationErrors: 0,
     evaluationDuration: { count: 0, sum: 0, min: Infinity, max: -Infinity, lastUpdated: 0 },
@@ -205,6 +208,23 @@ export function recordAlert(
   target.set(label, entry);
 }
 
+export type AlertRuleSkipReason = 'unknown_metric' | 'invalid_rule_id' | 'unexpected_error';
+
+/**
+ * Record a rule the evaluator could not use and skipped for the rest of that
+ * call. Reached only when a rule's own data is unusable — an unrecognized
+ * `metric`, an `_id` that will not parse as an ObjectId, or some other error
+ * during matching — which a `.lean()` read or a stale Redis cache entry can
+ * hand the evaluator without re-validating. Distinct from `evaluation_error`:
+ * the call itself still completed and every other rule was still evaluated.
+ */
+export function recordAlertRuleSkipped(reason: AlertRuleSkipReason): void {
+  const entry = metrics.alertRulesSkipped.get(reason) || { value: 0, lastUpdated: 0 };
+  entry.value++;
+  entry.lastUpdated = Date.now();
+  metrics.alertRulesSkipped.set(reason, entry);
+}
+
 /**
  * Record how long one evaluateReadings() call took.
  */
@@ -277,6 +297,9 @@ export function getMetricsSnapshot(): Record<string, unknown> {
   const alertsResolvedCounts: Record<string, number> = {};
   for (const [key, entry] of metrics.alertsResolved) alertsResolvedCounts[key] = entry.value;
 
+  const alertRulesSkippedCounts: Record<string, number> = {};
+  for (const [key, entry] of metrics.alertRulesSkipped) alertRulesSkippedCounts[key] = entry.value;
+
   const alertEvalDuration = metrics.alerts.evaluationDuration;
   const avgAlertEvaluationDuration =
     alertEvalDuration.count > 0 ? Math.round(alertEvalDuration.sum / alertEvalDuration.count) : 0;
@@ -305,6 +328,7 @@ export function getMetricsSnapshot(): Record<string, unknown> {
     alerts: {
       fired: alertsFiredCounts,
       resolved: alertsResolvedCounts,
+      rulesSkipped: alertRulesSkippedCounts,
       evaluationErrors: metrics.alerts.evaluationErrors,
       avgEvaluationDuration: avgAlertEvaluationDuration,
     },
@@ -384,6 +408,13 @@ export function getPrometheusMetrics(): string {
   for (const [resolution, entry] of metrics.alertsResolved)
     lines.push(`alerts_resolved_total{resolution="${resolution}"} ${entry.value}`);
 
+  lines.push(
+    '# HELP alert_rules_skipped_total Rules the evaluator could not use and skipped, by reason'
+  );
+  lines.push('# TYPE alert_rules_skipped_total counter');
+  for (const [reason, entry] of metrics.alertRulesSkipped)
+    lines.push(`alert_rules_skipped_total{reason="${reason}"} ${entry.value}`);
+
   lines.push('# HELP alert_evaluation_duration_ms Alert rule evaluation latency');
   lines.push('# TYPE alert_evaluation_duration_ms histogram');
   lines.push(`alert_evaluation_duration_ms_count ${metrics.alerts.evaluationDuration.count}`);
@@ -409,6 +440,7 @@ export function resetMetrics(): void {
   metrics.database = { queryCount: 0, slowQueries: 0, totalQueryTime: 0 };
   metrics.alertsFired.clear();
   metrics.alertsResolved.clear();
+  metrics.alertRulesSkipped.clear();
   metrics.alerts = {
     evaluationErrors: 0,
     evaluationDuration: { count: 0, sum: 0, min: Infinity, max: -Infinity, lastUpdated: 0 },

--- a/lib/monitoring/sentry.ts
+++ b/lib/monitoring/sentry.ts
@@ -1,14 +1,43 @@
 /**
- * Optional Sentry Integration
+ * Sentry Integration
  *
- * Conditionally initializes Sentry if SENTRY_DSN is configured.
- * Provides error tracking and performance monitoring.
+ * Sentry itself stays optional — every helper here is a no-op when no
+ * `SENTRY_DSN` is configured. Thin wrapper over the `@sentry/nextjs` module
+ * singleton, used by
+ * `withErrorHandler` and by `lib/alerting`'s swallowed-failure escalation.
+ *
+ * WHY THIS FILE IMPORTS SENTRY STATICALLY AND GATES ON CONFIGURATION:
+ *
+ * Production never calls `initSentry()`. Next.js initializes Sentry through
+ * `instrumentation.ts` -> `sentry.server.config.ts` / `sentry.edge.config.ts`,
+ * each of which calls `Sentry.init()` on the `@sentry/nextjs` module singleton.
+ * An earlier version of this file lazily `await import(...)`-ed the SDK inside
+ * `initSentry()`, stashed it in a module-local, and gated every capture helper
+ * on that local being populated. Since nothing in production ever called
+ * `initSentry()`, the local stayed `null` and EVERY `captureException()` in the
+ * codebase returned early — the escalation path was dead code across the whole
+ * app, and the only thing that hid it was a unit test that called
+ * `initSentry()` itself, which production does not do.
+ *
+ * So: the helpers below talk to the same module singleton the Next.js config
+ * files initialize, and they gate on `isSentryConfigured()` (is a DSN set at
+ * all?) rather than on this module's private state. Do not reintroduce a
+ * module-local initialization flag as a precondition for capturing.
+ *
+ * The import is static rather than dynamic on purpose. `@sentry/nextjs` is a
+ * hard dependency (package.json), the `sentry.*.config.ts` files already import
+ * it statically, and the dynamic import is what created the
+ * initialization-order trap in the first place.
  */
 
-import type * as SentryTypes from '@sentry/nextjs';
+import * as Sentry from '@sentry/nextjs';
 
+/**
+ * Guards `initSentry()`'s idempotency and NOTHING else. Deliberately not
+ * consulted by any capture helper — see the file header: making it a
+ * precondition is exactly how the escalation path became dead code.
+ */
 let sentryInitialized = false;
-let Sentry: typeof SentryTypes | null = null;
 
 /**
  * Check if Sentry is configured
@@ -18,8 +47,16 @@ export function isSentryConfigured(): boolean {
 }
 
 /**
- * Initialize Sentry if configured
- * Should be called early in the application lifecycle
+ * Initialize Sentry if configured.
+ *
+ * Retained for entry points that are NOT Next.js request handlers (standalone
+ * scripts under `scripts/v2/`, one-off tooling) and re-exported from
+ * `lib/monitoring/index.ts`. Inside the Next.js server and edge runtimes this
+ * is redundant: `instrumentation.ts` has already initialized the same
+ * singleton, and calling this again would just re-`init()` it.
+ *
+ * Calling it is NOT a precondition for `captureException()` / `captureMessage()`
+ * / `addBreadcrumb()` to reach Sentry.
  */
 export async function initSentry(): Promise<boolean> {
   const dsn = process.env.SENTRY_DSN;
@@ -29,9 +66,6 @@ export async function initSentry(): Promise<boolean> {
   if (sentryInitialized) return true;
 
   try {
-    // Dynamic import for optional Sentry dependency
-    Sentry = await import('@sentry/nextjs');
-
     Sentry.init({
       dsn,
       environment: process.env.NODE_ENV || 'development',
@@ -68,13 +102,17 @@ export async function initSentry(): Promise<boolean> {
  * classifier like `{ subsystem: 'alerting' }` as `tags`, not folded into `context` — nesting it
  * under `extra` (e.g. `captureException(err, { tags: {...} })`) does NOT make it a real tag, it
  * just produces a literal `tags` key inside Additional Data.
+ *
+ * Gated on DSN configuration, never on `initSentry()` having run — see the file
+ * header. With no DSN the SDK is inert anyway, but returning early keeps the
+ * documented `undefined` return that callers use to mean "not escalated".
  */
 export function captureException(
   error: Error,
   context?: Record<string, unknown>,
   tags?: Record<string, string>
 ): string | undefined {
-  if (!Sentry || !sentryInitialized) return undefined;
+  if (!isSentryConfigured()) return undefined;
 
   return Sentry.captureException(error, {
     extra: context,
@@ -90,7 +128,7 @@ export function captureMessage(
   level: 'info' | 'warning' | 'error' = 'info',
   context?: Record<string, unknown>
 ): string | undefined {
-  if (!Sentry || !sentryInitialized) return undefined;
+  if (!isSentryConfigured()) return undefined;
 
   return Sentry.captureMessage(message, {
     level,
@@ -107,7 +145,7 @@ export function addBreadcrumb(
   data?: Record<string, unknown>,
   level: 'debug' | 'info' | 'warning' | 'error' = 'info'
 ): void {
-  if (!Sentry || !sentryInitialized) return;
+  if (!isSentryConfigured()) return;
 
   Sentry.addBreadcrumb({
     message,
@@ -128,7 +166,7 @@ export function setUser(
     [key: string]: unknown;
   } | null
 ): void {
-  if (!Sentry || !sentryInitialized) return;
+  if (!isSentryConfigured()) return;
 
   Sentry.setUser(user);
 }
@@ -137,7 +175,7 @@ export function setUser(
  * Set additional context tags
  */
 export function setTag(key: string, value: string): void {
-  if (!Sentry || !sentryInitialized) return;
+  if (!isSentryConfigured()) return;
 
   Sentry.setTag(key, value);
 }
@@ -146,7 +184,7 @@ export function setTag(key: string, value: string): void {
  * Set extra context data
  */
 export function setExtra(key: string, value: unknown): void {
-  if (!Sentry || !sentryInitialized) return;
+  if (!isSentryConfigured()) return;
 
   Sentry.setExtra(key, value);
 }
@@ -155,7 +193,7 @@ export function setExtra(key: string, value: unknown): void {
  * Start a new transaction for performance monitoring
  */
 export function startTransaction(name: string, op: string): { finish: () => void } | undefined {
-  if (!Sentry || !sentryInitialized) return undefined;
+  if (!isSentryConfigured()) return undefined;
 
   const transaction = Sentry.startInactiveSpan({
     name,

--- a/lib/monitoring/sentry.ts
+++ b/lib/monitoring/sentry.ts
@@ -61,16 +61,24 @@ export async function initSentry(): Promise<boolean> {
 }
 
 /**
- * Capture an exception to Sentry
+ * Capture an exception to Sentry.
+ *
+ * `context` lands under Sentry's "Additional Data" (`extra`) — searchable but not filterable.
+ * `tags` are indexed, filterable facets (Sentry's Tags panel / issue search). Pass a coarse
+ * classifier like `{ subsystem: 'alerting' }` as `tags`, not folded into `context` — nesting it
+ * under `extra` (e.g. `captureException(err, { tags: {...} })`) does NOT make it a real tag, it
+ * just produces a literal `tags` key inside Additional Data.
  */
 export function captureException(
   error: Error,
-  context?: Record<string, unknown>
+  context?: Record<string, unknown>,
+  tags?: Record<string, string>
 ): string | undefined {
   if (!Sentry || !sentryInitialized) return undefined;
 
   return Sentry.captureException(error, {
     extra: context,
+    ...(tags ? { tags } : {}),
   });
 }
 

--- a/lib/pusher-channels.ts
+++ b/lib/pusher-channels.ts
@@ -1,0 +1,30 @@
+/**
+ * Pusher channel names, shared by the server publishers and the browser client.
+ *
+ * These live in their own dependency-free module on purpose. The obvious home
+ * would be `lib/alerting/notify.ts` (server) or `lib/pusher-context.tsx`
+ * (browser), but importing either one from the other side of the boundary drags
+ * along `lib/pusher` (which throws unless the server-only PUSHER_SECRET is set)
+ * or `pusher-js`. A module containing nothing but string constants can be
+ * imported from a route handler, a client component, and a test alike.
+ */
+
+/**
+ * Public channel carrying sensor readings.
+ *
+ * Deliberately NOT `private-`. `app/api/v2/cron/simulate/route.ts` publishes
+ * readings here, and readings were already public before the alerting
+ * subsystem existed. Renaming it would silently break that producer.
+ */
+export const READINGS_CHANNEL = 'InfraSight';
+
+/**
+ * Private channel carrying alert envelopes.
+ *
+ * The `private-` prefix is load-bearing, not cosmetic: it is what makes
+ * pusher-js call `channelAuthorization.endpoint` (`/api/pusher/auth`) before
+ * subscribing. On a public channel, anyone holding `NEXT_PUBLIC_PUSHER_KEY` —
+ * which is readable in the JS bundle by design — could stream the whole
+ * fleet's alert feed, including rule names, device ids and trigger values.
+ */
+export const ALERT_CHANNEL = 'private-alerts';

--- a/lib/pusher-client.ts
+++ b/lib/pusher-client.ts
@@ -1,5 +1,13 @@
 import Pusher from 'pusher-js';
 
+/**
+ * Endpoint pusher-js posts to before it will join a `private-` channel.
+ *
+ * Exported so the route handler and its tests can agree on the path with the
+ * client that calls it. See `app/api/pusher/auth/route.ts`.
+ */
+export const PUSHER_AUTH_ENDPOINT = '/api/pusher/auth';
+
 // Singleton Pusher client instance for reuse across components
 let pusherInstance: Pusher | null = null;
 
@@ -19,6 +27,15 @@ export function getPusherClient(): Pusher {
   // Create new instance
   pusherInstance = new Pusher(key, {
     cluster: cluster,
+    // Required for the private alert channel. `transport: 'ajax'` makes pusher-js
+    // POST socket_id/channel_name as a form body to the endpoint below and send
+    // the browser's cookies with it, which is what lets the route identify the
+    // caller through Clerk. Without this block a `private-` subscription fails
+    // immediately with a subscription_error and no alert ever arrives.
+    channelAuthorization: {
+      endpoint: PUSHER_AUTH_ENDPOINT,
+      transport: 'ajax',
+    },
   });
 
   return pusherInstance;

--- a/lib/pusher-context.tsx
+++ b/lib/pusher-context.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useEffect, useRef, useCallback } from 'react';
 import { getPusherClient } from '@/lib/pusher-client';
+import type { AlertEvent } from '@/types/v2/alert.types';
 
 /**
  * Shape of a reading received from Pusher on the 'new-readings' event.
@@ -18,24 +19,30 @@ export interface PusherReading {
 }
 
 type ReadingsCallback = (readings: PusherReading[]) => void;
+export type AlertsCallback = (event: AlertEvent) => void;
 
 interface PusherContextValue {
   /** Register a callback that fires every time new readings arrive. */
   subscribe: (cb: ReadingsCallback) => void;
   /** Remove a previously registered callback. */
   unsubscribe: (cb: ReadingsCallback) => void;
+  /** Register a callback that fires for every alert envelope. */
+  subscribeAlerts: (cb: AlertsCallback) => void;
+  /** Remove a previously registered alert callback. */
+  unsubscribeAlerts: (cb: AlertsCallback) => void;
 }
 
 const PusherContext = createContext<PusherContextValue | null>(null);
 
 /**
- * Provides a single Pusher subscription to the `InfraSight` channel and
- * `new-readings` event. All consuming components share this one subscription
- * instead of each creating their own, which prevents duplicate event
- * processing and the associated extra re-renders.
+ * Provides a single Pusher subscription to the `InfraSight` channel and its
+ * `new-readings` and `alert-event` events. All consuming components share
+ * this one subscription instead of each creating their own, which prevents
+ * duplicate event processing and the associated extra re-renders.
  */
 export function PusherProvider({ children }: { children: React.ReactNode }) {
   const callbacksRef = useRef<Set<ReadingsCallback>>(new Set());
+  const alertCallbacksRef = useRef<Set<AlertsCallback>>(new Set());
 
   useEffect(() => {
     // Gracefully degrade when Pusher env vars are not configured.
@@ -61,10 +68,22 @@ export function PusherProvider({ children }: { children: React.ReactNode }) {
       });
     };
 
+    const alertHandler = (event: AlertEvent) => {
+      alertCallbacksRef.current.forEach(cb => {
+        try {
+          cb(event);
+        } catch (err) {
+          console.error('PusherProvider: error in alert subscriber callback', err);
+        }
+      });
+    };
+
     channel.bind('new-readings', handler);
+    channel.bind('alert-event', alertHandler);
 
     return () => {
       channel.unbind('new-readings', handler);
+      channel.unbind('alert-event', alertHandler);
       pusher.unsubscribe('InfraSight');
     };
   }, []);
@@ -77,8 +96,18 @@ export function PusherProvider({ children }: { children: React.ReactNode }) {
     callbacksRef.current.delete(cb);
   }, []);
 
+  const subscribeAlerts = useCallback((cb: AlertsCallback) => {
+    alertCallbacksRef.current.add(cb);
+  }, []);
+
+  const unsubscribeAlerts = useCallback((cb: AlertsCallback) => {
+    alertCallbacksRef.current.delete(cb);
+  }, []);
+
   return (
-    <PusherContext.Provider value={{ subscribe, unsubscribe }}>
+    <PusherContext.Provider
+      value={{ subscribe, unsubscribe, subscribeAlerts, unsubscribeAlerts }}
+    >
       {children}
     </PusherContext.Provider>
   );
@@ -123,6 +152,43 @@ export function usePusherReadings(callback: ReadingsCallback): void {
     ctx.subscribe(stableCallback);
     return () => {
       ctx.unsubscribe(stableCallback);
+    };
+  }, [ctx]);
+}
+
+/**
+ * Hook for components that need to react to real-time alert envelopes.
+ *
+ * The callback is held in a ref so a caller that does not memoize will not cause
+ * a re-subscribe on every render. The ref is refreshed in a commit-phase effect
+ * rather than assigned during render: assigning during render violates
+ * react-hooks/refs, and Pusher handlers only ever read the ref asynchronously,
+ * long after commit.
+ */
+export function usePusherAlerts(callback: AlertsCallback): void {
+  const ctx = useContext(PusherContext);
+
+  const callbackRef = useRef<AlertsCallback>(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    if (!ctx) {
+      console.warn(
+        'usePusherAlerts: PusherProvider is not in the component tree. Real-time alerts are disabled.'
+      );
+      return;
+    }
+
+    const stableCallback: AlertsCallback = event => {
+      callbackRef.current(event);
+    };
+
+    ctx.subscribeAlerts(stableCallback);
+    return () => {
+      ctx.unsubscribeAlerts(stableCallback);
     };
   }, [ctx]);
 }

--- a/lib/pusher-context.tsx
+++ b/lib/pusher-context.tsx
@@ -1,7 +1,16 @@
 'use client';
 
-import { createContext, useContext, useEffect, useRef, useCallback } from 'react';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+  useState,
+} from 'react';
 import { getPusherClient } from '@/lib/pusher-client';
+import { ALERT_CHANNEL, READINGS_CHANNEL } from '@/lib/pusher-channels';
 import type { AlertEvent } from '@/types/v2/alert.types';
 
 /**
@@ -21,6 +30,162 @@ export interface PusherReading {
 type ReadingsCallback = (readings: PusherReading[]) => void;
 export type AlertsCallback = (event: AlertEvent) => void;
 
+// ============================================================================
+// CONNECTION HEALTH
+// ============================================================================
+
+/**
+ * What the realtime layer is currently doing, from the app's point of view.
+ *
+ * Not a straight copy of pusher-js's own connection states: `no-provider` and
+ * `not-configured` are conditions pusher-js never reports (there is no client
+ * to report them), and `unauthorized` is a channel-level failure that leaves
+ * the socket itself perfectly healthy.
+ */
+export type RealtimeState =
+  | 'connecting'
+  | 'connected'
+  /** Socket dropped; pusher-js is retrying on its own. */
+  | 'reconnecting'
+  /** Socket closed and pusher-js will NOT retry (4000-4099 close codes). */
+  | 'failed'
+  /** NEXT_PUBLIC_PUSHER_* not set — the client was never constructed. */
+  | 'not-configured'
+  /** Socket is up but the private alert channel refused us. */
+  | 'unauthorized'
+  /** No PusherProvider above this component. */
+  | 'no-provider';
+
+export interface RealtimeConnection {
+  /** True only when alerts are genuinely arriving live. Drives the poll fallback. */
+  connected: boolean;
+  state: RealtimeState;
+  /**
+   * True when the user should be told. Distinct from `!connected` so the first
+   * second of every page load — a perfectly normal `connecting` — does not
+   * flash a scary banner at everyone.
+   */
+  degraded: boolean;
+  /** Operator-facing explanation. Null while healthy. */
+  message: string | null;
+  /** True when nothing will recover this without a reload. */
+  terminal: boolean;
+}
+
+/** Internal state the provider tracks; `RealtimeConnection` is derived from it. */
+interface RealtimeStatus {
+  /** Raw pusher-js connection state, or null before the client exists. */
+  socket: string | null;
+  /** Whether the private alert channel subscription succeeded. */
+  alerts: 'pending' | 'subscribed' | 'rejected';
+  configured: boolean;
+  /** Set when Pusher reports a close code it will not retry. */
+  fatal: string | null;
+}
+
+const INITIAL_STATUS: RealtimeStatus = {
+  socket: null,
+  alerts: 'pending',
+  configured: true,
+  fatal: null,
+};
+
+/**
+ * Pusher close codes 4000-4099 are terminal by protocol: the client is told not
+ * to retry. 4004 (quota exceeded) and 4001 (unknown app key) both land here, and
+ * both otherwise present as a socket that simply stops delivering forever.
+ */
+function isTerminalCloseCode(code: number | undefined): boolean {
+  return typeof code === 'number' && code >= 4000 && code <= 4099;
+}
+
+function deriveConnection(status: RealtimeStatus): RealtimeConnection {
+  if (!status.configured)
+    return {
+      connected: false,
+      state: 'not-configured',
+      degraded: true,
+      message:
+        'Real-time updates are not configured on this deployment. Data refreshes on a timer instead.',
+      terminal: true,
+    };
+
+  if (status.fatal)
+    return {
+      connected: false,
+      state: 'failed',
+      degraded: true,
+      message: `${status.fatal} Reload the page to try again. Data refreshes on a timer meanwhile.`,
+      terminal: true,
+    };
+
+  if (status.socket === 'failed' || status.socket === 'disconnected')
+    return {
+      connected: false,
+      state: 'failed',
+      degraded: true,
+      message:
+        'The real-time connection closed and will not reopen on its own. Reload the page to restore live updates.',
+      terminal: true,
+    };
+
+  if (status.socket === 'unavailable')
+    return {
+      connected: false,
+      state: 'reconnecting',
+      degraded: true,
+      message:
+        'Lost the real-time connection — retrying. Data refreshes on a timer until it is back.',
+      terminal: false,
+    };
+
+  if (status.socket !== 'connected')
+    return {
+      connected: false,
+      state: 'connecting',
+      degraded: false,
+      message: null,
+      terminal: false,
+    };
+
+  // Socket is up. The alert channel can still have been refused on its own —
+  // an expired session, or a member removed from the org — and that leaves
+  // readings flowing while alerts silently stop.
+  if (status.alerts === 'rejected')
+    return {
+      connected: false,
+      state: 'unauthorized',
+      degraded: true,
+      message:
+        'Not authorized for live alerts. Your session may have expired — sign in again. Alerts refresh on a timer meanwhile.',
+      terminal: true,
+    };
+
+  if (status.alerts === 'pending')
+    return {
+      connected: false,
+      state: 'connecting',
+      degraded: false,
+      message: null,
+      terminal: false,
+    };
+
+  return { connected: true, state: 'connected', degraded: false, message: null, terminal: false };
+}
+
+/**
+ * What a consumer sees with no provider above it. A frozen module constant
+ * rather than a fresh object per call so it is referentially stable — hooks
+ * feed it straight into React Query options.
+ */
+const NO_PROVIDER_CONNECTION: RealtimeConnection = Object.freeze({
+  connected: false,
+  state: 'no-provider' as const,
+  degraded: false,
+  message: null,
+  terminal: false,
+});
+
 interface PusherContextValue {
   /** Register a callback that fires every time new readings arrive. */
   subscribe: (cb: ReadingsCallback) => void;
@@ -30,22 +195,35 @@ interface PusherContextValue {
   subscribeAlerts: (cb: AlertsCallback) => void;
   /** Remove a previously registered alert callback. */
   unsubscribeAlerts: (cb: AlertsCallback) => void;
+  /** Live health of the realtime layer. */
+  connection: RealtimeConnection;
 }
 
 const PusherContext = createContext<PusherContextValue | null>(null);
 
 /**
- * Provides a single Pusher subscription to the `InfraSight` channel and its
- * `new-readings` and `alert-event` events. All consuming components share
- * this one subscription instead of each creating their own, which prevents
- * duplicate event processing and the associated extra re-renders.
+ * Provides the app's Pusher subscriptions and reports their health.
+ *
+ * TWO channels, deliberately:
+ *   - `InfraSight` (public) carries `new-readings`. It predates alerting and
+ *     `app/api/v2/cron/simulate/route.ts` publishes to it by that name.
+ *   - `private-alerts` carries `alert-event`. Alert payloads name a rule, a
+ *     device and the value that tripped it, so they are gated behind
+ *     `/api/pusher/auth`.
+ *
+ * All consuming components share these subscriptions instead of each creating
+ * their own, which prevents duplicate event processing and the associated extra
+ * re-renders.
  */
 export function PusherProvider({ children }: { children: React.ReactNode }) {
   const callbacksRef = useRef<Set<ReadingsCallback>>(new Set());
   const alertCallbacksRef = useRef<Set<AlertsCallback>>(new Set());
+  const [status, setStatus] = useState<RealtimeStatus>(INITIAL_STATUS);
 
   useEffect(() => {
-    // Gracefully degrade when Pusher env vars are not configured.
+    // Gracefully degrade when Pusher env vars are not configured. This used to
+    // be a console.warn and nothing else, which meant a misconfigured
+    // deployment looked identical to a quiet one: "No open alerts." forever.
     let pusher: ReturnType<typeof getPusherClient>;
     try {
       pusher = getPusherClient();
@@ -53,10 +231,13 @@ export function PusherProvider({ children }: { children: React.ReactNode }) {
       console.warn(
         'PusherProvider: Pusher environment variables are not set. Real-time updates are disabled.'
       );
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- Reflecting the state of an external system (the Pusher client) into React at subscribe time; it cannot be read during render because getPusherClient() must not run on the server.
+      setStatus(prev => ({ ...prev, configured: false }));
       return;
     }
 
-    const channel = pusher.subscribe('InfraSight');
+    const readingsChannel = pusher.subscribe(READINGS_CHANNEL);
+    const alertChannel = pusher.subscribe(ALERT_CHANNEL);
 
     const handler = (newReadings: PusherReading[]) => {
       callbacksRef.current.forEach(cb => {
@@ -78,13 +259,68 @@ export function PusherProvider({ children }: { children: React.ReactNode }) {
       });
     };
 
-    channel.bind('new-readings', handler);
-    channel.bind('alert-event', alertHandler);
+    const stateChangeHandler = ({ current }: { current: string }) => {
+      setStatus(prev => ({
+        ...prev,
+        socket: current,
+        // A fresh connection clears a previous fatal and gives a previously
+        // refused alert channel another chance — pusher-js re-authorizes every
+        // channel on reconnect, so a rejection from an expired session should
+        // not outlive the session it was about.
+        ...(current === 'connected'
+          ? { fatal: null, alerts: prev.alerts === 'rejected' ? ('pending' as const) : prev.alerts }
+          : {}),
+      }));
+    };
+
+    // pusher-js reports transport failures here. The payload for a protocol
+    // close carries the code under error.data.code.
+    const errorHandler = (err: unknown) => {
+      const data = (err as { error?: { data?: { code?: number; message?: string } } })?.error?.data;
+      console.error('PusherProvider: connection error', err);
+
+      if (isTerminalCloseCode(data?.code))
+        setStatus(prev => ({
+          ...prev,
+          fatal: `Real-time updates stopped (Pusher error ${data?.code}${
+            data?.message ? `: ${data.message}` : ''
+          }).`,
+        }));
+    };
+
+    const subscriptionSucceeded = () => setStatus(prev => ({ ...prev, alerts: 'subscribed' }));
+
+    const subscriptionError = (err: unknown) => {
+      console.error('PusherProvider: alert channel subscription failed', err);
+      setStatus(prev => ({ ...prev, alerts: 'rejected' }));
+    };
+
+    readingsChannel.bind('new-readings', handler);
+    alertChannel.bind('alert-event', alertHandler);
+    alertChannel.bind('pusher:subscription_succeeded', subscriptionSucceeded);
+    alertChannel.bind('pusher:subscription_error', subscriptionError);
+    pusher.connection.bind('state_change', stateChangeHandler);
+    pusher.connection.bind('error', errorHandler);
+
+    // Seed from the live socket. getPusherClient() is a singleton, so on a
+    // remount it may already be connected and already subscribed — in which
+    // case neither state_change nor subscription_succeeded is coming, and
+    // waiting for them would leave the app polling forever.
+    setStatus(prev => ({
+      ...prev,
+      socket: pusher.connection.state ?? prev.socket,
+      alerts: alertChannel.subscribed ? 'subscribed' : prev.alerts,
+    }));
 
     return () => {
-      channel.unbind('new-readings', handler);
-      channel.unbind('alert-event', alertHandler);
-      pusher.unsubscribe('InfraSight');
+      readingsChannel.unbind('new-readings', handler);
+      alertChannel.unbind('alert-event', alertHandler);
+      alertChannel.unbind('pusher:subscription_succeeded', subscriptionSucceeded);
+      alertChannel.unbind('pusher:subscription_error', subscriptionError);
+      pusher.connection.unbind('state_change', stateChangeHandler);
+      pusher.connection.unbind('error', errorHandler);
+      pusher.unsubscribe(READINGS_CHANNEL);
+      pusher.unsubscribe(ALERT_CHANNEL);
     };
   }, []);
 
@@ -104,13 +340,29 @@ export function PusherProvider({ children }: { children: React.ReactNode }) {
     alertCallbacksRef.current.delete(cb);
   }, []);
 
-  return (
-    <PusherContext.Provider
-      value={{ subscribe, unsubscribe, subscribeAlerts, unsubscribeAlerts }}
-    >
-      {children}
-    </PusherContext.Provider>
+  const connection = useMemo(() => deriveConnection(status), [status]);
+
+  const value = useMemo(
+    () => ({ subscribe, unsubscribe, subscribeAlerts, unsubscribeAlerts, connection }),
+    [subscribe, unsubscribe, subscribeAlerts, unsubscribeAlerts, connection]
   );
+
+  return <PusherContext.Provider value={value}>{children}</PusherContext.Provider>;
+}
+
+/**
+ * Health of the realtime layer, for anything that needs to behave differently
+ * when live updates are not arriving — the degraded banner, and the poll
+ * fallback in `lib/query/hooks/useAlerts.ts`.
+ *
+ * Returns a "not connected" reading rather than throwing when there is no
+ * provider: a component rendered outside the provider genuinely is not
+ * receiving live updates, and the honest answer makes callers fall back to
+ * polling instead of trusting a socket that isn't there.
+ */
+export function useRealtimeConnection(): RealtimeConnection {
+  const ctx = useContext(PusherContext);
+  return ctx?.connection ?? NO_PROVIDER_CONNECTION;
 }
 
 /**

--- a/lib/query/hooks/index.ts
+++ b/lib/query/hooks/index.ts
@@ -5,3 +5,5 @@ export * from './useAnomalies';
 export * from './useMetadata';
 export * from './useEnergyAnalytics';
 export * from './useSchedules';
+export * from './useAlerts';
+export * from './useAlertRules';

--- a/lib/query/hooks/useAlertRules.ts
+++ b/lib/query/hooks/useAlertRules.ts
@@ -1,0 +1,105 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { v2Api } from '@/lib/api/v2-client';
+import { queryKeys } from '../queryClient';
+import type { QueryConfig, MutationConfig } from '../types';
+import type {
+  AlertRuleV2Response,
+  ListAlertRulesQueryParams,
+  CreateAlertRuleBody,
+  UpdateAlertRuleBody,
+} from '@/types/v2';
+
+// ============================================================================
+// QUERY HOOKS
+// ============================================================================
+
+/**
+ * List alert rules. Long staleTime: rules are admin-authored configuration
+ * that changes almost never, unlike alerts which change on every ingest.
+ */
+export function useAlertRulesList(
+  filters: ListAlertRulesQueryParams = {},
+  config?: QueryConfig<AlertRuleV2Response[]>
+) {
+  return useQuery({
+    queryKey: queryKeys.alertRules.list(filters as Record<string, unknown>),
+    queryFn: async () => {
+      const response = await v2Api.alertRules.list(filters);
+      return response.data;
+    },
+    staleTime: 5 * 60 * 1000,
+    gcTime: 5 * 60 * 1000,
+    ...config,
+  });
+}
+
+export function useAlertRuleDetail(id: string, config?: QueryConfig<AlertRuleV2Response>) {
+  return useQuery({
+    queryKey: queryKeys.alertRules.detail(id),
+    queryFn: async () => {
+      const response = await v2Api.alertRules.getById(id);
+      return response.data;
+    },
+    enabled: !!id,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 5 * 60 * 1000,
+    ...config,
+  });
+}
+
+// ============================================================================
+// MUTATION HOOKS
+// ============================================================================
+
+export function useCreateAlertRule(
+  config?: MutationConfig<AlertRuleV2Response, CreateAlertRuleBody>
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (data: CreateAlertRuleBody) => {
+      const response = await v2Api.alertRules.create(data);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.alertRules.all });
+    },
+    ...config,
+  });
+}
+
+export function useUpdateAlertRule(
+  config?: MutationConfig<AlertRuleV2Response, { id: string; data: UpdateAlertRuleBody }>
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, data }: { id: string; data: UpdateAlertRuleBody }) => {
+      const response = await v2Api.alertRules.update(id, data);
+      return response.data;
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.alertRules.detail(variables.id) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.alertRules.all });
+    },
+    ...config,
+  });
+}
+
+export function useDeleteAlertRule(
+  config?: MutationConfig<{ _id: string; deleted: boolean; deleted_at?: string }, string>
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const response = await v2Api.alertRules.delete(id);
+      return response.data;
+    },
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.alertRules.detail(id) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.alertRules.all });
+    },
+    ...config,
+  });
+}

--- a/lib/query/hooks/useAlertRules.ts
+++ b/lib/query/hooks/useAlertRules.ts
@@ -81,6 +81,18 @@ export function useUpdateAlertRule(
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.alertRules.detail(variables.id) });
       queryClient.invalidateQueries({ queryKey: queryKeys.alertRules.all });
+      // Alerts too, not just rules. Editing a rule's metric/comparison/
+      // threshold closes every open episode carrying the now-false snapshot
+      // (see closeEpisodesOrphanedByConditionChange in
+      // app/api/v2/alert-rules/[id]/route.ts). Nothing patches alert rows into
+      // this cache, so without this the alerts list and the nav badge keep
+      // rendering those episodes as firing until something else invalidates
+      // them. The route also broadcasts, but that path is best-effort by
+      // design — notify.ts swallows a Pusher trigger failure so a committed
+      // write is never lost to a broadcast fault, and the socket may simply be
+      // down. This invalidation is the one refresh the acting admin's own
+      // client does not have to take on faith.
+      queryClient.invalidateQueries({ queryKey: queryKeys.alerts.all });
     },
     ...config,
   });

--- a/lib/query/hooks/useAlerts.ts
+++ b/lib/query/hooks/useAlerts.ts
@@ -1,21 +1,61 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { v2Api } from '@/lib/api/v2-client';
+import { useRealtimeConnection } from '@/lib/pusher-context';
 import { queryKeys } from '../queryClient';
 import type { QueryConfig, MutationConfig } from '../types';
 import type { AlertV2Response, ListAlertsQueryParams } from '@/types/v2';
+
+// ============================================================================
+// REALTIME FALLBACK
+// ============================================================================
+
+/** Poll cadence used only while the Pusher socket is NOT delivering. */
+export const REALTIME_FALLBACK_POLL_MS = 30 * 1000;
+
+/**
+ * `refetchInterval` for a query whose freshness normally comes from Pusher.
+ *
+ * Deliberately not an unconditional interval. While the socket is healthy every
+ * update already arrives as an event, and a background timer on top of that
+ * would put a request per alert surface per 30s on the API for no new
+ * information — on a wall display, forever. The interval exists for the case
+ * the socket cannot cover: a dropped connection, an unauthorized channel, or a
+ * terminal Pusher close code (4004 quota, 4001 bad key) that never
+ * auto-reconnects and would otherwise leave a screen reading "No open alerts."
+ * indefinitely.
+ */
+function useRealtimeFallbackInterval(): number | false {
+  const { connected } = useRealtimeConnection();
+  return connected ? false : REALTIME_FALLBACK_POLL_MS;
+}
 
 // ============================================================================
 // QUERY HOOKS
 // ============================================================================
 
 /**
- * List alerts. Short staleTime: the list changes on every ingest and is patched
- * live by usePusherAlerts, so React Query is the fallback rather than the driver.
+ * List alerts.
+ *
+ * Short staleTime because the set changes on every ingest.
+ *
+ * How this list stays current: NOTHING patches rows into the cache. There is no
+ * `setQueryData` anywhere in this subsystem. Consumers of the Pusher
+ * `alert-event` (AlertToaster, TopNav) call `invalidateQueries` and React Query
+ * refetches from `/api/v2/alerts`.
+ *
+ * That makes the invalidations load-bearing. Removing one because the rows
+ * "arrive over the socket anyway" is the regression it looks like an
+ * optimization: the socket carries the notification, never the row, and the
+ * list would then only change when something else happened to invalidate it.
+ * `refetchInterval` below is the fallback for when the socket is down, not a
+ * substitute for the invalidations.
  */
 export function useAlertsList(
   filters: ListAlertsQueryParams = {},
   config?: QueryConfig<AlertV2Response[]>
 ) {
+  const refetchInterval = useRealtimeFallbackInterval();
+
   return useQuery({
     queryKey: queryKeys.alerts.list(filters as Record<string, unknown>),
     queryFn: async () => {
@@ -24,6 +64,8 @@ export function useAlertsList(
     },
     staleTime: 30 * 1000,
     gcTime: 5 * 60 * 1000,
+    refetchInterval,
+    // Spread last so a caller can still override any of the above.
     ...config,
   });
 }
@@ -56,6 +98,8 @@ export function useAlertDetail(
  * 100 full alert documents on every navigation to render one number.
  */
 export function useOpenAlertCount(config?: QueryConfig<number>) {
+  const refetchInterval = useRealtimeFallbackInterval();
+
   return useQuery({
     queryKey: queryKeys.alerts.list({ count: true }),
     queryFn: async () => {
@@ -65,6 +109,10 @@ export function useOpenAlertCount(config?: QueryConfig<number>) {
     },
     staleTime: 30 * 1000,
     gcTime: 5 * 60 * 1000,
+    // The nav badge is the one alert surface visible on every route, so a
+    // silently dead socket shows here first. See useRealtimeFallbackInterval.
+    refetchInterval,
+    // Spread last so a caller can still override any of the above.
     ...config,
   });
 }

--- a/lib/query/hooks/useAlerts.ts
+++ b/lib/query/hooks/useAlerts.ts
@@ -1,0 +1,110 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { v2Api } from '@/lib/api/v2-client';
+import { queryKeys } from '../queryClient';
+import type { QueryConfig, MutationConfig } from '../types';
+import type { AlertV2Response, ListAlertsQueryParams } from '@/types/v2';
+
+// ============================================================================
+// QUERY HOOKS
+// ============================================================================
+
+/**
+ * List alerts. Short staleTime: the list changes on every ingest and is patched
+ * live by usePusherAlerts, so React Query is the fallback rather than the driver.
+ */
+export function useAlertsList(
+  filters: ListAlertsQueryParams = {},
+  config?: QueryConfig<AlertV2Response[]>
+) {
+  return useQuery({
+    queryKey: queryKeys.alerts.list(filters as Record<string, unknown>),
+    queryFn: async () => {
+      const response = await v2Api.alerts.list(filters);
+      return response.data;
+    },
+    staleTime: 30 * 1000,
+    gcTime: 5 * 60 * 1000,
+    ...config,
+  });
+}
+
+export function useAlertDetail(
+  id: string,
+  options: { include_device?: boolean } = {},
+  config?: QueryConfig<AlertV2Response>
+) {
+  return useQuery({
+    queryKey: queryKeys.alerts.detail(id),
+    queryFn: async () => {
+      const response = await v2Api.alerts.getById(id, options);
+      return response.data;
+    },
+    enabled: !!id,
+    staleTime: 30 * 1000,
+    gcTime: 5 * 60 * 1000,
+    ...config,
+  });
+}
+
+/**
+ * Count of open alerts, for the nav badge.
+ *
+ * Reads `pagination.total` off a one-row page rather than counting a fetched
+ * array. Counting `data.length` would be wrong twice over: the API caps `limit`
+ * at 100 (`lib/validations/common.validation.ts:17`), so a real storm would
+ * display a frozen "100"; and TopNav renders on every route, so it would pull
+ * 100 full alert documents on every navigation to render one number.
+ */
+export function useOpenAlertCount(config?: QueryConfig<number>) {
+  return useQuery({
+    queryKey: queryKeys.alerts.list({ count: true }),
+    queryFn: async () => {
+      // No `status` filter — the server defaults to open (firing + acknowledged).
+      const response = await v2Api.alerts.list({ limit: 1 });
+      return response.pagination.total;
+    },
+    staleTime: 30 * 1000,
+    gcTime: 5 * 60 * 1000,
+    ...config,
+  });
+}
+
+// ============================================================================
+// MUTATION HOOKS
+// ============================================================================
+
+export function useAcknowledgeAlert(
+  config?: MutationConfig<AlertV2Response, { id: string; note?: string }>
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, note }: { id: string; note?: string }) => {
+      const response = await v2Api.alerts.acknowledge(id, note);
+      return response.data;
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.alerts.detail(variables.id) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.alerts.all });
+    },
+    ...config,
+  });
+}
+
+export function useResolveAlert(
+  config?: MutationConfig<AlertV2Response, { id: string; note?: string }>
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, note }: { id: string; note?: string }) => {
+      const response = await v2Api.alerts.resolve(id, note);
+      return response.data;
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.alerts.detail(variables.id) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.alerts.all });
+    },
+    ...config,
+  });
+}

--- a/lib/query/queryClient.ts
+++ b/lib/query/queryClient.ts
@@ -58,4 +58,14 @@ export const queryKeys = {
     list: (filters?: Record<string, unknown>) => ['schedules', 'list', filters] as const,
     detail: (id: string) => ['schedules', 'detail', id] as const,
   },
+  alerts: {
+    all: ['alerts'] as const,
+    list: (filters?: Record<string, unknown>) => ['alerts', 'list', filters] as const,
+    detail: (id: string) => ['alerts', 'detail', id] as const,
+  },
+  alertRules: {
+    all: ['alert-rules'] as const,
+    list: (filters?: Record<string, unknown>) => ['alert-rules', 'list', filters] as const,
+    detail: (id: string) => ['alert-rules', 'detail', id] as const,
+  },
 } as const;

--- a/lib/validations/v2/alert-rule.validation.ts
+++ b/lib/validations/v2/alert-rule.validation.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { READING_TYPES } from '@/models/v2/AlertRuleV2';
+import type { UpdateAlertRuleBody } from '@/types/v2/alert.types';
 import {
   buildingIdSchema,
   floorSchema,
@@ -81,37 +82,85 @@ const THRESHOLD_BOUNDS_MESSAGE =
 // CREATE
 // ============================================================================
 
-export const createAlertRuleSchema = z
-  .object({
-    name: z.string().min(1, 'Name is required').max(200, 'Name must be 200 characters or less'),
-    description: z.string().max(1000, 'Description must be 1000 characters or less').optional(),
-    enabled: z.union([z.boolean(), z.string().transform(v => v === 'true')]).default(true),
-    selector: alertRuleSelectorSchema.default({}),
-    metric: alertMetricSchema,
-    comparison: alertComparisonSchema,
+/**
+ * The fields every metric arm shares, including their defaults. Spread into
+ * each arm below so the three arms cannot drift on `cooldown_seconds`'s
+ * default or `name`'s length cap.
+ */
+const alertRuleBaseShape = {
+  name: z.string().min(1, 'Name is required').max(200, 'Name must be 200 characters or less'),
+  description: z.string().max(1000, 'Description must be 1000 characters or less').optional(),
+  enabled: z.union([z.boolean(), z.string().transform(v => v === 'true')]).default(true),
+  comparison: alertComparisonSchema,
+  for_duration_seconds: z
+    .number()
+    .int('for_duration_seconds must be an integer')
+    .min(0)
+    .max(86400, 'for_duration_seconds cannot exceed 24 hours')
+    .default(0),
+  severity: alertSeveritySchema,
+  cooldown_seconds: z
+    .number()
+    .int('cooldown_seconds must be an integer')
+    .min(0)
+    .max(86400, 'cooldown_seconds cannot exceed 24 hours')
+    .default(300),
+};
+
+/**
+ * `metric: 'value'` requires at least one reading type — see
+ * `typesRequiredForValueMetric` for why. Expressed as a required, non-empty
+ * `types` on this arm's selector rather than as a cross-field refinement, so
+ * the constraint survives into `z.input<typeof createAlertRuleSchema>`.
+ */
+const valueMetricSelectorSchema = alertRuleSelectorSchema.extend({
+  types: z.array(readingTypeSchema).min(1, TYPES_REQUIRED_MESSAGE).max(15),
+});
+
+/**
+ * A DISCRIMINATED UNION, not a flat object with refinements.
+ *
+ * The flat version accepted `{ metric: 'value', … }` with no `selector` and
+ * `{ metric: 'anomaly_score', threshold: 30 }` at the TYPE level and rejected
+ * both at runtime, which is why `z.infer` of it was a trap: it described a
+ * request shape the API always 400s. Discriminating on `metric` moves both
+ * constraints into the type, so `z.input<typeof createAlertRuleSchema>` and the
+ * hand-written `CreateAlertRuleBody` (types/v2/alert.types.ts) finally describe
+ * the same request. The conformance assertions in
+ * __tests__/unit/types/alerting-type-contracts.test.ts keep them that way.
+ *
+ * Runtime behaviour is unchanged in what it accepts and rejects. The two
+ * refinement helpers above are still the single statement of each rule and are
+ * still used by `updateAlertRuleSchema`; here their messages are attached to
+ * the arm-level constraints that now enforce them.
+ */
+export const createAlertRuleSchema = z.discriminatedUnion('metric', [
+  z.object({
+    ...alertRuleBaseShape,
+    metric: z.literal('value'),
+    /** Unbounded: a value threshold is in the sensor's own unit. */
     threshold: z.number(),
-    for_duration_seconds: z
+    selector: valueMetricSelectorSchema,
+  }),
+  z.object({
+    ...alertRuleBaseShape,
+    metric: z.literal('anomaly_score'),
+    threshold: z
       .number()
-      .int('for_duration_seconds must be an integer')
-      .min(0)
-      .max(86400, 'for_duration_seconds cannot exceed 24 hours')
-      .default(0),
-    severity: alertSeveritySchema,
-    cooldown_seconds: z
+      .min(0, THRESHOLD_BOUNDS_MESSAGE)
+      .max(1, THRESHOLD_BOUNDS_MESSAGE),
+    selector: alertRuleSelectorSchema.default({}),
+  }),
+  z.object({
+    ...alertRuleBaseShape,
+    metric: z.literal('battery_level'),
+    threshold: z
       .number()
-      .int('cooldown_seconds must be an integer')
-      .min(0)
-      .max(86400, 'cooldown_seconds cannot exceed 24 hours')
-      .default(300),
-  })
-  .refine(thresholdWithinMetricBounds, {
-    message: THRESHOLD_BOUNDS_MESSAGE,
-    path: ['threshold'],
-  })
-  .refine(typesRequiredForValueMetric, {
-    message: TYPES_REQUIRED_MESSAGE,
-    path: ['selector', 'types'],
-  });
+      .min(0, THRESHOLD_BOUNDS_MESSAGE)
+      .max(100, THRESHOLD_BOUNDS_MESSAGE),
+    selector: alertRuleSelectorSchema.default({}),
+  }),
+]);
 
 // ============================================================================
 // UPDATE
@@ -187,7 +236,43 @@ export const alertRuleIdParamSchema = z.object({
 // TYPE EXPORTS
 // ============================================================================
 
-export type CreateAlertRuleInput = z.infer<typeof createAlertRuleSchema>;
-export type UpdateAlertRuleInput = z.infer<typeof updateAlertRuleSchema>;
+/**
+ * The request body a client SENDS (`z.input`), not the parsed output
+ * (`z.infer`/`z.output`) — the old export used `z.infer`, which describes the
+ * post-parse document, with every default already applied. It typed
+ * `cooldown_seconds` as required, so it was useless as a request type, and it
+ * was flat, so it accepted condition shapes the API always 400s.
+ *
+ * Now that `createAlertRuleSchema` is a discriminated union, `z.input` of it is
+ * the honest request type and is checked against the hand-written
+ * `CreateAlertRuleBody` by a conformance assertion (see
+ * __tests__/unit/types/alerting-type-contracts.test.ts).
+ */
+export type CreateAlertRuleInput = z.input<typeof createAlertRuleSchema>;
+
+/**
+ * Deliberately the hand-written union from `types/v2/alert.types.ts`, NOT
+ * `z.infer<typeof updateAlertRuleSchema>`.
+ *
+ * The inferred type is flat and all-optional, so `{ threshold: 5 }` satisfies
+ * it and the API always 400s it — precisely the trap this alias removes.
+ * `updateAlertRuleSchema` cannot be rewritten as a union to fix that at the
+ * source the way `createAlertRuleSchema` was: its contract is "every field
+ * optional, at least one present, and the four condition fields all-or-none",
+ * whose only Zod encoding is a `z.union` of a no-condition arm plus one arm per
+ * metric. Zod reports a union failure as a nested `invalid_union` issue whose
+ * own `message` is the literal string "Invalid input" — measured, not assumed —
+ * and PATCH /api/v2/alert-rules/[id] joins `errors.map(e => e.message)` straight
+ * into its 400 body, which `CreateAlertRuleModal` renders. Today a partial
+ * condition update answers with one actionable sentence ("metric, comparison,
+ * threshold and selector must be updated together — send all four or none");
+ * under a union it would answer "Invalid input".
+ *
+ * So the runtime keeps the refinements and the exported TYPE is the union that
+ * already encodes the same rule. A conformance assertion checks that every
+ * shape this type permits is a shape the schema accepts.
+ */
+export type UpdateAlertRuleInput = UpdateAlertRuleBody;
+
 export type ListAlertRulesQuery = z.infer<typeof listAlertRulesQuerySchema>;
 export type AlertRuleSelectorInput = z.infer<typeof alertRuleSelectorSchema>;

--- a/lib/validations/v2/alert-rule.validation.ts
+++ b/lib/validations/v2/alert-rule.validation.ts
@@ -12,7 +12,9 @@ import {
 // ENUMS
 // ============================================================================
 
-export const readingTypeSchema = z.enum(READING_TYPES as unknown as [string, ...string[]]);
+export const readingTypeSchema = z.enum(
+  READING_TYPES as unknown as [(typeof READING_TYPES)[number], ...(typeof READING_TYPES)[number][]]
+);
 export const alertMetricSchema = z.enum(['value', 'anomaly_score', 'battery_level']);
 export const alertComparisonSchema = z.enum(['gt', 'gte', 'lt', 'lte']);
 export const alertSeveritySchema = z.enum(['info', 'warning', 'critical']);

--- a/lib/validations/v2/alert-rule.validation.ts
+++ b/lib/validations/v2/alert-rule.validation.ts
@@ -1,0 +1,191 @@
+import { z } from 'zod';
+import { READING_TYPES } from '@/models/v2/AlertRuleV2';
+import {
+  buildingIdSchema,
+  floorSchema,
+  zoneSchema,
+  paginationSchema,
+  createSortSchema,
+} from '../common.validation';
+
+// ============================================================================
+// ENUMS
+// ============================================================================
+
+export const readingTypeSchema = z.enum(READING_TYPES as unknown as [string, ...string[]]);
+export const alertMetricSchema = z.enum(['value', 'anomaly_score', 'battery_level']);
+export const alertComparisonSchema = z.enum(['gt', 'gte', 'lt', 'lte']);
+export const alertSeveritySchema = z.enum(['info', 'warning', 'critical']);
+
+// ============================================================================
+// SELECTOR
+// ============================================================================
+
+/**
+ * Every dimension is optional; an absent dimension means "no constraint".
+ * A device must satisfy ALL present dimensions, and carry ALL listed tags.
+ */
+export const alertRuleSelectorSchema = z
+  .object({
+    types: z.array(readingTypeSchema).max(15).optional(),
+    building_id: buildingIdSchema.optional(),
+    floor: floorSchema.optional(),
+    zone: zoneSchema,
+    tags: z
+      .array(
+        z
+          .string()
+          .min(1, 'Tag cannot be empty')
+          .max(50, 'Tag must be 50 characters or less')
+          .regex(/^[a-zA-Z0-9_-]+$/, 'Tags can only contain alphanumeric characters, underscores, and hyphens')
+      )
+      .max(20, 'Cannot have more than 20 tags')
+      .optional(),
+  })
+  .strict();
+
+// ============================================================================
+// CROSS-FIELD REFINEMENTS
+// ============================================================================
+
+interface ConditionShape {
+  metric: 'value' | 'anomaly_score' | 'battery_level';
+  threshold: number;
+  selector: z.infer<typeof alertRuleSelectorSchema>;
+}
+
+/**
+ * A bare value threshold across mixed units is meaningless — 30 is a reasonable
+ * temperature ceiling and an absurd power one. anomaly_score and battery_level
+ * are unit-free and meaningful fleet-wide, so they may omit `types`.
+ */
+function typesRequiredForValueMetric(data: ConditionShape): boolean {
+  if (data.metric !== 'value') return true;
+  return (data.selector?.types?.length ?? 0) > 0;
+}
+
+/** Reject a rule that can never fire, at the edge rather than at evaluation. */
+function thresholdWithinMetricBounds(data: ConditionShape): boolean {
+  if (data.metric === 'anomaly_score') return data.threshold >= 0 && data.threshold <= 1;
+  if (data.metric === 'battery_level') return data.threshold >= 0 && data.threshold <= 100;
+  return true;
+}
+
+const TYPES_REQUIRED_MESSAGE = "selector.types must list at least one reading type when metric is 'value'";
+const THRESHOLD_BOUNDS_MESSAGE =
+  'threshold is outside the valid range for this metric (anomaly_score: 0-1, battery_level: 0-100)';
+
+// ============================================================================
+// CREATE
+// ============================================================================
+
+export const createAlertRuleSchema = z
+  .object({
+    name: z.string().min(1, 'Name is required').max(200, 'Name must be 200 characters or less'),
+    description: z.string().max(1000, 'Description must be 1000 characters or less').optional(),
+    enabled: z.union([z.boolean(), z.string().transform(v => v === 'true')]).default(true),
+    selector: alertRuleSelectorSchema.default({}),
+    metric: alertMetricSchema,
+    comparison: alertComparisonSchema,
+    threshold: z.number(),
+    for_duration_seconds: z
+      .number()
+      .int('for_duration_seconds must be an integer')
+      .min(0)
+      .max(86400, 'for_duration_seconds cannot exceed 24 hours')
+      .default(0),
+    severity: alertSeveritySchema,
+    cooldown_seconds: z
+      .number()
+      .int('cooldown_seconds must be an integer')
+      .min(0)
+      .max(86400, 'cooldown_seconds cannot exceed 24 hours')
+      .default(300),
+  })
+  .refine(thresholdWithinMetricBounds, {
+    message: THRESHOLD_BOUNDS_MESSAGE,
+    path: ['threshold'],
+  })
+  .refine(typesRequiredForValueMetric, {
+    message: TYPES_REQUIRED_MESSAGE,
+    path: ['selector', 'types'],
+  });
+
+// ============================================================================
+// UPDATE
+// ============================================================================
+
+/**
+ * `metric`, `comparison`, `threshold` and `selector` form an atomic group: if any
+ * is present, all must be. Otherwise the cross-field refinements above are
+ * undecidable — you cannot bound a threshold without knowing its metric.
+ */
+const CONDITION_FIELDS = ['metric', 'comparison', 'threshold', 'selector'] as const;
+
+export const updateAlertRuleSchema = z
+  .object({
+    name: z.string().min(1).max(200).optional(),
+    description: z.string().max(1000).optional(),
+    enabled: z.union([z.boolean(), z.string().transform(v => v === 'true')]).optional(),
+    selector: alertRuleSelectorSchema.optional(),
+    metric: alertMetricSchema.optional(),
+    comparison: alertComparisonSchema.optional(),
+    threshold: z.number().optional(),
+    for_duration_seconds: z.number().int().min(0).max(86400).optional(),
+    severity: alertSeveritySchema.optional(),
+    cooldown_seconds: z.number().int().min(0).max(86400).optional(),
+  })
+  .refine(
+    data => Object.values(data).some(v => v !== undefined),
+    'At least one field must be provided for update'
+  )
+  .refine(
+    data => {
+      const present = CONDITION_FIELDS.filter(f => data[f] !== undefined);
+      return present.length === 0 || present.length === CONDITION_FIELDS.length;
+    },
+    {
+      message:
+        'metric, comparison, threshold and selector must be updated together — send all four or none',
+      path: ['metric'],
+    }
+  )
+  .refine(
+    data =>
+      data.metric === undefined ||
+      thresholdWithinMetricBounds(data as unknown as ConditionShape),
+    { message: THRESHOLD_BOUNDS_MESSAGE, path: ['threshold'] }
+  )
+  .refine(
+    data =>
+      data.metric === undefined ||
+      typesRequiredForValueMetric(data as unknown as ConditionShape),
+    { message: TYPES_REQUIRED_MESSAGE, path: ['selector', 'types'] }
+  );
+
+// ============================================================================
+// QUERY
+// ============================================================================
+
+const alertRuleSortFields = ['name', 'created_at', 'updated_at', 'severity'] as const;
+
+export const listAlertRulesQuerySchema = z.object({
+  ...paginationSchema.shape,
+  ...createSortSchema(alertRuleSortFields).shape,
+  enabled: z.union([z.boolean(), z.string().transform(v => v === 'true')]).optional(),
+  metric: alertMetricSchema.optional(),
+  severity: alertSeveritySchema.optional(),
+});
+
+export const alertRuleIdParamSchema = z.object({
+  id: z.string().regex(/^[0-9a-fA-F]{24}$/, 'Invalid alert rule ID format'),
+});
+
+// ============================================================================
+// TYPE EXPORTS
+// ============================================================================
+
+export type CreateAlertRuleInput = z.infer<typeof createAlertRuleSchema>;
+export type UpdateAlertRuleInput = z.infer<typeof updateAlertRuleSchema>;
+export type ListAlertRulesQuery = z.infer<typeof listAlertRulesQuerySchema>;
+export type AlertRuleSelectorInput = z.infer<typeof alertRuleSelectorSchema>;

--- a/lib/validations/v2/alert.validation.ts
+++ b/lib/validations/v2/alert.validation.ts
@@ -1,0 +1,91 @@
+import { z } from 'zod';
+import {
+  deviceIdSchema,
+  objectIdSchema,
+  paginationSchema,
+  dateRangeSchema,
+  createSortSchema,
+} from '../common.validation';
+import { alertSeveritySchema } from './alert-rule.validation';
+
+// ============================================================================
+// ENUMS
+// ============================================================================
+
+export const alertStatusSchema = z.enum(['pending', 'firing', 'acknowledged', 'resolved']);
+export const alertResolutionSchema = z.enum(['manual', 'auto', 'stale', 'device_inactive']);
+
+// ============================================================================
+// UPDATE (PATCH /api/v2/alerts/:id)
+// ============================================================================
+
+/**
+ * The only transitions a human can drive. `pending` is internal and `firing` is
+ * system-generated, so neither is a legal PATCH target.
+ */
+export const updateAlertSchema = z.object({
+  status: z.enum(['acknowledged', 'resolved']),
+  note: z.string().max(1000, 'Note must be 1000 characters or less').optional(),
+});
+
+// ============================================================================
+// QUERY
+// ============================================================================
+
+const alertSortFields = [
+  'created_at',
+  'fired_at',
+  'severity',
+  'status',
+  'last_observed_at',
+] as const;
+
+export const listAlertsQuerySchema = z
+  .object({
+    ...paginationSchema.shape,
+    ...createSortSchema(alertSortFields).shape,
+    ...dateRangeSchema.shape,
+    // Accepts `firing`, `['firing','acknowledged']`, or `'firing,acknowledged'`.
+    status: z
+      .union([
+        alertStatusSchema,
+        z.array(alertStatusSchema),
+        z
+          .string()
+          .transform(val => val.split(',').map(s => s.trim()).filter(Boolean))
+          .pipe(z.array(alertStatusSchema)),
+      ])
+      .optional(),
+    severity: z
+      .union([
+        alertSeveritySchema,
+        z.array(alertSeveritySchema),
+        z
+          .string()
+          .transform(val => val.split(',').map(s => s.trim()).filter(Boolean))
+          .pipe(z.array(alertSeveritySchema)),
+      ])
+      .optional(),
+    device_id: deviceIdSchema.optional(),
+    rule_id: objectIdSchema.optional(),
+  })
+  .refine(
+    data => !(data.startDate && data.endDate) || data.startDate <= data.endDate,
+    { message: 'Start date must be before or equal to end date', path: ['endDate'] }
+  );
+
+export const getAlertQuerySchema = z.object({
+  include_device: z.union([z.boolean(), z.string().transform(v => v === 'true')]).default(false),
+});
+
+export const alertIdParamSchema = z.object({
+  id: z.string().regex(/^[0-9a-fA-F]{24}$/, 'Invalid alert ID format'),
+});
+
+// ============================================================================
+// TYPE EXPORTS
+// ============================================================================
+
+export type UpdateAlertInput = z.infer<typeof updateAlertSchema>;
+export type ListAlertsQuery = z.infer<typeof listAlertsQuerySchema>;
+export type GetAlertQuery = z.infer<typeof getAlertQuerySchema>;

--- a/models/v2/AlertRuleV2.ts
+++ b/models/v2/AlertRuleV2.ts
@@ -8,6 +8,9 @@ import type { ReadingType } from './ReadingV2';
 /**
  * All 15 reading types. Exported so the validation schema and the rule
  * bucketer share one source of truth with the schema enum below.
+ *
+ * If you add a reading type, see "Adding a New Device / Reading Type" in
+ * CLAUDE.md — this is one of several hand-maintained copies of the list.
  */
 export const READING_TYPES = [
   'temperature',
@@ -26,6 +29,41 @@ export const READING_TYPES = [
   'current',
   'energy',
 ] as const satisfies readonly ReadingType[];
+
+/** The element type of `READING_TYPES`, for the exhaustiveness guard below. */
+export type ReadingTypeInList = (typeof READING_TYPES)[number];
+
+/**
+ * `T` must be `never`, or this alias is a compile error naming the offender.
+ *
+ * `tsc` reports it as
+ * `Type '"<the offending type>"' does not satisfy the constraint 'never'`,
+ * which is why the two aliases below are worth more than a boolean assertion:
+ * the error text names the reading type that was forgotten.
+ */
+type AssertNever<T extends never> = T;
+
+/**
+ * EXHAUSTIVENESS, IN BOTH DIRECTIONS. Do not delete these two aliases.
+ *
+ * `as const satisfies readonly ReadingType[]` above only checks that each
+ * element IS a ReadingType. It does NOT check that every ReadingType appears.
+ * Without the guard below, adding a 16th type to `ReadingType`
+ * (models/v2/ReadingV2.ts) and forgetting this list compiles clean — and then:
+ *
+ *   1. `buildRuleBuckets` (lib/alerting/rule-cache.ts) seeds no bucket for it;
+ *   2. `evaluateReadings` (lib/alerting/evaluate.ts) looks the type up with
+ *      `byType.get(type) ?? []` and evaluates the reading against zero rules;
+ *   3. a FLEET-WIDE rule — one with no `selector.types` at all, such as the
+ *      seeded "Low battery" rule — is expanded across exactly this list, so it
+ *      too silently stops applying to devices of the new type.
+ *
+ * No error, no metric, no log, and every affected rule still shows as Enabled
+ * in the UI. Making the omission a `tsc` failure is the only cheap way to catch
+ * it, because the failure mode is silence.
+ */
+export type ReadingTypesMissingFromList = AssertNever<Exclude<ReadingType, ReadingTypeInList>>;
+export type ReadingTypesNotAReadingType = AssertNever<Exclude<ReadingTypeInList, ReadingType>>;
 
 // ============================================================================
 // TYPESCRIPT INTERFACES

--- a/models/v2/AlertRuleV2.ts
+++ b/models/v2/AlertRuleV2.ts
@@ -1,0 +1,200 @@
+import mongoose, { Schema, type Document, type Model, type Types } from 'mongoose';
+import type { ReadingType } from './ReadingV2';
+
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
+/**
+ * All 15 reading types. Exported so the validation schema and the rule
+ * bucketer share one source of truth with the schema enum below.
+ */
+export const READING_TYPES = [
+  'temperature',
+  'humidity',
+  'occupancy',
+  'power',
+  'co2',
+  'pressure',
+  'light',
+  'motion',
+  'air_quality',
+  'water_flow',
+  'gas',
+  'vibration',
+  'voltage',
+  'current',
+  'energy',
+] as const satisfies readonly ReadingType[];
+
+// ============================================================================
+// TYPESCRIPT INTERFACES
+// ============================================================================
+
+export type AlertMetric = 'value' | 'anomaly_score' | 'battery_level';
+export type AlertComparison = 'gt' | 'gte' | 'lt' | 'lte';
+export type AlertSeverity = 'info' | 'warning' | 'critical';
+
+/**
+ * Declarative device selector. Every field is optional; an absent field means
+ * "no constraint on this dimension". Devices must satisfy ALL present fields,
+ * and for `tags` must carry ALL listed tags.
+ */
+export interface IAlertRuleSelector {
+  types?: ReadingType[];
+  building_id?: string;
+  floor?: number;
+  zone?: string;
+  tags?: string[];
+}
+
+export interface IAlertRuleAudit {
+  created_at: Date;
+  created_by: string;
+  updated_at: Date;
+  updated_by: string;
+  deleted_at?: Date;
+  deleted_by?: string;
+}
+
+export interface IAlertRuleV2 {
+  _id: Types.ObjectId;
+  name: string;
+  description?: string;
+  enabled: boolean;
+  selector: IAlertRuleSelector;
+  metric: AlertMetric;
+  comparison: AlertComparison;
+  threshold: number;
+  /** Breach must hold this long before the alert fires. 0 = fire immediately. */
+  for_duration_seconds: number;
+  severity: AlertSeverity;
+  /** A new episode for the same (rule, device) pair is suppressed this long after resolution. */
+  cooldown_seconds: number;
+  audit: IAlertRuleAudit;
+}
+
+// ============================================================================
+// MONGOOSE SCHEMA
+// ============================================================================
+
+const SelectorSchema = new Schema<IAlertRuleSelector>(
+  {
+    // `default: undefined` overrides Mongoose's implicit `[]` default for
+    // array paths, so an omitted field stays truly absent (no constraint)
+    // rather than becoming a vacuous empty array.
+    types: { type: [String], enum: READING_TYPES as unknown as string[], default: undefined },
+    building_id: { type: String },
+    floor: { type: Number },
+    zone: { type: String },
+    tags: { type: [String], default: undefined },
+  },
+  { _id: false }
+);
+
+const AuditSchema = new Schema<IAlertRuleAudit>(
+  {
+    created_at: { type: Date, default: () => new Date() },
+    created_by: { type: String, required: true },
+    updated_at: { type: Date, default: () => new Date() },
+    updated_by: { type: String, required: true },
+    deleted_at: { type: Date },
+    deleted_by: { type: String },
+  },
+  { _id: false }
+);
+
+const AlertRuleV2Schema = new Schema<IAlertRuleV2>(
+  {
+    name: { type: String, required: true, maxlength: 200 },
+    description: { type: String, maxlength: 1000 },
+    enabled: { type: Boolean, default: true },
+    selector: { type: SelectorSchema, default: () => ({}) },
+    metric: {
+      type: String,
+      enum: ['value', 'anomaly_score', 'battery_level'],
+      required: true,
+    },
+    comparison: {
+      type: String,
+      enum: ['gt', 'gte', 'lt', 'lte'],
+      required: true,
+    },
+    threshold: { type: Number, required: true },
+    for_duration_seconds: { type: Number, default: 0, min: 0, max: 86400 },
+    severity: {
+      type: String,
+      enum: ['info', 'warning', 'critical'],
+      required: true,
+    },
+    cooldown_seconds: { type: Number, default: 300, min: 0, max: 86400 },
+    audit: { type: AuditSchema, required: true },
+  },
+  {
+    collection: 'alert_rules_v2',
+    timestamps: false,
+  }
+);
+
+// ============================================================================
+// INDEXES
+// ============================================================================
+
+// The actual load predicate used by the evaluator's rule cache.
+AlertRuleV2Schema.index({ enabled: 1, 'audit.deleted_at': 1 });
+
+// Default list sort.
+AlertRuleV2Schema.index({ 'audit.created_at': -1 });
+
+// ============================================================================
+// MIDDLEWARE
+// ============================================================================
+
+AlertRuleV2Schema.pre('save', function () {
+  if (!this.isNew) this.audit.updated_at = new Date();
+});
+
+AlertRuleV2Schema.pre('findOneAndUpdate', function () {
+  this.set({ 'audit.updated_at': new Date() });
+});
+
+// ============================================================================
+// STATIC METHODS
+// ============================================================================
+
+AlertRuleV2Schema.statics.findActive = function (filter: Record<string, unknown> = {}) {
+  return this.find({ ...filter, 'audit.deleted_at': { $exists: false } });
+};
+
+AlertRuleV2Schema.statics.softDelete = async function (id: string, deletedBy: string) {
+  return this.findOneAndUpdate(
+    { _id: id, 'audit.deleted_at': { $exists: false } },
+    {
+      $set: {
+        'audit.deleted_at': new Date(),
+        'audit.deleted_by': deletedBy,
+        enabled: false,
+      },
+    },
+    { new: true }
+  );
+};
+
+// ============================================================================
+// INTERFACE FOR STATIC METHODS
+// ============================================================================
+
+export interface IAlertRuleV2Model extends Model<IAlertRuleV2> {
+  findActive(filter?: Record<string, unknown>): ReturnType<Model<IAlertRuleV2>['find']>;
+  softDelete(id: string, deletedBy: string): Promise<(IAlertRuleV2 & Document) | null>;
+}
+
+// ============================================================================
+// MODEL EXPORT
+// ============================================================================
+
+const AlertRuleV2 =
+  (mongoose.models.AlertRuleV2 as unknown as IAlertRuleV2Model) ||
+  mongoose.model<IAlertRuleV2, IAlertRuleV2Model>('AlertRuleV2', AlertRuleV2Schema);
+
+export default AlertRuleV2;

--- a/models/v2/AlertRuleV2.ts
+++ b/models/v2/AlertRuleV2.ts
@@ -62,7 +62,15 @@ export interface IAlertRuleV2 {
   name: string;
   description?: string;
   enabled: boolean;
-  selector: IAlertRuleSelector;
+  // Optional, not just "always defaulted": the schema below gives `selector`
+  // a `default: () => ({})`, but Mongoose's default `minimize` behavior strips
+  // an empty nested object before it reaches Mongo, so a rule with no
+  // constraints at all (e.g. the seeded "Low battery" rule) reads back with
+  // this field genuinely absent. `matchesSelector` (lib/alerting/selector.ts)
+  // and the rule bucketer (lib/alerting/rule-cache.ts) already treat it as
+  // optional -- this makes the type honest about that runtime shape instead
+  // of promising a guarantee `.lean()` doesn't keep.
+  selector?: IAlertRuleSelector;
   metric: AlertMetric;
   comparison: AlertComparison;
   threshold: number;

--- a/models/v2/AlertV2.ts
+++ b/models/v2/AlertV2.ts
@@ -1,0 +1,292 @@
+// Type-only `Types` import: this file uses Types.ObjectId as a field TYPE and
+// Schema.Types.ObjectId as the schema value — it never calls `new Types.…`.
+import mongoose, { Schema, type Document, type Model, type Types } from 'mongoose';
+import type { AlertMetric, AlertComparison, AlertSeverity } from './AlertRuleV2';
+
+// ============================================================================
+// CUSTOM ERRORS
+// ============================================================================
+
+/**
+ * Three codes, not four. ScheduleV2 needs four because its two terminal targets
+ * are symmetric — either can block the other. Alerts are not symmetric:
+ * `acknowledged` sits between `firing` and `resolved`.
+ */
+export type AlertTransitionCode =
+  | 'ALREADY_ACKNOWLEDGED'
+  | 'ALREADY_RESOLVED'
+  | 'NOT_YET_FIRING';
+
+export class AlertTransitionError extends Error {
+  code: AlertTransitionCode;
+
+  constructor(code: AlertTransitionCode, message: string) {
+    super(message);
+    this.name = 'AlertTransitionError';
+    this.code = code;
+  }
+}
+
+// ============================================================================
+// TYPESCRIPT INTERFACES
+// ============================================================================
+
+export type AlertStatus = 'pending' | 'firing' | 'acknowledged' | 'resolved';
+export type AlertResolution = 'manual' | 'auto' | 'stale' | 'device_inactive';
+
+export interface IAlertAudit {
+  created_at: Date;
+  created_by: string;
+  updated_at: Date;
+  updated_by: string;
+  acknowledged_at?: Date;
+  acknowledged_by?: string;
+  resolved_at?: Date;
+  resolved_by?: string;
+  resolution?: AlertResolution;
+  note?: string;
+}
+
+/**
+ * One document per *episode*: a continuous stretch during which one rule is
+ * breached on one device.
+ */
+export interface IAlertV2 {
+  _id: Types.ObjectId;
+  rule_id: Types.ObjectId;
+  /** Denormalized so history survives a rule rename or soft delete. */
+  rule_name: string;
+  device_id: string;
+
+  status: AlertStatus;
+  /**
+   * Invariant: is_open === (status !== 'resolved').
+   *
+   * Denormalized because the dedup index needs an equality predicate — a
+   * `status: { $in: [...] }` partialFilterExpression would require MongoDB 6.0+.
+   * Maintained in exactly four places: the evaluator's bulk write,
+   * `acknowledge` (leaves it true), `resolve` (sets it false), and the sweep.
+   */
+  is_open: boolean;
+  severity: AlertSeverity;
+
+  // Condition snapshot — an alert is self-describing even if the rule later changes.
+  metric: AlertMetric;
+  comparison: AlertComparison;
+  threshold: number;
+
+  trigger_value: number;
+  last_value: number;
+  resolved_value?: number;
+
+  /** First breach of this episode — drives for_duration_seconds. */
+  breached_since: Date;
+  /** Most recent evaluated reading — drives staleness, moves only forward. */
+  last_observed_at: Date;
+  fired_at?: Date;
+
+  audit: IAlertAudit;
+}
+
+// ============================================================================
+// MONGOOSE SCHEMA
+// ============================================================================
+
+const AuditSchema = new Schema<IAlertAudit>(
+  {
+    created_at: { type: Date, default: () => new Date() },
+    created_by: { type: String, required: true },
+    updated_at: { type: Date, default: () => new Date() },
+    updated_by: { type: String, required: true },
+    acknowledged_at: { type: Date },
+    acknowledged_by: { type: String },
+    resolved_at: { type: Date },
+    resolved_by: { type: String },
+    resolution: {
+      type: String,
+      enum: ['manual', 'auto', 'stale', 'device_inactive'],
+    },
+    note: { type: String, maxlength: 1000 },
+  },
+  { _id: false }
+);
+
+const AlertV2Schema = new Schema<IAlertV2>(
+  {
+    rule_id: { type: Schema.Types.ObjectId, required: true },
+    rule_name: { type: String, required: true },
+    device_id: { type: String, required: true },
+
+    status: {
+      type: String,
+      enum: ['pending', 'firing', 'acknowledged', 'resolved'],
+      required: true,
+    },
+    is_open: { type: Boolean, required: true },
+    severity: {
+      type: String,
+      enum: ['info', 'warning', 'critical'],
+      required: true,
+    },
+
+    metric: {
+      type: String,
+      enum: ['value', 'anomaly_score', 'battery_level'],
+      required: true,
+    },
+    comparison: {
+      type: String,
+      enum: ['gt', 'gte', 'lt', 'lte'],
+      required: true,
+    },
+    threshold: { type: Number, required: true },
+
+    trigger_value: { type: Number, required: true },
+    last_value: { type: Number, required: true },
+    resolved_value: { type: Number },
+
+    breached_since: { type: Date, required: true },
+    last_observed_at: { type: Date, required: true },
+    fired_at: { type: Date },
+
+    audit: { type: AuditSchema, required: true },
+  },
+  {
+    collection: 'alerts_v2',
+    timestamps: false,
+  }
+);
+
+// ============================================================================
+// INDEXES
+// ============================================================================
+
+// Deduplication: at most one OPEN episode per (rule, device) pair, enforced by
+// MongoDB rather than by application logic. The partial filter is what allows
+// unlimited *resolved* episodes for the same pair.
+AlertV2Schema.index(
+  { rule_id: 1, device_id: 1 },
+  { unique: true, partialFilterExpression: { is_open: true } }
+);
+
+// Cooldown lookback. NOT optional: the partial unique index above is only usable
+// by queries matching its filter, so a lookback over resolved episodes cannot use
+// it, and there is no other { rule_id, device_id } index to fall back on.
+AlertV2Schema.index({ rule_id: 1, device_id: 1, 'audit.resolved_at': -1 });
+
+// Active list — the default view.
+AlertV2Schema.index({ status: 1, 'audit.created_at': -1 });
+
+// Device detail page.
+AlertV2Schema.index({ device_id: 1, 'audit.created_at': -1 });
+
+// Severity filter.
+AlertV2Schema.index({ severity: 1, status: 1 });
+
+// Staleness sweep.
+AlertV2Schema.index({ is_open: 1, last_observed_at: 1 });
+
+// ============================================================================
+// MIDDLEWARE
+// ============================================================================
+
+AlertV2Schema.pre('save', function () {
+  if (!this.isNew) this.audit.updated_at = new Date();
+});
+
+// ============================================================================
+// STATIC METHODS
+// ============================================================================
+
+/**
+ * Acknowledge a firing alert (atomic). Acknowledged alerts never return to
+ * firing: re-firing under a human already working the problem is noise.
+ */
+AlertV2Schema.statics.acknowledge = async function (id: string, by: string) {
+  const now = new Date();
+  const result = await this.findOneAndUpdate(
+    { _id: id, status: 'firing' },
+    {
+      $set: {
+        status: 'acknowledged',
+        is_open: true,
+        'audit.updated_at': now,
+        'audit.updated_by': by,
+        'audit.acknowledged_at': now,
+        'audit.acknowledged_by': by,
+      },
+    },
+    { new: true }
+  );
+
+  if (!result) {
+    const existing = await this.findById(id);
+    if (!existing) return null;
+    if (existing.status === 'acknowledged')
+      throw new AlertTransitionError('ALREADY_ACKNOWLEDGED', 'Alert is already acknowledged');
+    if (existing.status === 'resolved')
+      throw new AlertTransitionError('ALREADY_RESOLVED', 'Alert is already resolved');
+    throw new AlertTransitionError('NOT_YET_FIRING', 'Alert has not fired yet');
+  }
+
+  return result;
+};
+
+/**
+ * Resolve a firing or acknowledged alert (atomic). `resolved` is terminal.
+ */
+AlertV2Schema.statics.resolve = async function (
+  id: string,
+  by: string,
+  resolution: AlertResolution = 'manual'
+) {
+  const now = new Date();
+  const result = await this.findOneAndUpdate(
+    { _id: id, status: { $in: ['firing', 'acknowledged'] } },
+    {
+      $set: {
+        status: 'resolved',
+        is_open: false,
+        'audit.updated_at': now,
+        'audit.updated_by': by,
+        'audit.resolved_at': now,
+        'audit.resolved_by': by,
+        'audit.resolution': resolution,
+      },
+    },
+    { new: true }
+  );
+
+  if (!result) {
+    const existing = await this.findById(id);
+    if (!existing) return null;
+    if (existing.status === 'resolved')
+      throw new AlertTransitionError('ALREADY_RESOLVED', 'Alert is already resolved');
+    throw new AlertTransitionError('NOT_YET_FIRING', 'Alert has not fired yet');
+  }
+
+  return result;
+};
+
+// ============================================================================
+// INTERFACE FOR STATIC METHODS
+// ============================================================================
+
+export interface IAlertV2Model extends Model<IAlertV2> {
+  acknowledge(id: string, by: string): Promise<(IAlertV2 & Document) | null>;
+  resolve(
+    id: string,
+    by: string,
+    resolution?: AlertResolution
+  ): Promise<(IAlertV2 & Document) | null>;
+}
+
+// ============================================================================
+// MODEL EXPORT
+// ============================================================================
+
+const AlertV2 =
+  (mongoose.models.AlertV2 as unknown as IAlertV2Model) ||
+  mongoose.model<IAlertV2, IAlertV2Model>('AlertV2', AlertV2Schema);
+
+export default AlertV2;

--- a/models/v2/AlertV2.ts
+++ b/models/v2/AlertV2.ts
@@ -27,12 +27,38 @@ export class AlertTransitionError extends Error {
   }
 }
 
+/**
+ * A write that would leave `status` and `is_open` disagreeing.
+ *
+ * Distinct from AlertTransitionError, which is about a legal-but-refused
+ * lifecycle move made by a caller. This one is always a programming error:
+ * `is_open` is a denormalization of `status` (see the invariant on IAlertV2),
+ * and a document where they disagree silently corrupts the partial unique
+ * dedup index rather than failing anywhere visible.
+ */
+export class AlertInvariantError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AlertInvariantError';
+  }
+}
+
 // ============================================================================
 // TYPESCRIPT INTERFACES
 // ============================================================================
 
 export type AlertStatus = 'pending' | 'firing' | 'acknowledged' | 'resolved';
 export type AlertResolution = 'manual' | 'auto' | 'stale' | 'device_inactive';
+
+/**
+ * The invariant, as a function rather than as prose: `is_open` is nothing but a
+ * denormalization of `status`. Every enforcement point below derives from this
+ * one expression, so there is exactly one place to change if the status set
+ * ever grows a second terminal state.
+ */
+export function isOpenForStatus(status: AlertStatus): boolean {
+  return status !== 'resolved';
+}
 
 export interface IAlertAudit {
   created_at: Date;
@@ -60,12 +86,18 @@ export interface IAlertV2 {
 
   status: AlertStatus;
   /**
-   * Invariant: is_open === (status !== 'resolved').
+   * Invariant: `is_open === isOpenForStatus(status)`, ENFORCED at the write
+   * path (see "INVARIANT ENFORCEMENT" below) rather than merely asserted here.
    *
    * Denormalized because the dedup index needs an equality predicate — a
    * `status: { $in: [...] }` partialFilterExpression would require MongoDB 6.0+.
-   * Maintained in exactly four places: the evaluator's bulk write,
-   * `acknowledge` (leaves it true), `resolve` (sets it false), and the sweep.
+   *
+   * The reason enforcement is not optional: a resolved document that kept
+   * `is_open: true` sits in the partial unique index forever, so the evaluator
+   * (which loads open episodes purely on `is_open` and branches only on
+   * `'pending'`) can never re-fire or resolve that (rule, device) pair again —
+   * silently, with no metric. A type-level guarantee buys nothing here, since
+   * the evaluator's bulk insert reaches the driver through a cast.
    */
   is_open: boolean;
   severity: AlertSeverity;
@@ -122,7 +154,26 @@ const AlertV2Schema = new Schema<IAlertV2>(
       enum: ['pending', 'firing', 'acknowledged', 'resolved'],
       required: true,
     },
-    is_open: { type: Boolean, required: true },
+    is_open: {
+      type: Boolean,
+      required: true,
+      validate: {
+        // Document validation only. `this` is the document on create()/save()/
+        // insertMany(), and on the documents Mongoose builds from a bulkWrite
+        // `insertOne` op before sending it. Under `runValidators: true` on a
+        // query `this` would instead be the Query, which has no `status` — the
+        // guard below returns true in that case and the update middleware
+        // further down covers those paths properly.
+        validator: function (this: unknown, value: boolean): boolean {
+          const status = (this as { status?: AlertStatus } | null)?.status;
+          if (status === undefined) return true;
+          return value === isOpenForStatus(status);
+        },
+        message: props =>
+          `is_open ${props.value} contradicts status — is_open must equal (status !== 'resolved'). ` +
+          'An inconsistent document corrupts the partial unique dedup index.',
+      },
+    },
     severity: {
       type: String,
       enum: ['info', 'warning', 'critical'],
@@ -187,11 +238,163 @@ AlertV2Schema.index({ severity: 1, status: 1 });
 AlertV2Schema.index({ is_open: 1, last_observed_at: 1 });
 
 // ============================================================================
+// INVARIANT ENFORCEMENT
+// ============================================================================
+
+/**
+ * Apply the status/is_open invariant to ONE write payload, in place.
+ *
+ * Three outcomes, and the asymmetry between them is deliberate:
+ *
+ *  - `status` alone      -> derive `is_open`. An update names only the fields
+ *                           it changes, so `{ status: 'firing' }` is a
+ *                           legitimate partial write whose `is_open` is
+ *                           implied. Rejecting it would break a correct
+ *                           existing writer (the evaluator's pending ->
+ *                           firing promotion sets status only), and deriving
+ *                           makes drift structurally impossible instead of
+ *                           merely detectable.
+ *  - both, disagreeing   -> throw. There is no reading of the caller's intent
+ *                           that is safe to guess at.
+ *  - `is_open` alone     -> throw. The stored `status` is not knowable from
+ *                           here, so this write cannot be checked — and it is
+ *                           exactly the shape the drift takes. No writer in
+ *                           the codebase does this; one that needs to should
+ *                           set both.
+ *
+ * Returns true if it changed `payload`, so query middleware can write the
+ * update back rather than relying on reference semantics.
+ */
+function applyIsOpenInvariant(payload: Record<string, unknown>, context: string): boolean {
+  const hasStatus = payload.status !== undefined;
+  const hasIsOpen = payload.is_open !== undefined;
+
+  if (!hasStatus && !hasIsOpen) return false;
+
+  if (!hasStatus)
+    throw new AlertInvariantError(
+      `${context} sets is_open without status. is_open is a denormalization of status ` +
+        "(is_open === status !== 'resolved') and cannot be verified on its own — set both, " +
+        'or set status alone and let the model derive is_open.'
+    );
+
+  const required = isOpenForStatus(payload.status as AlertStatus);
+
+  if (!hasIsOpen) {
+    payload.is_open = required;
+    return true;
+  }
+
+  if (payload.is_open !== required)
+    throw new AlertInvariantError(
+      `${context} sets status '${String(payload.status)}' with is_open ${String(payload.is_open)}; ` +
+        `is_open must be ${required}. An inconsistent document stays in the partial unique dedup ` +
+        'index forever and the evaluator can never re-fire or resolve that (rule, device) pair again.'
+    );
+
+  return false;
+}
+
+/**
+ * The sub-documents of an update that can carry field values.
+ *
+ * `$set` and `$setOnInsert` explicitly; an operator-free update document is
+ * MongoDB shorthand for `$set` (and a `replaceOne` replacement is a whole
+ * document), so that case is handled too. Query middleware runs BEFORE
+ * Mongoose casts `{ status: x }` into `{ $set: { status: x } }`, so both
+ * shapes genuinely reach here.
+ */
+function invariantTargets(update: Record<string, unknown>): Record<string, unknown>[] {
+  const targets: Record<string, unknown>[] = [];
+  let sawOperator = false;
+
+  for (const key of Object.keys(update)) {
+    if (!key.startsWith('$')) continue;
+    sawOperator = true;
+    if (key !== '$set' && key !== '$setOnInsert') continue;
+    const value = update[key];
+    if (value && typeof value === 'object' && !Array.isArray(value))
+      targets.push(value as Record<string, unknown>);
+  }
+
+  if (!sawOperator) targets.push(update);
+  return targets;
+}
+
+function enforceInvariantOnUpdate(update: unknown, context: string): boolean {
+  // An aggregation-pipeline update is an array of stages. This model never
+  // uses one, and silently ignoring it would be a hole in the guard.
+  if (Array.isArray(update))
+    throw new AlertInvariantError(
+      `${context} uses an aggregation-pipeline update, which the status/is_open invariant guard ` +
+        'cannot inspect. Use $set so the invariant stays enforceable.'
+    );
+
+  if (!update || typeof update !== 'object') return false;
+
+  let mutated = false;
+  for (const target of invariantTargets(update as Record<string, unknown>))
+    mutated = applyIsOpenInvariant(target, context) || mutated;
+
+  return mutated;
+}
+
+// ============================================================================
 // MIDDLEWARE
 // ============================================================================
 
 AlertV2Schema.pre('save', function () {
   if (!this.isNew) this.audit.updated_at = new Date();
+});
+
+/**
+ * Covers every single-document update path: `updateOne`, `updateMany`,
+ * `findOneAndUpdate` (which `acknowledge` and `resolve` both use) and
+ * `replaceOne`. Query middleware does NOT run for ops inside a `bulkWrite` —
+ * the `bulkWrite` hook below covers those.
+ */
+for (const hook of ['updateOne', 'updateMany', 'findOneAndUpdate', 'replaceOne'] as const)
+  AlertV2Schema.pre(hook, function () {
+    const update = this.getUpdate();
+    if (enforceInvariantOnUpdate(update, `AlertV2.${hook}()`))
+      this.setUpdate(update as Record<string, unknown>);
+  });
+
+/**
+ * The evaluator and the staleness sweep both write through `bulkWrite`, which
+ * bypasses query middleware entirely. This hook runs before Mongoose casts the
+ * ops, so it sees exactly what the caller queued.
+ *
+ * `insertOne` is checked here as well as by the `is_open` validator above: with
+ * `{ ordered: false }` — which both callers use — a document that fails
+ * validation is DROPPED from the batch and merely decorated onto the result,
+ * not thrown. That is silent, and silence is the whole complaint. Throwing here
+ * makes an inconsistent insert fail the call.
+ */
+AlertV2Schema.pre('bulkWrite', function (ops: unknown) {
+  if (!Array.isArray(ops)) return;
+
+  for (const op of ops as Record<string, Record<string, unknown>>[]) {
+    if (!op || typeof op !== 'object') continue;
+
+    if (op.insertOne?.document)
+      applyIsOpenInvariant(
+        op.insertOne.document as Record<string, unknown>,
+        'AlertV2.bulkWrite() insertOne'
+      );
+
+    if (op.updateOne?.update)
+      enforceInvariantOnUpdate(op.updateOne.update, 'AlertV2.bulkWrite() updateOne');
+
+    if (op.updateMany?.update)
+      enforceInvariantOnUpdate(op.updateMany.update, 'AlertV2.bulkWrite() updateMany');
+
+    if (op.replaceOne?.replacement)
+      applyIsOpenInvariant(
+        op.replaceOne.replacement as Record<string, unknown>,
+        'AlertV2.bulkWrite() replaceOne'
+      );
+  }
 });
 
 // ============================================================================

--- a/models/v2/DeviceV2.ts
+++ b/models/v2/DeviceV2.ts
@@ -360,7 +360,17 @@ DeviceV2Schema.index({ status: 1, type: 1 });
  * Mongoose 9+ uses async middleware without next callback
  */
 DeviceV2Schema.pre('save', function () {
-  if (!this.isNew) this.audit.updated_at = new Date();
+  if (!this.isNew) {
+    this.audit.updated_at = new Date();
+    return;
+  }
+
+  // created_at and updated_at default to two separate `new Date()` calls, so under load
+  // they can land in different milliseconds. Consumers (the device history and audit
+  // endpoints) read any difference as a real edit, which invents an "updated" entry for
+  // a device nobody has touched. A device that has never been modified must report a
+  // single instant. Only collapse the defaults — an explicit updated_at is intentional.
+  if (this.$isDefault('audit.updated_at')) this.audit.updated_at = this.audit.created_at;
 });
 
 /**

--- a/scripts/v2/alert-rule-seeds.ts
+++ b/scripts/v2/alert-rule-seeds.ts
@@ -1,0 +1,101 @@
+/**
+ * Starter alert rules.
+ *
+ * Lives in its own module rather than in seed-v2.ts, which invokes seed() at
+ * module scope — importing that from a test would wipe the test database.
+ */
+
+// ============================================================================
+// ALERT RULE SEEDS
+// ============================================================================
+
+export interface AlertRuleSeed {
+  name: string;
+  description: string;
+  enabled: boolean;
+  selector: { types?: string[] };
+  metric: 'value' | 'anomaly_score' | 'battery_level';
+  comparison: 'gt' | 'gte' | 'lt' | 'lte';
+  threshold: number;
+  for_duration_seconds: number;
+  severity: 'info' | 'warning' | 'critical';
+  cooldown_seconds: number;
+  audit: {
+    created_at: Date;
+    created_by: string;
+    updated_at: Date;
+    updated_by: string;
+  };
+}
+
+/**
+ * A small rule set so /alerts is populated on first load. Without it the whole
+ * phase is invisible to a visitor.
+ */
+export function buildAlertRuleSeeds(): AlertRuleSeed[] {
+  const now = new Date();
+  const audit = {
+    created_at: now,
+    created_by: 'sys-seed-agent',
+    updated_at: now,
+    updated_by: 'sys-seed-agent',
+  };
+
+  return [
+    {
+      name: 'High temperature',
+      description: 'Temperature sustained above 30 C for five minutes.',
+      enabled: true,
+      selector: { types: ['temperature'] },
+      metric: 'value',
+      comparison: 'gt',
+      threshold: 30,
+      for_duration_seconds: 300,
+      severity: 'critical',
+      cooldown_seconds: 900,
+      audit,
+    },
+    {
+      name: 'Power spike',
+      description: 'Instantaneous power draw above 4000 W.',
+      enabled: true,
+      selector: { types: ['power'] },
+      metric: 'value',
+      comparison: 'gt',
+      threshold: 4000,
+      for_duration_seconds: 0,
+      severity: 'warning',
+      cooldown_seconds: 600,
+      audit,
+    },
+    {
+      // No selector.types: battery is a DEVICE property, so a rule that only
+      // watched temperature sensors' batteries would be close to useless. This
+      // is the rule that motivates making selector.types optional.
+      name: 'Low battery',
+      description: 'Any device reporting below 20% battery.',
+      enabled: true,
+      selector: {},
+      metric: 'battery_level',
+      comparison: 'lt',
+      threshold: 20,
+      for_duration_seconds: 0,
+      severity: 'warning',
+      cooldown_seconds: 3600,
+      audit,
+    },
+    {
+      name: 'High anomaly score',
+      description: 'Any reading scored 0.85 or higher by anomaly detection.',
+      enabled: true,
+      selector: {},
+      metric: 'anomaly_score',
+      comparison: 'gte',
+      threshold: 0.85,
+      for_duration_seconds: 0,
+      severity: 'info',
+      cooldown_seconds: 300,
+      audit,
+    },
+  ];
+}

--- a/scripts/v2/alert-rule-seeds.ts
+++ b/scripts/v2/alert-rule-seeds.ts
@@ -29,8 +29,14 @@ export interface AlertRuleSeed {
 }
 
 /**
- * A small rule set so /alerts is populated on first load. Without it the whole
+ * A small rule set so alert rules exist to be evaluated. Without it the whole
  * phase is invisible to a visitor.
+ *
+ * Seeding rules is necessary but not sufficient for /alerts to show anything:
+ * neither `pnpm seed` nor `scripts/v2/simulate.ts` triggers evaluation — both
+ * insert readings via raw `ReadingV2.insertMany`, bypassing the API routes
+ * where `evaluateReadings` actually runs. Alerts only appear once an
+ * authenticated `GET /api/v2/cron/simulate` call runs the evaluator.
  */
 export function buildAlertRuleSeeds(): AlertRuleSeed[] {
   const now = new Date();
@@ -72,13 +78,18 @@ export function buildAlertRuleSeeds(): AlertRuleSeed[] {
       // No selector.types: battery is a DEVICE property, so a rule that only
       // watched temperature sensors' batteries would be close to useless. This
       // is the rule that motivates making selector.types optional.
+      //
+      // Threshold is 25, not 20, deliberately: both data generators floor
+      // context.battery_level at exactly 20 (seed-v2.ts:299,
+      // lib/simulation/readings.ts:262), so `lt 20` can never be satisfied.
+      // 25 catches the [20, 24] band — roughly 6% of devices.
       name: 'Low battery',
-      description: 'Any device reporting below 20% battery.',
+      description: 'Any device reporting below 25% battery.',
       enabled: true,
       selector: {},
       metric: 'battery_level',
       comparison: 'lt',
-      threshold: 20,
+      threshold: 25,
       for_duration_seconds: 0,
       severity: 'warning',
       cooldown_seconds: 3600,

--- a/scripts/v2/create-indexes-v2.ts
+++ b/scripts/v2/create-indexes-v2.ts
@@ -276,7 +276,16 @@ async function createCollectionIndexes(
   const stats = { success: 0, skipped: 0, mismatched: 0, failed: 0 };
 
   // Get existing indexes, keyed by name, so a name match can be shape-checked below.
-  const existingIndexes = await collection.indexes();
+  // A collection that has never been created — e.g. alerts_v2 before any alert has
+  // ever fired, the normal state of a fresh database — makes `.indexes()` throw
+  // NamespaceNotFound rather than resolve empty. That is zero existing indexes,
+  // not a failure, so it is caught here instead of aborting the whole script.
+  let existingIndexes: Awaited<ReturnType<typeof collection.indexes>> = [];
+  try {
+    existingIndexes = await collection.indexes();
+  } catch (error) {
+    if ((error as { code?: number }).code !== 26) throw error;
+  }
   const existingIndexByName = new Map(existingIndexes.map(idx => [idx.name, idx]));
 
   console.log(`\n📦 Collection: ${collectionName}`);

--- a/scripts/v2/create-indexes-v2.ts
+++ b/scripts/v2/create-indexes-v2.ts
@@ -23,7 +23,12 @@ type IndexSpec = Record<string, 1 | -1>;
 interface IndexDefinition {
   name: string;
   spec: IndexSpec;
-  options: { unique?: boolean; sparse?: boolean; background?: boolean };
+  options: {
+    unique?: boolean;
+    sparse?: boolean;
+    background?: boolean;
+    partialFilterExpression?: Record<string, unknown>;
+  };
   description: string;
 }
 
@@ -184,6 +189,53 @@ const ALERT_RULE_V2_INDEXES: IndexDefinition[] = [
   },
 ];
 
+/**
+ * AlertV2 Index Definitions
+ *
+ * The partial unique index is the deduplication mechanism in full — at most one
+ * open episode per (rule, device) pair, enforced by MongoDB. It uses an equality
+ * predicate on `is_open` (supported since MongoDB 3.2) rather than a status
+ * `$in` (which would require 6.0+).
+ */
+const ALERT_V2_INDEXES: IndexDefinition[] = [
+  {
+    name: 'rule_device_open_unique',
+    spec: { rule_id: 1, device_id: 1 } as IndexSpec,
+    options: { unique: true, background: true, partialFilterExpression: { is_open: true } },
+    description: 'Partial unique index enforcing one open episode per (rule, device)',
+  },
+  {
+    name: 'rule_device_resolved_at',
+    spec: { rule_id: 1, device_id: 1, 'audit.resolved_at': -1 } as IndexSpec,
+    options: { background: true },
+    description: 'Cooldown lookback over resolved episodes',
+  },
+  {
+    name: 'status_created_at',
+    spec: { status: 1, 'audit.created_at': -1 } as IndexSpec,
+    options: { background: true },
+    description: 'Active alert list, the default view',
+  },
+  {
+    name: 'device_created_at',
+    spec: { device_id: 1, 'audit.created_at': -1 } as IndexSpec,
+    options: { background: true },
+    description: 'Alerts for a single device',
+  },
+  {
+    name: 'severity_status',
+    spec: { severity: 1, status: 1 } as IndexSpec,
+    options: { background: true },
+    description: 'Severity filter on the alert list',
+  },
+  {
+    name: 'is_open_last_observed_at',
+    spec: { is_open: 1, last_observed_at: 1 } as IndexSpec,
+    options: { background: true },
+    description: 'Staleness sweep',
+  },
+];
+
 // ============================================================================
 // HELPER FUNCTIONS
 // ============================================================================
@@ -223,6 +275,8 @@ async function createCollectionIndexes(
       if (index.options.sparse !== undefined) indexOptions.sparse = index.options.sparse;
       if (index.options.background !== undefined)
         indexOptions.background = index.options.background;
+      if (index.options.partialFilterExpression !== undefined)
+        indexOptions.partialFilterExpression = index.options.partialFilterExpression;
 
       await collection.createIndex(index.spec, indexOptions);
       const duration = Date.now() - startTime;
@@ -280,6 +334,7 @@ async function createIndexes(): Promise<void> {
     const hasDevicesV2 = collectionNames.has('devices_v2');
     const hasReadingsV2 = collectionNames.has('readings_v2');
     const hasAlertRulesV2 = collectionNames.has('alert_rules_v2');
+    const hasAlertsV2 = collectionNames.has('alerts_v2');
 
     if (!hasDevicesV2)
       console.log(
@@ -296,6 +351,11 @@ async function createIndexes(): Promise<void> {
         '\n⚠️  Collection alert_rules_v2 does not exist yet. Creating indexes will create the collection.'
       );
 
+    if (!hasAlertsV2)
+      console.log(
+        '\n⚠️  Collection alerts_v2 does not exist yet. Creating indexes will create the collection.'
+      );
+
     // Create indexes for devices_v2
     const deviceStats = await createCollectionIndexes('devices_v2', DEVICE_V2_INDEXES);
 
@@ -305,15 +365,22 @@ async function createIndexes(): Promise<void> {
     // Create indexes for alert_rules_v2
     const alertRuleStats = await createCollectionIndexes('alert_rules_v2', ALERT_RULE_V2_INDEXES);
 
+    // Create indexes for alerts_v2
+    const alertStats = await createCollectionIndexes('alerts_v2', ALERT_V2_INDEXES);
+
     // Verify indexes
     await verifyIndexes('devices_v2');
     await verifyIndexes('readings_v2');
     await verifyIndexes('alert_rules_v2');
+    await verifyIndexes('alerts_v2');
 
     // Summary
-    const totalSuccess = deviceStats.success + readingStats.success + alertRuleStats.success;
-    const totalSkipped = deviceStats.skipped + readingStats.skipped + alertRuleStats.skipped;
-    const totalFailed = deviceStats.failed + readingStats.failed + alertRuleStats.failed;
+    const totalSuccess =
+      deviceStats.success + readingStats.success + alertRuleStats.success + alertStats.success;
+    const totalSkipped =
+      deviceStats.skipped + readingStats.skipped + alertRuleStats.skipped + alertStats.skipped;
+    const totalFailed =
+      deviceStats.failed + readingStats.failed + alertRuleStats.failed + alertStats.failed;
     const duration = Date.now() - startTime;
 
     console.log('\n' + '═'.repeat(60));

--- a/scripts/v2/create-indexes-v2.ts
+++ b/scripts/v2/create-indexes-v2.ts
@@ -12,7 +12,7 @@
 
 import mongoose from 'mongoose';
 import dbConnect from '../../lib/db';
-import { indexShapeMatches } from './index-shape';
+import { indexShapeMatches, keysMatch } from './index-shape';
 
 // ============================================================================
 // INDEX DEFINITIONS
@@ -267,6 +267,22 @@ function describeShape(shape: {
  * up quietly missing its `partialFilterExpression`. Dropping a unique index against
  * production data is not a decision a script should make unattended, so a mismatch
  * is reported loudly and the run is marked as failed instead.
+ *
+ * A live index can also fail to name-match for an entirely benign reason: every
+ * index in this file's definitions is ALSO declared directly on its Mongoose schema
+ * via an unnamed `Schema.index({...})` call, so Mongoose's `autoIndex` (the default
+ * for any connection that has ever registered that schema - e.g. `pnpm seed`, or the
+ * app itself via `lib/db.ts`'s `dbConnect()`, neither of which disables it) builds it
+ * under MongoDB's own generated name the first time that model initializes, before
+ * this script ever gets a chance to create its own custom-named equivalent. MongoDB
+ * then refuses a second index with the identical key pattern under a different name
+ * outright. That is an already-satisfied index wearing the wrong name, not a missing
+ * one, so it is treated as a skip below - but ONLY when the full shape (key pattern,
+ * `unique`, and `partialFilterExpression`, all exact) matches, not merely the key
+ * pattern. A plain unique index on the same keys as the alert dedup index, for
+ * example, has an identical key pattern but silently permits only one alert document
+ * ever per (rule, device) pair - that must still be reported as loudly as a
+ * same-name mismatch, never silently accepted just because the name differs.
  */
 async function createCollectionIndexes(
   collectionName: string,
@@ -341,6 +357,76 @@ async function createCollectionIndexes(
             `existing shape is wrong, drop it yourself and re-run this script:`
         );
         console.error(`        db.${collectionName}.dropIndex(${JSON.stringify(index.name)})`);
+        console.error(`        pnpm create-indexes-v2`);
+        stats.mismatched++;
+        continue;
+      }
+
+      // No exact-name match. Before creating, check whether some OTHER index
+      // already has this exact shape under a different name - see the autoIndex
+      // note above. Full shape match only (key, unique, partialFilterExpression
+      // all exact, via the same indexShapeMatches used above) - not just the key
+      // pattern - so this cannot be fooled by the dangerous case below.
+      const shapeMatch = existingIndexes.find(idx =>
+        indexShapeMatches(
+          {
+            key: idx.key as Record<string, number>,
+            unique: idx.unique,
+            partialFilterExpression: idx.partialFilterExpression as
+              | Record<string, unknown>
+              | undefined,
+          },
+          {
+            fields: index.spec,
+            unique: index.options.unique,
+            partialFilterExpression: index.options.partialFilterExpression,
+          }
+        )
+      );
+
+      if (shapeMatch) {
+        console.log(
+          `   ⏭️  [SKIP] ${index.name} - already exists as "${shapeMatch.name}" ` +
+            `(autoIndex-built under a different name, same shape)`
+        );
+        stats.skipped++;
+        continue;
+      }
+
+      // Same key pattern under a different name, but NOT the same shape - the
+      // dangerous case described above (e.g. a plain unique index masquerading
+      // as the partial-unique dedup index). This must stay exactly as loud as a
+      // same-name mismatch: never silently accepted just because the name differs.
+      const keyMatch = existingIndexes.find(idx =>
+        keysMatch(idx.key as Record<string, number>, index.spec)
+      );
+
+      if (keyMatch) {
+        console.error(
+          `   🛑 [MISMATCH] ${index.name} - an index named "${keyMatch.name}" already has this ` +
+            `key pattern but a different unique/partialFilterExpression shape`
+        );
+        console.error(
+          `      Expected: { ${describeShape({
+            fields: index.spec,
+            unique: index.options.unique,
+            partialFilterExpression: index.options.partialFilterExpression,
+          })} }`
+        );
+        console.error(
+          `      Actual:   { ${describeShape({
+            fields: keyMatch.key as Record<string, number>,
+            unique: keyMatch.unique,
+            partialFilterExpression: keyMatch.partialFilterExpression as
+              | Record<string, unknown>
+              | undefined,
+          })} }`
+        );
+        console.error(
+          `      Refusing to drop or modify an existing index automatically. If the ` +
+            `existing shape is wrong, drop it yourself and re-run this script:`
+        );
+        console.error(`        db.${collectionName}.dropIndex(${JSON.stringify(keyMatch.name)})`);
         console.error(`        pnpm create-indexes-v2`);
         stats.mismatched++;
         continue;

--- a/scripts/v2/create-indexes-v2.ts
+++ b/scripts/v2/create-indexes-v2.ts
@@ -162,6 +162,28 @@ const READING_V2_INDEXES: IndexDefinition[] = [
   },
 ];
 
+/**
+ * AlertRuleV2 Index Definitions
+ *
+ * These indexes optimize:
+ * - The evaluator's rule-cache load predicate (enabled + not soft-deleted)
+ * - The default list sort
+ */
+const ALERT_RULE_V2_INDEXES: IndexDefinition[] = [
+  {
+    name: 'enabled_deleted_at',
+    spec: { enabled: 1, 'audit.deleted_at': 1 } as IndexSpec,
+    options: { background: true },
+    description: 'Rule cache load predicate: { enabled: true, audit.deleted_at: { $exists: false } }',
+  },
+  {
+    name: 'audit_created_at_desc',
+    spec: { 'audit.created_at': -1 } as IndexSpec,
+    options: { background: true },
+    description: 'Default sort for GET /api/v2/alert-rules',
+  },
+];
+
 // ============================================================================
 // HELPER FUNCTIONS
 // ============================================================================
@@ -257,6 +279,7 @@ async function createIndexes(): Promise<void> {
 
     const hasDevicesV2 = collectionNames.has('devices_v2');
     const hasReadingsV2 = collectionNames.has('readings_v2');
+    const hasAlertRulesV2 = collectionNames.has('alert_rules_v2');
 
     if (!hasDevicesV2)
       console.log(
@@ -268,20 +291,29 @@ async function createIndexes(): Promise<void> {
         '\n⚠️  Collection readings_v2 does not exist yet. Creating indexes will create the collection.'
       );
 
+    if (!hasAlertRulesV2)
+      console.log(
+        '\n⚠️  Collection alert_rules_v2 does not exist yet. Creating indexes will create the collection.'
+      );
+
     // Create indexes for devices_v2
     const deviceStats = await createCollectionIndexes('devices_v2', DEVICE_V2_INDEXES);
 
     // Create indexes for readings_v2
     const readingStats = await createCollectionIndexes('readings_v2', READING_V2_INDEXES);
 
+    // Create indexes for alert_rules_v2
+    const alertRuleStats = await createCollectionIndexes('alert_rules_v2', ALERT_RULE_V2_INDEXES);
+
     // Verify indexes
     await verifyIndexes('devices_v2');
     await verifyIndexes('readings_v2');
+    await verifyIndexes('alert_rules_v2');
 
     // Summary
-    const totalSuccess = deviceStats.success + readingStats.success;
-    const totalSkipped = deviceStats.skipped + readingStats.skipped;
-    const totalFailed = deviceStats.failed + readingStats.failed;
+    const totalSuccess = deviceStats.success + readingStats.success + alertRuleStats.success;
+    const totalSkipped = deviceStats.skipped + readingStats.skipped + alertRuleStats.skipped;
+    const totalFailed = deviceStats.failed + readingStats.failed + alertRuleStats.failed;
     const duration = Date.now() - startTime;
 
     console.log('\n' + '═'.repeat(60));

--- a/scripts/v2/create-indexes-v2.ts
+++ b/scripts/v2/create-indexes-v2.ts
@@ -12,6 +12,7 @@
 
 import mongoose from 'mongoose';
 import dbConnect from '../../lib/db';
+import { indexShapeMatches } from './index-shape';
 
 // ============================================================================
 // INDEX DEFINITIONS
@@ -179,7 +180,8 @@ const ALERT_RULE_V2_INDEXES: IndexDefinition[] = [
     name: 'enabled_deleted_at',
     spec: { enabled: 1, 'audit.deleted_at': 1 } as IndexSpec,
     options: { background: true },
-    description: 'Rule cache load predicate: { enabled: true, audit.deleted_at: { $exists: false } }',
+    description:
+      'Rule cache load predicate: { enabled: true, audit.deleted_at: { $exists: false } }',
   },
   {
     name: 'audit_created_at_desc',
@@ -240,30 +242,98 @@ const ALERT_V2_INDEXES: IndexDefinition[] = [
 // HELPER FUNCTIONS
 // ============================================================================
 
+/** Render an index's shape for the mismatch report — compact and exact, not pretty. */
+function describeShape(shape: {
+  fields: Record<string, number>;
+  unique?: boolean;
+  partialFilterExpression?: Record<string, unknown>;
+}): string {
+  const parts = [`spec: ${JSON.stringify(shape.fields)}`, `unique: ${Boolean(shape.unique)}`];
+  parts.push(
+    `partialFilterExpression: ${
+      shape.partialFilterExpression ? JSON.stringify(shape.partialFilterExpression) : 'none'
+    }`
+  );
+  return parts.join(', ');
+}
+
 /**
- * Create indexes for a collection with logging
+ * Create indexes for a collection with logging.
+ *
+ * When a live index already has the expected name but its shape (keys, `unique`, or
+ * `partialFilterExpression`) has drifted from what this script would create, this
+ * does NOT drop or modify it. Silently accepting a same-name/different-shape index —
+ * or worse, auto-dropping and recreating it — is exactly how a unique index can end
+ * up quietly missing its `partialFilterExpression`. Dropping a unique index against
+ * production data is not a decision a script should make unattended, so a mismatch
+ * is reported loudly and the run is marked as failed instead.
  */
 async function createCollectionIndexes(
   collectionName: string,
   indexes: IndexDefinition[]
-): Promise<{ success: number; skipped: number; failed: number }> {
+): Promise<{ success: number; skipped: number; mismatched: number; failed: number }> {
   const collection = mongoose.connection.collection(collectionName);
-  const stats = { success: 0, skipped: 0, failed: 0 };
+  const stats = { success: 0, skipped: 0, mismatched: 0, failed: 0 };
 
-  // Get existing indexes
+  // Get existing indexes, keyed by name, so a name match can be shape-checked below.
   const existingIndexes = await collection.indexes();
-  const existingIndexNames = new Set(existingIndexes.map(idx => idx.name));
+  const existingIndexByName = new Map(existingIndexes.map(idx => [idx.name, idx]));
 
   console.log(`\n📦 Collection: ${collectionName}`);
-  console.log(`   Existing indexes: ${existingIndexNames.size}`);
+  console.log(`   Existing indexes: ${existingIndexByName.size}`);
   console.log('─'.repeat(60));
 
   for (const index of indexes)
     try {
-      // Check if index already exists
-      if (existingIndexNames.has(index.name)) {
-        console.log(`   ⏭️  [SKIP] ${index.name} - already exists`);
-        stats.skipped++;
+      const existing = existingIndexByName.get(index.name);
+      if (existing) {
+        const matches = indexShapeMatches(
+          {
+            key: existing.key as Record<string, number>,
+            unique: existing.unique,
+            partialFilterExpression: existing.partialFilterExpression as
+              | Record<string, unknown>
+              | undefined,
+          },
+          {
+            fields: index.spec,
+            unique: index.options.unique,
+            partialFilterExpression: index.options.partialFilterExpression,
+          }
+        );
+
+        if (matches) {
+          console.log(`   ⏭️  [SKIP] ${index.name} - already exists`);
+          stats.skipped++;
+          continue;
+        }
+
+        console.error(
+          `   🛑 [MISMATCH] ${index.name} - existing index shape differs from expected`
+        );
+        console.error(
+          `      Expected: { ${describeShape({
+            fields: index.spec,
+            unique: index.options.unique,
+            partialFilterExpression: index.options.partialFilterExpression,
+          })} }`
+        );
+        console.error(
+          `      Actual:   { ${describeShape({
+            fields: existing.key as Record<string, number>,
+            unique: existing.unique,
+            partialFilterExpression: existing.partialFilterExpression as
+              | Record<string, unknown>
+              | undefined,
+          })} }`
+        );
+        console.error(
+          `      Refusing to drop or modify an existing index automatically. If the ` +
+            `existing shape is wrong, drop it yourself and re-run this script:`
+        );
+        console.error(`        db.${collectionName}.dropIndex(${JSON.stringify(index.name)})`);
+        console.error(`        pnpm create-indexes-v2`);
+        stats.mismatched++;
         continue;
       }
 
@@ -379,6 +449,11 @@ async function createIndexes(): Promise<void> {
       deviceStats.success + readingStats.success + alertRuleStats.success + alertStats.success;
     const totalSkipped =
       deviceStats.skipped + readingStats.skipped + alertRuleStats.skipped + alertStats.skipped;
+    const totalMismatched =
+      deviceStats.mismatched +
+      readingStats.mismatched +
+      alertRuleStats.mismatched +
+      alertStats.mismatched;
     const totalFailed =
       deviceStats.failed + readingStats.failed + alertRuleStats.failed + alertStats.failed;
     const duration = Date.now() - startTime;
@@ -386,11 +461,23 @@ async function createIndexes(): Promise<void> {
     console.log('\n' + '═'.repeat(60));
     console.log('📊 Summary');
     console.log('═'.repeat(60));
-    console.log(`   ✅ Created: ${totalSuccess} indexes`);
-    console.log(`   ⏭️  Skipped: ${totalSkipped} indexes (already existed)`);
-    console.log(`   ❌ Failed:  ${totalFailed} indexes`);
+    console.log(`   ✅ Created:    ${totalSuccess} indexes`);
+    console.log(`   ⏭️  Skipped:    ${totalSkipped} indexes (already existed)`);
+    console.log(
+      `   🛑 Mismatched: ${totalMismatched} indexes (existing shape differs - see above)`
+    );
+    console.log(`   ❌ Failed:     ${totalFailed} indexes`);
     console.log(`   ⏱️  Duration: ${duration}ms`);
     console.log('═'.repeat(60));
+
+    if (totalMismatched > 0) {
+      console.log(
+        '\n⚠️  Some existing indexes do not match their expected shape. This script will ' +
+          'not drop or modify them automatically - see the [MISMATCH] entries above for the ' +
+          'exact dropIndex command to run before re-running this script.'
+      );
+      process.exit(1);
+    }
 
     if (totalFailed > 0) {
       console.log('\n⚠️  Some indexes failed to create. Please check the errors above.');

--- a/scripts/v2/index-shape.ts
+++ b/scripts/v2/index-shape.ts
@@ -1,0 +1,159 @@
+/**
+ * Index shape comparison helpers.
+ *
+ * Shared by `verify-indexes.ts` ("does a live index satisfy this expected shape?")
+ * and `create-indexes-v2.ts` ("does a pre-existing, name-matched index exactly match
+ * what this script would create?"). Pulled into its own side-effect-free module —
+ * mirroring `db-guard.ts` — so the comparison logic is unit-testable without a live
+ * database: both scripts connect to MongoDB and run unconditionally at import time,
+ * so importing them directly in a test would attempt a real connection.
+ */
+
+/** An index as reported by MongoDB (`listIndexes()` / `collection.indexes()`). */
+export interface IndexInfo {
+  name: string;
+  key: Record<string, number>;
+  unique?: boolean;
+  partialFilterExpression?: Record<string, unknown>;
+}
+
+/** The shape a caller expects some index to have. */
+export interface ExpectedIndex {
+  name: string;
+  fields: Record<string, number>;
+  unique?: boolean;
+  partialFilterExpression?: Record<string, unknown>;
+}
+
+/**
+ * Whether two index key specs are identical: same fields, same sort direction,
+ * same order.
+ *
+ * Field order is functionally significant for compound indexes — it determines
+ * which query and sort patterns the index can serve — so this is deliberately an
+ * exact, order-sensitive match rather than a subset check. A subset check would let
+ * `rule_device_resolved_at`'s `{rule_id, device_id, 'audit.resolved_at': -1}` satisfy
+ * an expectation of `rule_device_open_unique`'s `{rule_id, device_id}`, since the
+ * former's first two fields happen to match the latter's only two fields.
+ */
+export function keysMatch(
+  actualKey: Record<string, number>,
+  expectedFields: Record<string, number>
+): boolean {
+  const actualEntries = Object.entries(actualKey);
+  const expectedEntries = Object.entries(expectedFields);
+
+  if (actualEntries.length !== expectedEntries.length) return false;
+
+  return actualEntries.every(([field, order], i) => {
+    const [expectedField, expectedOrder] = expectedEntries[i];
+    return field === expectedField && order === expectedOrder;
+  });
+}
+
+/**
+ * Recursive, key-order-insensitive structural equality for plain JSON-like values.
+ * Sufficient for comparing `partialFilterExpression` documents, which are ordinary
+ * BSON filter predicates with no significance attached to key order.
+ */
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b)) return false;
+    return a.length === b.length && a.every((item, i) => deepEqual(item, b[i]));
+  }
+
+  const aIsObject = typeof a === 'object' && a !== null;
+  const bIsObject = typeof b === 'object' && b !== null;
+  if (!aIsObject || !bIsObject) return false;
+
+  const aRecord = a as Record<string, unknown>;
+  const bRecord = b as Record<string, unknown>;
+  const aKeys = Object.keys(aRecord);
+  const bKeys = Object.keys(bRecord);
+  if (aKeys.length !== bKeys.length) return false;
+
+  return aKeys.every(
+    key =>
+      Object.prototype.hasOwnProperty.call(bRecord, key) && deepEqual(aRecord[key], bRecord[key])
+  );
+}
+
+/**
+ * Whether two `partialFilterExpression` values match: exact and symmetric. Unlike
+ * the `unique` flag (see `checkIndexExists`), there is no "unspecified means don't
+ * care" case here — an index with a filter never satisfies an expectation with none,
+ * and vice versa. That asymmetry is exactly what let a plain unique index on
+ * `{rule_id, device_id}` masquerade as the partial dedup index: both have identical
+ * keys and both are unique, differing only in a property nobody compared.
+ */
+export function partialFilterExpressionsMatch(
+  actual: Record<string, unknown> | undefined,
+  expected: Record<string, unknown> | undefined
+): boolean {
+  if (actual === undefined && expected === undefined) return true;
+  if (actual === undefined || expected === undefined) return false;
+  return deepEqual(actual, expected);
+}
+
+/**
+ * Whether at least one live index satisfies the expected shape.
+ *
+ * Key fields and `partialFilterExpression` must match exactly. `unique` is checked
+ * only when the expectation requires it — an expectation that doesn't care about
+ * uniqueness is satisfied by either a unique or a non-unique index. This mirrors the
+ * function's original, more permissive behavior; only `checkIndexExists` (an
+ * "at-least-this-strict" existence check) treats `unique` this way. Callers
+ * comparing a specific index against its exact intended definition — see
+ * `indexShapeMatches` below — should not.
+ */
+export function checkIndexExists(
+  indexes: IndexInfo[],
+  expected: {
+    fields: Record<string, number>;
+    unique?: boolean;
+    partialFilterExpression?: Record<string, unknown>;
+  }
+): boolean {
+  return indexes.some(idx => {
+    const keyOk = keysMatch(idx.key, expected.fields);
+    const uniqueOk = expected.unique ? idx.unique === true : true;
+    const partialOk = partialFilterExpressionsMatch(
+      idx.partialFilterExpression,
+      expected.partialFilterExpression
+    );
+    return keyOk && uniqueOk && partialOk;
+  });
+}
+
+/**
+ * Whether a single, name-matched live index is an EXACT match for an expected
+ * definition — fields, `unique`, and `partialFilterExpression` all identical.
+ *
+ * Unlike `checkIndexExists`, `unique` is compared exactly rather than treated as a
+ * floor: this powers `create-indexes-v2.ts`'s pre-flight check for a same-name index
+ * whose shape has drifted from what the script would create, where any difference —
+ * including an index that is unique when it should not be, or vice versa — is a
+ * mismatch worth flagging rather than silently skipping.
+ */
+export function indexShapeMatches(
+  actual: {
+    key: Record<string, number>;
+    unique?: boolean;
+    partialFilterExpression?: Record<string, unknown>;
+  },
+  expected: {
+    fields: Record<string, number>;
+    unique?: boolean;
+    partialFilterExpression?: Record<string, unknown>;
+  }
+): boolean {
+  const keyOk = keysMatch(actual.key, expected.fields);
+  const uniqueOk = Boolean(actual.unique) === Boolean(expected.unique);
+  const partialOk = partialFilterExpressionsMatch(
+    actual.partialFilterExpression,
+    expected.partialFilterExpression
+  );
+  return keyOk && uniqueOk && partialOk;
+}

--- a/scripts/v2/seed-v2.ts
+++ b/scripts/v2/seed-v2.ts
@@ -367,7 +367,10 @@ async function seed(): Promise<void> {
 
     console.log(`\n✅ Inserted ${totalReadings} readings total\n`);
 
-    // Seed alert rules so /alerts is populated on first load.
+    // Seed alert rules so alert rules exist to be evaluated. This alone does not
+    // populate /alerts: readings are inserted directly via ReadingV2.insertMany
+    // above, bypassing the API route that runs evaluateReadings. Alerts appear
+    // only once an authenticated GET /api/v2/cron/simulate call evaluates them.
     console.log('🔔 Seeding alert rules...');
     const alertRules = buildAlertRuleSeeds();
     await AlertRuleV2.insertMany(alertRules);

--- a/scripts/v2/seed-v2.ts
+++ b/scripts/v2/seed-v2.ts
@@ -13,6 +13,7 @@ import mongoose from 'mongoose';
 import DeviceV2 from '../../models/v2/DeviceV2';
 import ReadingV2 from '../../models/v2/ReadingV2';
 import AlertRuleV2 from '../../models/v2/AlertRuleV2';
+import AlertV2 from '../../models/v2/AlertV2';
 import { assertSafeToWipe, describeTarget } from './db-guard';
 import { buildAlertRuleSeeds } from './alert-rule-seeds';
 
@@ -335,6 +336,15 @@ async function seed(): Promise<void> {
     await DeviceV2.deleteMany({});
     await ReadingV2.deleteMany({});
     await AlertRuleV2.deleteMany({});
+    // Alerts reference rule ids, and a fresh AlertRuleV2 seed above just
+    // invalidated every one of them. Leaving old alerts_v2 documents behind
+    // would show a freshly seeded demo phantom "firing" alerts pointing at
+    // rules that no longer exist — their devices still exist too, so they
+    // are not swept as device_inactive, and would only clear once the
+    // staleness sweep eventually closes them (up to ALERT_STALE_AFTER_SECONDS
+    // later). Clearing them here trades away using a re-seed to demonstrate
+    // the staleness sweep, in favor of not shipping a broken first impression.
+    await AlertV2.deleteMany({});
     console.log('✅ Cleared existing data\n');
 
     // Generate and insert devices

--- a/scripts/v2/seed-v2.ts
+++ b/scripts/v2/seed-v2.ts
@@ -12,7 +12,9 @@
 import mongoose from 'mongoose';
 import DeviceV2 from '../../models/v2/DeviceV2';
 import ReadingV2 from '../../models/v2/ReadingV2';
+import AlertRuleV2 from '../../models/v2/AlertRuleV2';
 import { assertSafeToWipe, describeTarget } from './db-guard';
+import { buildAlertRuleSeeds } from './alert-rule-seeds';
 
 const MONGODB_URI = process.env.MONGODB_URI;
 
@@ -332,6 +334,7 @@ async function seed(): Promise<void> {
     if (FORCE) console.log('   ⚠️  --force: wiping a non-local database');
     await DeviceV2.deleteMany({});
     await ReadingV2.deleteMany({});
+    await AlertRuleV2.deleteMany({});
     console.log('✅ Cleared existing data\n');
 
     // Generate and insert devices
@@ -364,6 +367,12 @@ async function seed(): Promise<void> {
 
     console.log(`\n✅ Inserted ${totalReadings} readings total\n`);
 
+    // Seed alert rules so /alerts is populated on first load.
+    console.log('🔔 Seeding alert rules...');
+    const alertRules = buildAlertRuleSeeds();
+    await AlertRuleV2.insertMany(alertRules);
+    console.log(`✅ Inserted ${alertRules.length} alert rules\n`);
+
     // Summary
     console.log('='.repeat(50));
     console.log('📋 Seed Summary');
@@ -373,6 +382,7 @@ async function seed(): Promise<void> {
     console.log(`  Readings per device: ${READINGS_PER_DEVICE}`);
     console.log(`  Device types: ${deviceTypes.length}`);
     console.log(`  Time range: ${READINGS_PER_DEVICE} hours (1 reading/hour)`);
+    console.log(`  Alert rules: ${alertRules.length}`);
     console.log('='.repeat(50));
 
     console.log('\n✅ Seed completed successfully!');

--- a/scripts/v2/verify-indexes.ts
+++ b/scripts/v2/verify-indexes.ts
@@ -102,7 +102,17 @@ async function main() {
   }
 
   console.log('Connecting to MongoDB...');
-  await mongoose.connect(uri);
+  // autoIndex: false is required, not optional. This script imports every v2
+  // model to register their schemas (see the imports above), and Mongoose's
+  // default is to auto-build any index declared on a schema as soon as the
+  // connection opens. AlertV2's dedup index has no explicit name, so Mongoose
+  // would build it under an auto-generated name (rule_id_1_device_id_1)
+  // alongside whatever is already on disk. checkIndexExists is name-agnostic —
+  // it asks "does *some* index satisfy this shape" — so a correctly-shaped index
+  // this connection just created would make a broken, differently-named
+  // rule_device_open_unique read as verified. A verification script must observe
+  // the database as it actually is, not as connecting to it would leave it.
+  await mongoose.connect(uri, { autoIndex: false });
   console.log('Connected successfully\n');
 
   // ---- DeviceV2 Indexes ----

--- a/scripts/v2/verify-indexes.ts
+++ b/scripts/v2/verify-indexes.ts
@@ -13,6 +13,7 @@ import 'dotenv/config';
 // Import models to ensure schemas are registered
 import '../../models/v2/DeviceV2';
 import '../../models/v2/ReadingV2';
+import '../../models/v2/AlertRuleV2';
 
 // ============================================================================
 // EXPECTED INDEXES
@@ -41,6 +42,11 @@ const EXPECTED_READING_INDEXES: ExpectedIndex[] = [
   { name: 'device_timestamp', fields: { 'metadata.device_id': 1, timestamp: 1 } },
   { name: 'is_anomaly', fields: { 'quality.is_anomaly': 1 } },
   { name: 'source', fields: { 'metadata.source': 1 } },
+];
+
+const EXPECTED_ALERT_RULE_INDEXES: ExpectedIndex[] = [
+  { name: 'enabled_deleted_at', fields: { enabled: 1, 'audit.deleted_at': 1 } },
+  { name: 'audit_created_at_desc', fields: { 'audit.created_at': -1 } },
 ];
 
 // ============================================================================
@@ -181,6 +187,41 @@ async function main() {
     console.error('Error checking ReadingV2 indexes:', error);
   }
 
+  // ---- AlertRuleV2 Indexes ----
+  console.log('\n' + '═'.repeat(60));
+  console.log(' AlertRuleV2 Collection Indexes');
+  console.log('═'.repeat(60));
+
+  try {
+    const alertRuleIndexes = await getCollectionIndexes('alert_rules_v2');
+
+    console.log('\nCurrent indexes:');
+    for (const idx of alertRuleIndexes) {
+      const uniqueStr = idx.unique ? ' (unique)' : '';
+      console.log(`  • ${idx.name}${uniqueStr}`);
+      console.log(`    Fields: { ${formatIndexKey(idx.key)} }`);
+    }
+
+    console.log('\nExpected indexes:');
+    let allAlertRuleIndexesPresent = true;
+    for (const expected of EXPECTED_ALERT_RULE_INDEXES) {
+      const exists = checkIndexExists(alertRuleIndexes, expected);
+      const status = exists ? '✓' : '✗';
+      const color = exists ? '\x1b[32m' : '\x1b[31m';
+      const reset = '\x1b[0m';
+      console.log(`  ${color}${status}${reset} ${expected.name}`);
+      if (!exists) {
+        allAlertRuleIndexesPresent = false;
+        console.log(`    Missing: { ${formatIndexKey(expected.fields)} }`);
+      }
+    }
+
+    if (allAlertRuleIndexesPresent) console.log('\n  \x1b[32m✓ All expected indexes present\x1b[0m');
+    else console.log('\n  \x1b[33m⚠ Some indexes are missing - run create-indexes-v2.ts\x1b[0m');
+  } catch (error) {
+    console.error('Error checking AlertRuleV2 indexes:', error);
+  }
+
   // ---- Collection Stats ----
   console.log('\n' + '═'.repeat(60));
   console.log(' Collection Statistics');
@@ -206,6 +247,17 @@ async function main() {
     }
   } catch {
     console.log('\nreadings_v2: Collection does not exist or is empty');
+  }
+
+  try {
+    const db = mongoose.connection.db;
+    if (db) {
+      const alertRuleCount = await db.collection('alert_rules_v2').estimatedDocumentCount();
+      console.log('\nalert_rules_v2:');
+      console.log(`  Documents: ${alertRuleCount.toLocaleString()}`);
+    }
+  } catch {
+    console.log('\nalert_rules_v2: Collection does not exist or is empty');
   }
 
   console.log('\n' + '═'.repeat(60));

--- a/scripts/v2/verify-indexes.ts
+++ b/scripts/v2/verify-indexes.ts
@@ -16,15 +16,11 @@ import '../../models/v2/ReadingV2';
 import '../../models/v2/AlertRuleV2';
 import '../../models/v2/AlertV2';
 
+import { checkIndexExists, type ExpectedIndex, type IndexInfo } from './index-shape';
+
 // ============================================================================
 // EXPECTED INDEXES
 // ============================================================================
-
-interface ExpectedIndex {
-  name: string;
-  fields: Record<string, number>;
-  unique?: boolean;
-}
 
 const EXPECTED_DEVICE_INDEXES: ExpectedIndex[] = [
   { name: 'serial_number', fields: { serial_number: 1 }, unique: true },
@@ -55,6 +51,12 @@ const EXPECTED_ALERT_INDEXES: ExpectedIndex[] = [
     name: 'rule_device_open_unique',
     fields: { rule_id: 1, device_id: 1 },
     unique: true,
+    // The partial filter is the entire dedup mechanism: it is what allows unlimited
+    // *resolved* episodes per (rule, device) while permitting only one *open* one.
+    // A plain unique index on the same two fields has identical keys and is also
+    // unique — without this, the verifier cannot tell them apart, and a plain
+    // unique index silently blocks every episode after the first for that pair.
+    partialFilterExpression: { is_open: true },
   },
   {
     name: 'rule_device_resolved_at',
@@ -70,12 +72,6 @@ const EXPECTED_ALERT_INDEXES: ExpectedIndex[] = [
 // VERIFICATION FUNCTIONS
 // ============================================================================
 
-interface IndexInfo {
-  name: string;
-  key: Record<string, number>;
-  unique?: boolean;
-}
-
 async function getCollectionIndexes(collectionName: string): Promise<IndexInfo[]> {
   const collection = mongoose.connection.collection(collectionName);
   const indexes = await collection.listIndexes().toArray();
@@ -83,6 +79,7 @@ async function getCollectionIndexes(collectionName: string): Promise<IndexInfo[]
     name: idx.name,
     key: idx.key as Record<string, number>,
     unique: idx.unique,
+    partialFilterExpression: idx.partialFilterExpression as Record<string, unknown> | undefined,
   }));
 }
 
@@ -90,19 +87,6 @@ function formatIndexKey(key: Record<string, number>): string {
   return Object.entries(key)
     .map(([field, order]) => `${field}: ${order}`)
     .join(', ');
-}
-
-function checkIndexExists(
-  indexes: IndexInfo[],
-  expected: { fields: Record<string, number>; unique?: boolean }
-): boolean {
-  return indexes.some(idx => {
-    const fieldsMatch = Object.entries(expected.fields).every(
-      ([field, order]) => idx.key[field] === order
-    );
-    const uniqueMatch = expected.unique ? idx.unique === true : true;
-    return fieldsMatch && uniqueMatch;
-  });
 }
 
 // ============================================================================
@@ -233,7 +217,8 @@ async function main() {
       }
     }
 
-    if (allAlertRuleIndexesPresent) console.log('\n  \x1b[32m✓ All expected indexes present\x1b[0m');
+    if (allAlertRuleIndexesPresent)
+      console.log('\n  \x1b[32m✓ All expected indexes present\x1b[0m');
     else console.log('\n  \x1b[33m⚠ Some indexes are missing - run create-indexes-v2.ts\x1b[0m');
   } catch (error) {
     console.error('Error checking AlertRuleV2 indexes:', error);

--- a/scripts/v2/verify-indexes.ts
+++ b/scripts/v2/verify-indexes.ts
@@ -14,6 +14,7 @@ import 'dotenv/config';
 import '../../models/v2/DeviceV2';
 import '../../models/v2/ReadingV2';
 import '../../models/v2/AlertRuleV2';
+import '../../models/v2/AlertV2';
 
 // ============================================================================
 // EXPECTED INDEXES
@@ -47,6 +48,22 @@ const EXPECTED_READING_INDEXES: ExpectedIndex[] = [
 const EXPECTED_ALERT_RULE_INDEXES: ExpectedIndex[] = [
   { name: 'enabled_deleted_at', fields: { enabled: 1, 'audit.deleted_at': 1 } },
   { name: 'audit_created_at_desc', fields: { 'audit.created_at': -1 } },
+];
+
+const EXPECTED_ALERT_INDEXES: ExpectedIndex[] = [
+  {
+    name: 'rule_device_open_unique',
+    fields: { rule_id: 1, device_id: 1 },
+    unique: true,
+  },
+  {
+    name: 'rule_device_resolved_at',
+    fields: { rule_id: 1, device_id: 1, 'audit.resolved_at': -1 },
+  },
+  { name: 'status_created_at', fields: { status: 1, 'audit.created_at': -1 } },
+  { name: 'device_created_at', fields: { device_id: 1, 'audit.created_at': -1 } },
+  { name: 'severity_status', fields: { severity: 1, status: 1 } },
+  { name: 'is_open_last_observed_at', fields: { is_open: 1, last_observed_at: 1 } },
 ];
 
 // ============================================================================
@@ -222,6 +239,41 @@ async function main() {
     console.error('Error checking AlertRuleV2 indexes:', error);
   }
 
+  // ---- AlertV2 Indexes ----
+  console.log('\n' + '═'.repeat(60));
+  console.log(' AlertV2 Collection Indexes');
+  console.log('═'.repeat(60));
+
+  try {
+    const alertIndexes = await getCollectionIndexes('alerts_v2');
+
+    console.log('\nCurrent indexes:');
+    for (const idx of alertIndexes) {
+      const uniqueStr = idx.unique ? ' (unique)' : '';
+      console.log(`  • ${idx.name}${uniqueStr}`);
+      console.log(`    Fields: { ${formatIndexKey(idx.key)} }`);
+    }
+
+    console.log('\nExpected indexes:');
+    let allAlertIndexesPresent = true;
+    for (const expected of EXPECTED_ALERT_INDEXES) {
+      const exists = checkIndexExists(alertIndexes, expected);
+      const status = exists ? '✓' : '✗';
+      const color = exists ? '\x1b[32m' : '\x1b[31m';
+      const reset = '\x1b[0m';
+      console.log(`  ${color}${status}${reset} ${expected.name}`);
+      if (!exists) {
+        allAlertIndexesPresent = false;
+        console.log(`    Missing: { ${formatIndexKey(expected.fields)} }`);
+      }
+    }
+
+    if (allAlertIndexesPresent) console.log('\n  \x1b[32m✓ All expected indexes present\x1b[0m');
+    else console.log('\n  \x1b[33m⚠ Some indexes are missing - run create-indexes-v2.ts\x1b[0m');
+  } catch (error) {
+    console.error('Error checking AlertV2 indexes:', error);
+  }
+
   // ---- Collection Stats ----
   console.log('\n' + '═'.repeat(60));
   console.log(' Collection Statistics');
@@ -258,6 +310,17 @@ async function main() {
     }
   } catch {
     console.log('\nalert_rules_v2: Collection does not exist or is empty');
+  }
+
+  try {
+    const db = mongoose.connection.db;
+    if (db) {
+      const alertCount = await db.collection('alerts_v2').estimatedDocumentCount();
+      console.log('\nalerts_v2:');
+      console.log(`  Documents: ${alertCount.toLocaleString()}`);
+    }
+  } catch {
+    console.log('\nalerts_v2: Collection does not exist or is empty');
   }
 
   console.log('\n' + '═'.repeat(60));

--- a/types/v2/alert.types.ts
+++ b/types/v2/alert.types.ts
@@ -1,8 +1,9 @@
 /**
  * TypeScript Type Definitions for the Alerting Subsystem
  *
- * Client-safe: no mongoose or model imports. `lib/pusher-context.tsx` imports
- * AlertEvent from this file.
+ * Client-safe: no mongoose or model imports. Nothing imports from this file
+ * yet — `lib/pusher-context.tsx` will consume `AlertEvent` once Task 13/14
+ * wires up alert delivery over Pusher.
  *
  * Aligned with:
  * - Mongoose models: /models/v2/AlertRuleV2.ts, /models/v2/AlertV2.ts
@@ -60,20 +61,125 @@ export interface AlertRuleV2Response {
   audit: AlertRuleAudit;
 }
 
-export interface CreateAlertRuleBody {
+/**
+ * Selector variant for `metric: 'value'` rules. `types` is required and must
+ * list at least one reading type: a bare value threshold is meaningless across
+ * mixed units — 30 is a reasonable temperature ceiling and an absurd power one.
+ * Enforced by `typesRequiredForValueMetric` in alert-rule.validation.ts.
+ */
+export interface ValueMetricSelector extends Omit<AlertRuleSelector, 'types'> {
+  types: [ReadingTypeName, ...ReadingTypeName[]];
+}
+
+/**
+ * The `metric` / `comparison` / `threshold` / `selector` group for CREATE,
+ * discriminated on `metric` so the two states `createAlertRuleSchema` always
+ * rejects are unrepresentable:
+ * - `metric: 'value'` with `selector.types` missing or empty.
+ * - a `threshold` outside the metric's valid range.
+ *
+ * `selector` is optional for `anomaly_score` / `battery_level` because
+ * `createAlertRuleSchema` defaults it to `{}` when the key is omitted
+ * (`selector: alertRuleSelectorSchema.default({})`).
+ *
+ * Threshold bounds (`anomaly_score` in [0, 1], `battery_level` in [0, 100]) are
+ * enforced by Zod's `thresholdWithinMetricBounds` (alert-rule.validation.ts),
+ * not by these types — TypeScript has no numeric refinement types, so
+ * `threshold` stays `number` on every arm; the bounds are documented instead.
+ */
+export type CreateAlertRuleCondition =
+  | {
+      metric: 'value';
+      comparison: AlertComparison;
+      threshold: number;
+      selector: ValueMetricSelector;
+    }
+  | {
+      metric: 'anomaly_score';
+      comparison: AlertComparison;
+      /** Must be within [0, 1]. Enforced by Zod, not representable in TypeScript. */
+      threshold: number;
+      selector?: AlertRuleSelector;
+    }
+  | {
+      metric: 'battery_level';
+      comparison: AlertComparison;
+      /** Must be within [0, 100]. Enforced by Zod, not representable in TypeScript. */
+      threshold: number;
+      selector?: AlertRuleSelector;
+    };
+
+interface AlertRuleBodyBase {
   name: string;
   description?: string;
   enabled?: boolean;
-  selector?: AlertRuleSelector;
-  metric: AlertMetric;
-  comparison: AlertComparison;
-  threshold: number;
   for_duration_seconds?: number;
   severity: AlertSeverity;
   cooldown_seconds?: number;
 }
 
-export type UpdateAlertRuleBody = Partial<CreateAlertRuleBody>;
+export type CreateAlertRuleBody = AlertRuleBodyBase & CreateAlertRuleCondition;
+
+/**
+ * The same condition group for UPDATE — deliberately a separate type from
+ * `CreateAlertRuleCondition`, not a reuse of it, because `selector`'s
+ * requiredness differs between create and update:
+ *
+ * `updateAlertRuleSchema` gives `selector` no default
+ * (`selector: alertRuleSelectorSchema.optional()`), and its atomic-group
+ * refinement tests `data.selector !== undefined`. So whenever `metric` is
+ * being changed, `selector` must be an explicit key for EVERY metric — send
+ * `{}` for `anomaly_score` / `battery_level` if there is nothing to
+ * constrain — not just for `'value'`. Confirmed against the live schema:
+ * `{ metric: 'anomaly_score', comparison: 'gt', threshold: 0.5 }` with no
+ * `selector` key is always rejected ("metric, comparison, threshold and
+ * selector must be updated together — send all four or none"), while the same
+ * body plus `selector: {}` is accepted. `metric: 'value'` still additionally
+ * requires `selector.types` to be non-empty, same as create.
+ */
+type UpdateAlertRuleCondition =
+  | {
+      metric: 'value';
+      comparison: AlertComparison;
+      threshold: number;
+      selector: ValueMetricSelector;
+    }
+  | {
+      metric: 'anomaly_score';
+      comparison: AlertComparison;
+      /** Must be within [0, 1]. Enforced by Zod, not representable in TypeScript. */
+      threshold: number;
+      selector: AlertRuleSelector;
+    }
+  | {
+      metric: 'battery_level';
+      comparison: AlertComparison;
+      /** Must be within [0, 100]. Enforced by Zod, not representable in TypeScript. */
+      threshold: number;
+      selector: AlertRuleSelector;
+    };
+
+/**
+ * None of `metric` / `comparison` / `threshold` / `selector` present — the
+ * "leave the condition untouched" half of the atomic-group rule below.
+ */
+type NoConditionUpdate = {
+  metric?: undefined;
+  comparison?: undefined;
+  threshold?: undefined;
+  selector?: undefined;
+};
+
+/**
+ * `metric`, `comparison`, `threshold` and `selector` must be updated together —
+ * send all four or none (`updateAlertRuleSchema`'s `CONDITION_FIELDS` check,
+ * alert-rule.validation.ts:144-154). A partial condition like `{ threshold: 5 }`
+ * is therefore not expressible: it satisfies neither an `UpdateAlertRuleCondition`
+ * arm (missing `metric`/`comparison`/`selector`) nor `NoConditionUpdate`
+ * (`threshold` must be absent or `undefined`).
+ */
+export type UpdateAlertRuleBody = Partial<AlertRuleBodyBase> &
+  (UpdateAlertRuleCondition | NoConditionUpdate);
 
 export interface ListAlertRulesQueryParams {
   page?: number;
@@ -168,8 +274,17 @@ export interface FiredAlert {
 
 /**
  * Trimmed payload broadcast when an episode resolves.
- * `actor` is 'system' for automatic resolution, otherwise the Clerk USER ID.
- * Never an email — this payload reaches every connected client.
+ *
+ * `actor` is 'system' for automatic resolution. For a manual resolution it MUST
+ * be `userId` — the Clerk user ID returned by `requireAdmin()` — and NEVER an
+ * email, because this payload reaches every connected client.
+ *
+ * Concretely: use the `userId` from `requireAdmin()`. Do NOT use `auditUser` or
+ * `getAuditUser(userId, user)` (lib/auth/index.ts) to populate this field —
+ * `getAuditUser` resolves to `user.email` whenever Clerk has one on file, which
+ * is exactly the leak this field must not have. `auditUser`/`getAuditUser`
+ * remain correct for audit-trail fields (e.g. `audit.resolved_by`), which are
+ * never broadcast; they are wrong specifically for this Pusher payload.
  */
 export interface ResolvedAlert {
   _id: string;

--- a/types/v2/alert.types.ts
+++ b/types/v2/alert.types.ts
@@ -1,0 +1,198 @@
+/**
+ * TypeScript Type Definitions for the Alerting Subsystem
+ *
+ * Client-safe: no mongoose or model imports. `lib/pusher-context.tsx` imports
+ * AlertEvent from this file.
+ *
+ * Aligned with:
+ * - Mongoose models: /models/v2/AlertRuleV2.ts, /models/v2/AlertV2.ts
+ * - Zod schemas: /lib/validations/v2/alert-rule.validation.ts, alert.validation.ts
+ */
+
+// ============================================================================
+// ENUMS
+// ============================================================================
+
+export type AlertMetric = 'value' | 'anomaly_score' | 'battery_level';
+export type AlertComparison = 'gt' | 'gte' | 'lt' | 'lte';
+export type AlertSeverity = 'info' | 'warning' | 'critical';
+export type AlertStatus = 'pending' | 'firing' | 'acknowledged' | 'resolved';
+export type AlertResolution = 'manual' | 'auto' | 'stale' | 'device_inactive';
+export type ReadingTypeName =
+  | 'temperature' | 'humidity' | 'occupancy' | 'power' | 'co2'
+  | 'pressure' | 'light' | 'motion' | 'air_quality' | 'water_flow'
+  | 'gas' | 'vibration' | 'voltage' | 'current' | 'energy';
+
+// ============================================================================
+// RULE
+// ============================================================================
+
+export interface AlertRuleSelector {
+  types?: ReadingTypeName[];
+  building_id?: string;
+  floor?: number;
+  zone?: string;
+  tags?: string[];
+}
+
+export interface AlertRuleAudit {
+  created_at: string;
+  created_by: string;
+  updated_at: string;
+  updated_by: string;
+  deleted_at?: string;
+  deleted_by?: string;
+}
+
+/** A rule as returned by the API (dates serialized to ISO strings). */
+export interface AlertRuleV2Response {
+  _id: string;
+  name: string;
+  description?: string;
+  enabled: boolean;
+  selector: AlertRuleSelector;
+  metric: AlertMetric;
+  comparison: AlertComparison;
+  threshold: number;
+  for_duration_seconds: number;
+  severity: AlertSeverity;
+  cooldown_seconds: number;
+  audit: AlertRuleAudit;
+}
+
+export interface CreateAlertRuleBody {
+  name: string;
+  description?: string;
+  enabled?: boolean;
+  selector?: AlertRuleSelector;
+  metric: AlertMetric;
+  comparison: AlertComparison;
+  threshold: number;
+  for_duration_seconds?: number;
+  severity: AlertSeverity;
+  cooldown_seconds?: number;
+}
+
+export type UpdateAlertRuleBody = Partial<CreateAlertRuleBody>;
+
+export interface ListAlertRulesQueryParams {
+  page?: number;
+  limit?: number;
+  sortBy?: 'name' | 'created_at' | 'updated_at' | 'severity';
+  sortDirection?: 'asc' | 'desc';
+  enabled?: boolean;
+  metric?: AlertMetric;
+  severity?: AlertSeverity;
+}
+
+// ============================================================================
+// ALERT
+// ============================================================================
+
+export interface AlertAudit {
+  created_at: string;
+  created_by: string;
+  updated_at: string;
+  updated_by: string;
+  acknowledged_at?: string;
+  acknowledged_by?: string;
+  resolved_at?: string;
+  resolved_by?: string;
+  resolution?: AlertResolution;
+  note?: string;
+}
+
+/** An alert as returned by the API (dates serialized to ISO strings). */
+export interface AlertV2Response {
+  _id: string;
+  rule_id: string;
+  rule_name: string;
+  device_id: string;
+  status: AlertStatus;
+  is_open: boolean;
+  severity: AlertSeverity;
+  metric: AlertMetric;
+  comparison: AlertComparison;
+  threshold: number;
+  trigger_value: number;
+  last_value: number;
+  resolved_value?: number;
+  breached_since: string;
+  last_observed_at: string;
+  fired_at?: string;
+  audit: AlertAudit;
+  /** Present only when `include_device=true`. */
+  device?: {
+    _id: string;
+    serial_number: string;
+    type: string;
+    location: { building_id?: string; floor?: number; room_name?: string };
+  } | null;
+}
+
+export interface UpdateAlertBody {
+  status: 'acknowledged' | 'resolved';
+  note?: string;
+}
+
+export interface ListAlertsQueryParams {
+  page?: number;
+  limit?: number;
+  sortBy?: 'created_at' | 'fired_at' | 'severity' | 'status' | 'last_observed_at';
+  sortDirection?: 'asc' | 'desc';
+  status?: AlertStatus | AlertStatus[];
+  severity?: AlertSeverity | AlertSeverity[];
+  device_id?: string;
+  rule_id?: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+// ============================================================================
+// PUSHER WIRE TYPES
+// ============================================================================
+
+/** Trimmed payload broadcast when an episode starts firing. */
+export interface FiredAlert {
+  _id: string;
+  rule_id: string;
+  rule_name: string;
+  device_id: string;
+  severity: AlertSeverity;
+  metric: AlertMetric;
+  comparison: AlertComparison;
+  threshold: number;
+  trigger_value: number;
+  fired_at: string;
+}
+
+/**
+ * Trimmed payload broadcast when an episode resolves.
+ * `actor` is 'system' for automatic resolution, otherwise the Clerk USER ID.
+ * Never an email — this payload reaches every connected client.
+ */
+export interface ResolvedAlert {
+  _id: string;
+  rule_id: string;
+  device_id: string;
+  severity: AlertSeverity;
+  resolution: AlertResolution;
+  resolved_at: string;
+  actor: string;
+}
+
+/**
+ * All alert traffic arrives on the single `alert-event` Pusher event name.
+ * The tag is carried in the payload because PusherContext holds one callback
+ * set bound to one event name — a subscriber receiving a bare array could not
+ * tell which event produced it.
+ */
+export type AlertEvent =
+  | { kind: 'fired'; alerts: FiredAlert[] }
+  | { kind: 'resolved'; alerts: ResolvedAlert[] }
+  | {
+      kind: 'storm';
+      count: number;
+      by_severity: Record<AlertSeverity, number>;
+      since: string;
+    };

--- a/types/v2/alert.types.ts
+++ b/types/v2/alert.types.ts
@@ -10,6 +10,8 @@
  * - Zod schemas: /lib/validations/v2/alert-rule.validation.ts, alert.validation.ts
  */
 
+import type { ReadingType } from './reading.types';
+
 // ============================================================================
 // ENUMS
 // ============================================================================
@@ -19,10 +21,21 @@ export type AlertComparison = 'gt' | 'gte' | 'lt' | 'lte';
 export type AlertSeverity = 'info' | 'warning' | 'critical';
 export type AlertStatus = 'pending' | 'firing' | 'acknowledged' | 'resolved';
 export type AlertResolution = 'manual' | 'auto' | 'stale' | 'device_inactive';
-export type ReadingTypeName =
-  | 'temperature' | 'humidity' | 'occupancy' | 'power' | 'co2'
-  | 'pressure' | 'light' | 'motion' | 'air_quality' | 'water_flow'
-  | 'gas' | 'vibration' | 'voltage' | 'current' | 'energy';
+
+/**
+ * ALIAS, not a copy. This used to be a hand-written 15-member union — the
+ * fourth such copy in the repo — which meant a reading type added everywhere
+ * else but here silently became unselectable in the alert-rule UI while the
+ * API happily accepted it.
+ *
+ * `types/v2/reading.types.ts` is the client-safe list (it imports nothing, so
+ * this file stays free of mongoose), and the compile-time guard in
+ * models/v2/AlertRuleV2.ts ties that list to the server-side `ReadingType` and
+ * to `READING_TYPES`. The name is kept because `ReadingType` is already
+ * exported from `types/v2` and re-exporting it under one name from two modules
+ * would be ambiguous.
+ */
+export type ReadingTypeName = ReadingType;
 
 // ============================================================================
 // RULE

--- a/types/v2/alert.types.ts
+++ b/types/v2/alert.types.ts
@@ -1,9 +1,9 @@
 /**
  * TypeScript Type Definitions for the Alerting Subsystem
  *
- * Client-safe: no mongoose or model imports. Nothing imports from this file
- * yet — `lib/pusher-context.tsx` will consume `AlertEvent` once Task 13/14
- * wires up alert delivery over Pusher.
+ * Client-safe: no mongoose or model imports. Consumed by
+ * `lib/pusher-context.tsx` (`AlertEvent`), which wires alert delivery over
+ * Pusher into `usePusherAlerts` / `AlertToaster` (Task 14).
  *
  * Aligned with:
  * - Mongoose models: /models/v2/AlertRuleV2.ts, /models/v2/AlertV2.ts
@@ -307,6 +307,8 @@ export type AlertEvent =
   | { kind: 'resolved'; alerts: ResolvedAlert[] }
   | {
       kind: 'storm';
+      /** Which direction this storm is: alerts opening, or alerts clearing. */
+      of: 'fired' | 'resolved';
       count: number;
       by_severity: Record<AlertSeverity, number>;
       since: string;

--- a/types/v2/alert.types.ts
+++ b/types/v2/alert.types.ts
@@ -51,7 +51,12 @@ export interface AlertRuleV2Response {
   name: string;
   description?: string;
   enabled: boolean;
-  selector: AlertRuleSelector;
+  // Optional, not just "usually populated": a rule with no constraints at all
+  // (e.g. the seeded "Low battery" rule) persists as `selector: {}`, and
+  // Mongoose's default `minimize` behavior strips an empty nested object
+  // before it reaches Mongo -- every `.lean()` read of that rule genuinely
+  // has no `selector` key. See models/v2/AlertRuleV2.ts's matching field.
+  selector?: AlertRuleSelector;
   metric: AlertMetric;
   comparison: AlertComparison;
   threshold: number;

--- a/types/v2/index.ts
+++ b/types/v2/index.ts
@@ -143,5 +143,35 @@ export type {
   ScheduleListResponse,
 } from './schedule.types';
 
+// ============================================================================
+// ALERT TYPES
+// ============================================================================
+
+export type {
+  // Enums
+  AlertMetric,
+  AlertComparison,
+  AlertSeverity,
+  AlertStatus,
+  AlertResolution,
+  ReadingTypeName,
+  // Rule
+  AlertRuleSelector,
+  AlertRuleAudit,
+  AlertRuleV2Response,
+  CreateAlertRuleBody,
+  UpdateAlertRuleBody,
+  ListAlertRulesQueryParams,
+  // Alert
+  AlertAudit,
+  AlertV2Response,
+  UpdateAlertBody,
+  ListAlertsQueryParams,
+  // Pusher wire types
+  FiredAlert,
+  ResolvedAlert,
+  AlertEvent,
+} from './alert.types';
+
 // Export type guards as values
 export { isSuccessResponse, isErrorResponse } from './api.types';

--- a/types/v2/reading.types.ts
+++ b/types/v2/reading.types.ts
@@ -268,8 +268,25 @@ export interface ListReadingsQuery {
   page?: number;
   /** Items per page (max 100) */
   limit?: number;
-  /** Sort field and direction (e.g., "timestamp:desc") */
+  /**
+   * Vestigial. GET /api/v2/readings has never read a combined "field:dir"
+   * param — it reads `sortBy`/`sortDirection` separately (see below), the
+   * same shape `ListDevicesQuery`/`ListSchedulesQuery` use. No caller in
+   * this codebase sets `sort`. Left in place rather than removed to keep
+   * this fix narrowly scoped; prefer `sortBy`/`sortDirection`.
+   */
   sort?: string;
+  /**
+   * Sort field. The route (app/api/v2/readings/route.ts) reads this and
+   * `sortDirection` directly — matching `listReadingsQuerySchema`'s
+   * `createSortSchema(readingSortFields)` — and defaults to
+   * `timestamp` descending (newest first) when omitted. A caller that wants
+   * a chronological window (e.g. a bracketing-readings table) must set both
+   * explicitly, or it will silently get the newest page instead.
+   */
+  sortBy?: 'timestamp' | 'value' | 'anomaly_score' | 'confidence_score';
+  /** Sort direction; the route defaults to 'desc' when this is omitted. */
+  sortDirection?: 'asc' | 'desc';
 }
 
 /**


### PR DESCRIPTION
Threshold-based alerting: declarative rules, a four-state alert lifecycle, evaluation inline on both write paths, eight API endpoints, real-time Pusher delivery, and an operator UI.

Closes #96, Closes #97, Closes #98, Closes #99, Closes #100.

## What this adds

Two collections — `alert_rules_v2` (declarative rules) and `alerts_v2` (`pending → firing → acknowledged → resolved`). An evaluator in `lib/alerting/` runs on both write paths **after** their inserts commit, so it can never affect data durability. Deduplication is enforced by a **partial unique index** on `{ rule_id, device_id }` filtered to `is_open: true` — by the database, not by application logic.

| Area | |
| --- | --- |
| Models, validation, client-safe wire types | `AlertRuleV2`, `AlertV2`, 8 indexes |
| Evaluator | breach-aware reduction, cooldowns, duration gating, staleness sweep |
| API | 8 endpoints; v2 goes 25 → 33 |
| Real-time | one tagged Pusher event, degrading to a storm summary above 20 alerts / 8 KB |
| UI | `/alerts`, `/alerts/[id]`, `/alerts/rules`, dashboard widget, nav badge |
| Seed + E2E | 4 starter rules, 8 Playwright specs |

## Verification

All four gates are strict — no baselines.

| Gate | Result |
| --- | --- |
| `npx tsc --noEmit` | 0 errors |
| `pnpm lint` | 0 problems |
| `pnpm build` | clean |
| `pnpm test` | **2616 passing / 115 suites** |
| `pnpm test:e2e e2e/alerts.spec.ts` | 8/8, **0 skipped** |

`pnpm seed` → `pnpm create-indexes-v2 && pnpm verify-indexes` completes with all 8 alert indexes present, verified in the documented seed-first order against a genuinely fresh database.

## Review

Every one of the 20 tasks passed an individual spec + quality review; 7 needed a fix round. A whole-branch review then ran over all 62 commits and found 1 Critical, 6 Important, and 4 Minor issues, all fixed in a single wave and verified by a scoped re-review.

**The Critical is worth calling out:** an anonymous visitor on a demo deployment was shown administrator **email addresses** on `/alerts/[id]`. `audit.acknowledged_by` / `resolved_by` carry `getAuditUser()`'s output (`user?.email || userId`), and `DEMO_MODE` grants anonymous callers a synthetic `org:member` context, so `requireOrgMembership()` passed and the endpoints returned the full audit block. The Pusher payload had been deliberately hardened against exactly this leak; the REST + render path never was. Now redacted at the API layer across all four alert endpoints, with tests that distinguish a demo caller from a real admin rather than passing against blanket redaction.

Other notable fixes from review, each caught before merge:

- **`sortBy=severity` sorted lexically**, so "most severe first" returned `warning → info → critical`. The dashboard widget asks for exactly that sort. Replaced with a `$switch` rank.
- **The ingest path evaluated readings that may never have persisted** — the twin of a bug already fixed on the cron path. Both now evaluate only the persisted subset.
- **A seeded rule could never fire.** Low battery was `< 20`, but both data generators floor `battery_level` at exactly 20.
- **`create-indexes-v2` crashed deterministically on a fresh database**, and separately rejected Mongoose's own autoIndex-built indexes as name conflicts. While fixing it we found MongoDB *accepts* a same-key index when only the options differ — meaning a wrongly-shaped dedup index could have silently coexisted with the correct one.
- **A resolved storm would have toasted "N alerts firing"** — a mass recovery announced as a mass outage.

## Notes

`docs/PHASE_4_HANDOFF.md` has the full record, including a retrospective on the recurring failure mode this phase kept hitting: **nine tests shipped green while asserting nothing real.**
