### PR TITLE
chore: fix typecheck and lint failures across the repo

### DIFF
--- a/__tests__/integration/api/analytics.integration.test.ts
+++ b/__tests__/integration/api/analytics.integration.test.ts
@@ -303,9 +303,9 @@ describe('Analytics API Integration Tests', () => {
 
         expect(response.status).toBe(200);
         const scores = data.data.anomalies.map((a) => a.quality.anomaly_score);
-        for (let i = 1; i < scores.length; i++) {
+        for (let i = 1; i < scores.length; i++) 
           expect(scores[i]).toBeLessThanOrEqual(scores[i - 1]);
-        }
+        
       });
 
       it('should sort by anomaly_score ascending', async () => {
@@ -321,9 +321,9 @@ describe('Analytics API Integration Tests', () => {
 
         expect(response.status).toBe(200);
         const scores = data.data.anomalies.map((a) => a.quality.anomaly_score);
-        for (let i = 1; i < scores.length; i++) {
+        for (let i = 1; i < scores.length; i++) 
           expect(scores[i]).toBeGreaterThanOrEqual(scores[i - 1]);
-        }
+        
       });
 
       it('should sort by value', async () => {
@@ -349,9 +349,9 @@ describe('Analytics API Integration Tests', () => {
 
         expect(response.status).toBe(200);
         const timestamps = data.data.anomalies.map((a) => new Date(a.timestamp).getTime());
-        for (let i = 1; i < timestamps.length; i++) {
+        for (let i = 1; i < timestamps.length; i++) 
           expect(timestamps[i]).toBeGreaterThanOrEqual(timestamps[i - 1]);
-        }
+        
       });
     });
 
@@ -655,7 +655,7 @@ describe('Analytics API Integration Tests', () => {
           health: {
             uptime_percentage: 99,
             error_count: 0,
-            last_communication: new Date(),
+            last_seen: new Date(),
             battery_level: 85,
             signal_strength: 90,
           },
@@ -666,7 +666,7 @@ describe('Analytics API Integration Tests', () => {
           health: {
             uptime_percentage: 50,
             error_count: 2,
-            last_communication: new Date(),
+            last_seen: new Date(),
             battery_level: 60,
             signal_strength: 40,
           },
@@ -677,7 +677,7 @@ describe('Analytics API Integration Tests', () => {
           health: {
             uptime_percentage: 70,
             error_count: 5,
-            last_communication: new Date(),
+            last_seen: new Date(),
             battery_level: 30,
             signal_strength: 60,
           },
@@ -820,7 +820,6 @@ describe('Analytics API Integration Tests', () => {
             health: {
               uptime_percentage: 80,
               error_count: 0,
-              last_communication: new Date(),
               last_seen: new Date(Date.now() - 10 * 60 * 1000), // 10 min ago
               battery_level: 80,
               signal_strength: 70,
@@ -853,7 +852,6 @@ describe('Analytics API Integration Tests', () => {
             health: {
               uptime_percentage: 80,
               error_count: 0,
-              last_communication: new Date(),
               last_seen: new Date(Date.now() - 3 * 60 * 1000), // 3 min ago
               battery_level: 80,
               signal_strength: 70,
@@ -894,7 +892,7 @@ describe('Analytics API Integration Tests', () => {
             health: {
               uptime_percentage: 90,
               error_count: 0,
-              last_communication: new Date(),
+              last_seen: new Date(),
               battery_level: 10,
               signal_strength: 80,
             },
@@ -935,7 +933,7 @@ describe('Analytics API Integration Tests', () => {
             health: {
               uptime_percentage: 90,
               error_count: 0,
-              last_communication: new Date(),
+              last_seen: new Date(),
               battery_level: 50,
               signal_strength: 80,
             },
@@ -1072,7 +1070,7 @@ describe('Analytics API Integration Tests', () => {
             health: {
               uptime_percentage: 90,
               error_count: 0,
-              last_communication: new Date(),
+              last_seen: new Date(),
               battery_level: 10, // < 15 → battery_critical
               signal_strength: 80,
             },
@@ -1110,7 +1108,7 @@ describe('Analytics API Integration Tests', () => {
             health: {
               uptime_percentage: 90,
               error_count: 0,
-              last_communication: new Date(),
+              last_seen: new Date(),
               battery_level: 80, // high battery so battery check doesn't trigger
               signal_strength: 80,
             },
@@ -1155,7 +1153,7 @@ describe('Analytics API Integration Tests', () => {
             health: {
               uptime_percentage: 90,
               error_count: 0,
-              last_communication: new Date(),
+              last_seen: new Date(),
               battery_level: 80,
               signal_strength: 80,
             },
@@ -1201,7 +1199,7 @@ describe('Analytics API Integration Tests', () => {
             health: {
               uptime_percentage: 60,
               error_count: 15, // > 10
-              last_communication: new Date(),
+              last_seen: new Date(),
               battery_level: 80, // high battery
               signal_strength: 70,
             },
@@ -1377,7 +1375,7 @@ describe('Analytics API Integration Tests', () => {
           health: {
             uptime_percentage: 95,
             error_count: 10,
-            last_communication: new Date(),
+            last_seen: new Date(),
             battery_level: 20, // Low battery
             signal_strength: 80,
           },
@@ -1387,7 +1385,7 @@ describe('Analytics API Integration Tests', () => {
           health: {
             uptime_percentage: 99,
             error_count: 1,
-            last_communication: new Date(),
+            last_seen: new Date(),
             battery_level: 90,
             signal_strength: 95,
           },

--- a/__tests__/integration/api/anomalies-analytics-coverage.integration.test.ts
+++ b/__tests__/integration/api/anomalies-analytics-coverage.integration.test.ts
@@ -18,7 +18,6 @@ import ReadingV2 from '@/models/v2/ReadingV2';
 import {
   createDeviceInput,
   createAnomalyReadingV2,
-  createReadingV2Input,
   resetCounters,
 } from '../../setup/factories';
 
@@ -78,14 +77,14 @@ async function seedDeviceWithAnomalies(
   const baseTime = Date.now() - timestampOffset;
   const unit = type === 'temperature' ? 'celsius' : type === 'humidity' ? 'percent' : 'watts';
 
-  for (let i = 0; i < count; i++) {
+  for (let i = 0; i < count; i++) 
     readings.push(
       createAnomalyReadingV2(deviceId, anomalyScore, {
         metadata: { device_id: deviceId, type, unit, source: 'sensor' },
         timestamp: new Date(baseTime - i * 60 * 60 * 1000), // 1 hour apart
       })
     );
-  }
+  
   await ReadingV2.insertMany(readings);
 }
 
@@ -257,10 +256,10 @@ describe('Anomalies Analytics API – Coverage Gaps', () => {
       expect(data.success).toBe(true);
       const anomalies = data.data!.anomalies;
       if (anomalies.length >= 2) {
-        const timestamps = anomalies.map((a: any) => new Date(a.timestamp).getTime());
-        for (let i = 1; i < timestamps.length; i++) {
+        const timestamps = anomalies.map(a => new Date(a.timestamp).getTime());
+        for (let i = 1; i < timestamps.length; i++) 
           expect(timestamps[i]).toBeGreaterThanOrEqual(timestamps[i - 1]);
-        }
+        
       }
     });
   });
@@ -300,12 +299,12 @@ describe('Anomalies Analytics API – Coverage Gaps', () => {
 
       expect(response.status).toBe(200);
       expect(data.success).toBe(true);
-      const scores = data.data!.anomalies.map((a: any) => a.quality?.anomaly_score);
-      if (scores.length >= 2) {
-        for (let i = 1; i < scores.length; i++) {
+      const scores = data.data!.anomalies.map(a => a.quality?.anomaly_score);
+      if (scores.length >= 2) 
+        for (let i = 1; i < scores.length; i++) 
           expect(scores[i]).toBeLessThanOrEqual(scores[i - 1]);
-        }
-      }
+        
+      
     });
   });
 
@@ -347,12 +346,12 @@ describe('Anomalies Analytics API – Coverage Gaps', () => {
 
       expect(response.status).toBe(200);
       expect(data.success).toBe(true);
-      const values = data.data!.anomalies.map((a: any) => a.value);
-      if (values.length >= 2) {
-        for (let i = 1; i < values.length; i++) {
+      const values = data.data!.anomalies.map(a => a.value);
+      if (values.length >= 2) 
+        for (let i = 1; i < values.length; i++) 
           expect(values[i]).toBeGreaterThanOrEqual(values[i - 1]);
-        }
-      }
+        
+      
     });
   });
 

--- a/__tests__/integration/api/auth.integration.test.ts
+++ b/__tests__/integration/api/auth.integration.test.ts
@@ -120,7 +120,7 @@ function createMockMutationRequest(
   method: 'POST' | 'PATCH' | 'DELETE',
   body?: unknown
 ): NextRequest {
-  const options: RequestInit = {
+  const options: NonNullable<ConstructorParameters<typeof NextRequest>[1]> = {
     method,
     headers: { 'Content-Type': 'application/json' },
   };

--- a/__tests__/integration/api/devices.integration.test.ts
+++ b/__tests__/integration/api/devices.integration.test.ts
@@ -472,7 +472,7 @@ describe('Devices API Integration Tests', () => {
 
       it('should reject invalid device type', async () => {
         const deviceData = createDeviceInput({ _id: 'invalid_type' });
-        (deviceData as Record<string, unknown>).type = 'invalid_type';
+        (deviceData as unknown as Record<string, unknown>).type = 'invalid_type';
 
         const request = createMockPostRequest(deviceData);
         const response = await POST(request);
@@ -482,7 +482,7 @@ describe('Devices API Integration Tests', () => {
 
       it('should reject invalid device ID format', async () => {
         const deviceData = createDeviceInput({});
-        (deviceData as Record<string, unknown>)._id = 'has spaces';
+        (deviceData as unknown as Record<string, unknown>)._id = 'has spaces';
 
         const request = createMockPostRequest(deviceData);
         const response = await POST(request);

--- a/__tests__/integration/api/energy-analytics.integration.test.ts
+++ b/__tests__/integration/api/energy-analytics.integration.test.ts
@@ -526,9 +526,9 @@ describe('Energy Analytics API - Comprehensive Tests', () => {
       expect(response.status).toBe(200);
       expect(data.data.metadata.group_by).toBe('device');
       // Results should have device_id field
-      if (data.data.results.length > 0) {
+      if (data.data.results.length > 0) 
         expect(data.data.results[0]).toHaveProperty('device_id');
-      }
+      
     });
 
     it('should group by type', async () => {
@@ -549,9 +549,9 @@ describe('Energy Analytics API - Comprehensive Tests', () => {
 
       expect(response.status).toBe(200);
       expect(data.data.metadata.group_by).toBe('type');
-      if (data.data.results.length > 0) {
+      if (data.data.results.length > 0) 
         expect(data.data.results[0]).toHaveProperty('type');
-      }
+      
     });
 
     it('should group by floor (requires device lookup)', async () => {
@@ -572,9 +572,9 @@ describe('Energy Analytics API - Comprehensive Tests', () => {
 
       expect(response.status).toBe(200);
       expect(data.data.metadata.group_by).toBe('floor');
-      if (data.data.results.length > 0) {
+      if (data.data.results.length > 0) 
         expect(data.data.results[0]).toHaveProperty('floor');
-      }
+      
     });
 
     it('should group by room (requires device lookup)', async () => {
@@ -595,9 +595,9 @@ describe('Energy Analytics API - Comprehensive Tests', () => {
 
       expect(response.status).toBe(200);
       expect(data.data.metadata.group_by).toBe('room');
-      if (data.data.results.length > 0) {
+      if (data.data.results.length > 0) 
         expect(data.data.results[0]).toHaveProperty('room');
-      }
+      
     });
 
     it('should group by building (requires device lookup)', async () => {
@@ -618,9 +618,9 @@ describe('Energy Analytics API - Comprehensive Tests', () => {
 
       expect(response.status).toBe(200);
       expect(data.data.metadata.group_by).toBe('building');
-      if (data.data.results.length > 0) {
+      if (data.data.results.length > 0) 
         expect(data.data.results[0]).toHaveProperty('building');
-      }
+      
     });
 
     it('should group by department (requires device lookup)', async () => {
@@ -641,9 +641,9 @@ describe('Energy Analytics API - Comprehensive Tests', () => {
 
       expect(response.status).toBe(200);
       expect(data.data.metadata.group_by).toBe('department');
-      if (data.data.results.length > 0) {
+      if (data.data.results.length > 0) 
         expect(data.data.results[0]).toHaveProperty('department');
-      }
+      
     });
   });
 
@@ -664,7 +664,7 @@ describe('Energy Analytics API - Comprehensive Tests', () => {
       const readings = [];
 
       // Current period readings
-      for (let i = 0; i < 24; i++) {
+      for (let i = 0; i < 24; i++) 
         readings.push(
           createReadingV2Input('compare_device_001', {
             metadata: {
@@ -677,10 +677,10 @@ describe('Energy Analytics API - Comprehensive Tests', () => {
             timestamp: new Date(now - i * 60 * 60 * 1000), // hourly for last 24 hours
           })
         );
-      }
+      
 
       // Previous period readings (24-48 hours ago)
-      for (let i = 24; i < 48; i++) {
+      for (let i = 24; i < 48; i++) 
         readings.push(
           createReadingV2Input('compare_device_001', {
             metadata: {
@@ -693,11 +693,11 @@ describe('Energy Analytics API - Comprehensive Tests', () => {
             timestamp: new Date(now - i * 60 * 60 * 1000),
           })
         );
-      }
+      
 
       // Last week readings
       const weekAgo = now - 7 * 24 * 60 * 60 * 1000;
-      for (let i = 0; i < 24; i++) {
+      for (let i = 0; i < 24; i++) 
         readings.push(
           createReadingV2Input('compare_device_001', {
             metadata: {
@@ -710,11 +710,11 @@ describe('Energy Analytics API - Comprehensive Tests', () => {
             timestamp: new Date(weekAgo - i * 60 * 60 * 1000),
           })
         );
-      }
+      
 
       // Last month readings
       const monthAgo = now - 30 * 24 * 60 * 60 * 1000;
-      for (let i = 0; i < 24; i++) {
+      for (let i = 0; i < 24; i++) 
         readings.push(
           createReadingV2Input('compare_device_001', {
             metadata: {
@@ -727,7 +727,7 @@ describe('Energy Analytics API - Comprehensive Tests', () => {
             timestamp: new Date(monthAgo - i * 60 * 60 * 1000),
           })
         );
-      }
+      
 
       await ReadingV2.insertMany(readings);
     });
@@ -829,7 +829,7 @@ describe('Energy Analytics API - Comprehensive Tests', () => {
 
       const now = Date.now();
       const readings = [];
-      for (let i = 0; i < 24; i++) {
+      for (let i = 0; i < 24; i++) 
         readings.push(
           createReadingV2Input('compare_device_001', {
             metadata: {
@@ -842,7 +842,7 @@ describe('Energy Analytics API - Comprehensive Tests', () => {
             timestamp: new Date(now - i * 60 * 60 * 1000),
           })
         );
-      }
+      
       await ReadingV2.insertMany(readings);
 
       const nowDate = new Date();
@@ -1057,7 +1057,7 @@ describe('Energy Analytics API - Comprehensive Tests', () => {
       const readings = [];
 
       // Create readings for current and comparison periods
-      for (let i = 0; i < 48; i++) {
+      for (let i = 0; i < 48; i++) 
         readings.push(
           createReadingV2Input('combined_device_001', {
             metadata: {
@@ -1070,7 +1070,7 @@ describe('Energy Analytics API - Comprehensive Tests', () => {
             timestamp: new Date(now - i * 60 * 60 * 1000),
           })
         );
-      }
+      
 
       await ReadingV2.insertMany(readings);
     });

--- a/__tests__/integration/api/health-analytics-coverage.integration.test.ts
+++ b/__tests__/integration/api/health-analytics-coverage.integration.test.ts
@@ -369,9 +369,7 @@ describe('Health Analytics API – Coverage Gaps', () => {
 
       expect(responseLong.status).toBe(200);
       // The device's last_seen is 10 mins ago, which is within the 15-min threshold
-      const offlineIds = dataLong.data!.alerts.offline_devices.devices.map(
-        (d: any) => d._id
-      );
+      const offlineIds = dataLong.data!.alerts.offline_devices.devices.map(d => d._id);
       expect(offlineIds).not.toContain('threshold_offline_dev');
     });
   });
@@ -411,9 +409,7 @@ describe('Health Analytics API – Coverage Gaps', () => {
       const dataLow: HealthResponse = await responseLow.json();
 
       expect(responseLow.status).toBe(200);
-      const lowBatteryIds = dataLow.data!.alerts.low_battery_devices.devices.map(
-        (d: any) => d._id
-      );
+      const lowBatteryIds = dataLow.data!.alerts.low_battery_devices.devices.map(d => d._id);
       expect(lowBatteryIds).not.toContain('battery_threshold_dev');
     });
   });

--- a/__tests__/integration/api/readings-ingest.integration.test.ts
+++ b/__tests__/integration/api/readings-ingest.integration.test.ts
@@ -1065,9 +1065,9 @@ describe('POST /api/v2/readings/ingest Integration Tests', () => {
         data: { inserted: number };
       }>(response);
 
-      if (response.status === 201) {
+      if (response.status === 201) 
         expect(data.data.inserted).toBe(100);
-      }
+      
     });
 
     it('should handle readings exceeding single batch (>100)', async () => {
@@ -1091,9 +1091,9 @@ describe('POST /api/v2/readings/ingest Integration Tests', () => {
         data: { inserted: number };
       }>(response);
 
-      if (response.status === 201) {
+      if (response.status === 201) 
         expect(data.data.inserted).toBe(250);
-      }
+      
     });
   });
 
@@ -1209,9 +1209,9 @@ describe('POST /api/v2/readings/ingest Integration Tests', () => {
         data: { submitted_by: string };
       }>(response);
 
-      if (response.status === 201) {
+      if (response.status === 201) 
         expect(data.data.submitted_by).toBe('test@example.com');
-      }
+      
     });
 
     it('should include submitted_at timestamp in response', async () => {

--- a/__tests__/setup/factories.ts
+++ b/__tests__/setup/factories.ts
@@ -21,6 +21,15 @@ import type {
 } from '@/models/v2/ReadingV2';
 
 // ============================================================================
+// SCHEDULE V2 FACTORIES
+// ============================================================================
+
+import type {
+  ServiceType as ScheduleServiceType,
+  ScheduleStatus,
+} from '@/models/v2/ScheduleV2';
+
+// ============================================================================
 // DEVICE FACTORIES
 // ============================================================================
 
@@ -29,7 +38,7 @@ import type {
  */
 let deviceCounter = 0;
 let _readingCounter = 0;
-let readingV2Counter = 0;
+let _readingV2Counter = 0;
 
 /**
  * Reset counters (for test isolation)
@@ -37,7 +46,7 @@ let readingV2Counter = 0;
 export function resetCounters(): void {
   deviceCounter = 0;
   _readingCounter = 0;
-  readingV2Counter = 0;
+  _readingV2Counter = 0;
   scheduleCounter = 0;
 }
 
@@ -113,9 +122,14 @@ export type ReadingSource = (typeof VALID_READING_SOURCES)[number];
 /**
  * Device input type matching the model
  */
-export interface DeviceInput extends Omit<IDeviceV2, 'audit' | 'health'> {
+export interface DeviceInput extends Omit<IDeviceV2, 'audit' | 'health' | 'configuration'> {
   audit?: Partial<IDeviceV2['audit']>;
   health?: Partial<IDeviceV2['health']>;
+  // calibration_date is optional here: inputs omit it and let the Mongoose
+  // default (null) apply -- the API's Zod schema rejects an explicit null.
+  configuration: Omit<IDeviceV2['configuration'], 'calibration_date'> & {
+    calibration_date?: Date;
+  };
 }
 
 /**
@@ -521,7 +535,7 @@ export function createReadingV2Input(
   deviceId: string,
   overrides: Partial<ReadingV2Input> = {}
 ): ReadingV2Input {
-  readingV2Counter += 1;
+  _readingV2Counter += 1;
 
   return {
     metadata: {
@@ -678,15 +692,6 @@ export function createBulkIngestPayloadV2(deviceId: string, count: number = 10) 
 
   return { readings };
 }
-
-// ============================================================================
-// SCHEDULE V2 FACTORIES
-// ============================================================================
-
-import type {
-  ServiceType as ScheduleServiceType,
-  ScheduleStatus,
-} from '@/models/v2/ScheduleV2';
 
 /**
  * Valid service types for schedule testing

--- a/__tests__/setup/globalSetup.ts
+++ b/__tests__/setup/globalSetup.ts
@@ -32,7 +32,7 @@ export default async function globalSetup(): Promise<void> {
 
   // Set environment variable for tests to use
   process.env.MONGODB_URI = uri;
-  process.env.NODE_ENV = 'test';
+  (process.env as Record<string, string | undefined>).NODE_ENV = 'test';
 
   // Set mock Pusher credentials for tests
   process.env.PUSHER_APP_ID = 'test-app-id';

--- a/__tests__/unit/components/DeviceStatusCards.test.tsx
+++ b/__tests__/unit/components/DeviceStatusCards.test.tsx
@@ -22,7 +22,7 @@ describe('DeviceStatusCards', () => {
   };
 
   it('shows dash placeholders when loading', () => {
-    render(<DeviceStatusCards {...defaultProps} loading={true} />);
+    render(<DeviceStatusCards {...defaultProps} loading />);
     const dashes = screen.getAllByText('—');
     expect(dashes.length).toBe(3);
   });

--- a/__tests__/unit/components/StatCard.test.tsx
+++ b/__tests__/unit/components/StatCard.test.tsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import type { LucideIcon } from 'lucide-react';
 import StatCard from '@/components/dashboard/StatCard';
 
 const MockIcon = (props: React.SVGProps<SVGSVGElement>) => <svg data-testid="mock-icon" {...props} />;
@@ -13,7 +14,7 @@ describe('StatCard', () => {
   const defaultProps = {
     title: 'Total Devices',
     value: 42,
-    icon: MockIcon as unknown as import('lucide-react').LucideIcon,
+    icon: MockIcon as unknown as LucideIcon,
     iconColor: 'text-blue-500',
     iconBgColor: 'bg-blue-100',
   };
@@ -100,7 +101,7 @@ describe('StatCard', () => {
   });
 
   it('passes iconColor class to the icon element', () => {
-    const { container } = render(<StatCard {...defaultProps} />);
+    render(<StatCard {...defaultProps} />);
     const icon = screen.getByTestId('mock-icon');
     expect(icon.getAttribute('class')).toContain('text-blue-500');
   });

--- a/__tests__/unit/lib/auth.test.ts
+++ b/__tests__/unit/lib/auth.test.ts
@@ -4,7 +4,7 @@
  * Tests for authentication utilities.
  */
 
-import { ApiError } from '@/lib/errors/ApiError';
+import type { ApiError } from '@/lib/errors/ApiError';
 
 // Mock Clerk auth functions
 jest.mock('@clerk/nextjs/server', () => ({
@@ -457,9 +457,9 @@ describe('Auth Module', () => {
       it('should refuse every mutating method', () => {
         const { isDemoReadableMethod } = require('@/lib/auth');
 
-        for (const method of ['POST', 'PATCH', 'PUT', 'DELETE']) {
+        for (const method of ['POST', 'PATCH', 'PUT', 'DELETE']) 
           expect(isDemoReadableMethod(method)).toBe(false);
-        }
+        
       });
 
       it('should refuse unknown methods rather than defaulting open', () => {

--- a/__tests__/unit/lib/bodySize.test.ts
+++ b/__tests__/unit/lib/bodySize.test.ts
@@ -39,9 +39,9 @@ describe('Body Size Middleware', () => {
         '/api/v2/analytics/health',
       ];
 
-      for (const path of paths) {
+      for (const path of paths) 
         expect(getMaxBodySize(path)).toBe(DEFAULT_BODY_SIZE_CONFIG.default);
-      }
+      
     });
 
     it('should return bulk size for readings ingest endpoint', () => {
@@ -75,9 +75,9 @@ describe('Body Size Middleware', () => {
   describe('validateBodySize()', () => {
     const createMockRequest = (contentLength: string | null): Request => {
       const headers = new Headers();
-      if (contentLength !== null) {
+      if (contentLength !== null) 
         headers.set('content-length', contentLength);
-      }
+      
       return {
         headers,
       } as unknown as Request;

--- a/__tests__/unit/lib/errorHandler.test.ts
+++ b/__tests__/unit/lib/errorHandler.test.ts
@@ -143,9 +143,10 @@ describe('Error Handler', () => {
 
         expect(error.metadata?.errors).toBeDefined();
         expect(Array.isArray(error.metadata?.errors)).toBe(true);
-        expect(error.metadata?.errors[0]).toHaveProperty('path');
-        expect(error.metadata?.errors[0]).toHaveProperty('message');
-        expect(error.metadata?.errors[0]).toHaveProperty('code');
+        const issues = error.metadata?.errors as unknown[];
+        expect(issues[0]).toHaveProperty('path');
+        expect(issues[0]).toHaveProperty('message');
+        expect(issues[0]).toHaveProperty('code');
       }
     });
   });
@@ -494,7 +495,7 @@ describe('Error Handler', () => {
         {
           code: 'invalid_type',
           expected: 'string',
-          received: 'number',
+          input: 42,
           path: ['field'],
           message: 'Expected string',
         },

--- a/__tests__/unit/lib/headers.test.ts
+++ b/__tests__/unit/lib/headers.test.ts
@@ -18,9 +18,9 @@ describe('Header Validation Middleware', () => {
       headers: Record<string, string> = {}
     ): Request => {
       const h = new Headers();
-      for (const [key, value] of Object.entries(headers)) {
+      for (const [key, value] of Object.entries(headers)) 
         h.set(key, value);
-      }
+      
       return { method, headers: h } as Request;
     };
 
@@ -216,9 +216,9 @@ describe('Header Validation Middleware', () => {
   describe('extractRequestMetadata()', () => {
     const createMockRequest = (headers: Record<string, string>): Request => {
       const h = new Headers();
-      for (const [key, value] of Object.entries(headers)) {
+      for (const [key, value] of Object.entries(headers)) 
         h.set(key, value);
-      }
+      
       return { headers: h } as Request;
     };
 

--- a/__tests__/unit/lib/logger.test.ts
+++ b/__tests__/unit/lib/logger.test.ts
@@ -93,9 +93,9 @@ describe('Logger', () => {
 
   describe('Specialized logging methods', () => {
     it('should have request method for logging requests', () => {
-      if (typeof logger.request === 'function') {
-        logger.request({ method: 'GET', path: '/api/v2/devices', statusCode: 200, duration: 50 });
-      }
+      if (typeof logger.request === 'function') 
+        logger.request('GET', '/api/v2/devices', 200, 50);
+      
     });
 
     it('should have error logging with Error object', () => {
@@ -104,9 +104,9 @@ describe('Logger', () => {
     });
 
     it('should handle cache logging if available', () => {
-      if (typeof logger.cache === 'function') {
+      if (typeof logger.cache === 'function') 
         logger.cache('hit', 'device:device_001');
-      }
+      
     });
   });
 
@@ -162,16 +162,16 @@ describe('Logger', () => {
   describe('Output format', () => {
     it('should format differently in production vs development', () => {
       // In production, output should be JSON
-      process.env.NODE_ENV = 'production';
+      (process.env as Record<string, string | undefined>).NODE_ENV = 'production';
       logger.info('Production log');
 
       // In development, output should be human-readable
-      process.env.NODE_ENV = 'development';
+      (process.env as Record<string, string | undefined>).NODE_ENV = 'development';
       logger.info('Development log');
     });
 
     it('should include timestamp in logs', () => {
-      process.env.NODE_ENV = 'production';
+      (process.env as Record<string, string | undefined>).NODE_ENV = 'production';
       logger.info('Test message');
 
       // Logs should contain timestamp (check format indirectly)

--- a/__tests__/unit/lib/pagination.test.ts
+++ b/__tests__/unit/lib/pagination.test.ts
@@ -591,7 +591,7 @@ describe('Pagination Utilities', () => {
     });
 
     it('should return undefined for undefined item', () => {
-      const cursor = createCursorFromItem(undefined, 'createdAt');
+      const cursor = createCursorFromItem<{ _id?: string; createdAt?: Date }>(undefined, 'createdAt');
 
       expect(cursor).toBeUndefined();
     });

--- a/__tests__/unit/lib/rateLimitMiddleware.test.ts
+++ b/__tests__/unit/lib/rateLimitMiddleware.test.ts
@@ -53,9 +53,9 @@ describe('Rate Limit Middleware', () => {
   describe('getClientIp()', () => {
     const createMockRequest = (headers: Record<string, string>): NextRequest => {
       const h = new Headers();
-      for (const [key, value] of Object.entries(headers)) {
+      for (const [key, value] of Object.entries(headers)) 
         h.set(key, value);
-      }
+      
       return { headers: h } as NextRequest;
     };
 

--- a/__tests__/unit/lib/sentry.test.ts
+++ b/__tests__/unit/lib/sentry.test.ts
@@ -7,13 +7,6 @@
 import {
   isSentryConfigured,
   initSentry,
-  captureException,
-  captureMessage,
-  addBreadcrumb,
-  setUser,
-  setTag,
-  setExtra,
-  startTransaction,
   withSentryErrorHandling,
 } from '@/lib/monitoring/sentry';
 
@@ -105,7 +98,7 @@ describe('Sentry Integration', () => {
 
     it('should use production sample rate in production', async () => {
       process.env.SENTRY_DSN = 'https://key@sentry.io/project';
-      process.env.NODE_ENV = 'production';
+      (process.env as Record<string, string | undefined>).NODE_ENV = 'production';
 
       // Reset module to get fresh initialization
       jest.resetModules();

--- a/__tests__/unit/lib/tracing.test.ts
+++ b/__tests__/unit/lib/tracing.test.ts
@@ -33,9 +33,9 @@ describe('Request Tracing', () => {
 
     it('should generate unique IDs', () => {
       const ids = new Set<string>();
-      for (let i = 0; i < 100; i++) {
+      for (let i = 0; i < 100; i++) 
         ids.add(generateTraceId());
-      }
+      
 
       expect(ids.size).toBe(100);
     });
@@ -48,9 +48,9 @@ describe('Request Tracing', () => {
   describe('getTraceId()', () => {
     const createMockRequest = (headers: Record<string, string>): Request => {
       const h = new Headers();
-      for (const [key, value] of Object.entries(headers)) {
+      for (const [key, value] of Object.entries(headers)) 
         h.set(key, value);
-      }
+      
       return { headers: h } as Request;
     };
 
@@ -194,9 +194,9 @@ describe('Request Tracing', () => {
   describe('withTracing()', () => {
     const createMockRequest = (headers: Record<string, string>, url: string): Request => {
       const h = new Headers();
-      for (const [key, value] of Object.entries(headers)) {
+      for (const [key, value] of Object.entries(headers)) 
         h.set(key, value);
-      }
+      
       return { headers: h, url } as Request;
     };
 
@@ -255,9 +255,9 @@ describe('Request Tracing', () => {
       headers: Record<string, string> = {}
     ): Request => {
       const h = new Headers();
-      for (const [key, value] of Object.entries(headers)) {
+      for (const [key, value] of Object.entries(headers)) 
         h.set(key, value);
-      }
+      
       return { method, url, headers: h } as Request;
     };
 

--- a/__tests__/unit/lib/useAnomalies.test.ts
+++ b/__tests__/unit/lib/useAnomalies.test.ts
@@ -1,5 +1,8 @@
 import { queryKeys } from '@/lib/query/queryClient';
 
+import { v2Api } from '@/lib/api/v2-client';
+import { useAnomalies } from '@/lib/query/hooks/useAnomalies';
+
 let capturedUseQueryArgs: Record<string, unknown> | null = null;
 
 jest.mock('@tanstack/react-query', () => ({
@@ -24,9 +27,6 @@ jest.mock('@/lib/api/v2-client', () => ({
     },
   },
 }));
-
-import { v2Api } from '@/lib/api/v2-client';
-import { useAnomalies } from '@/lib/query/hooks/useAnomalies';
 
 describe('queryKeys.analytics.anomalies', () => {
   it('should generate key without params', () => {

--- a/__tests__/unit/lib/useDevicesList.test.ts
+++ b/__tests__/unit/lib/useDevicesList.test.ts
@@ -1,5 +1,8 @@
 import { queryKeys } from '@/lib/query/queryClient';
 
+import { v2Api } from '@/lib/api/v2-client';
+import { useDevicesList } from '@/lib/query/hooks/useDevicesList';
+
 let capturedUseQueryArgs: Record<string, unknown> | null = null;
 
 jest.mock('@tanstack/react-query', () => ({
@@ -25,9 +28,6 @@ jest.mock('@/lib/api/v2-client', () => ({
     },
   },
 }));
-
-import { v2Api } from '@/lib/api/v2-client';
-import { useDevicesList } from '@/lib/query/hooks/useDevicesList';
 
 describe('queryKeys.devices', () => {
   it('should generate list key without filters', () => {

--- a/__tests__/unit/lib/useEnergyAnalytics.test.ts
+++ b/__tests__/unit/lib/useEnergyAnalytics.test.ts
@@ -1,5 +1,8 @@
 import { queryKeys } from '@/lib/query/queryClient';
 
+import { v2Api } from '@/lib/api/v2-client';
+import { useEnergyAnalytics } from '@/lib/query/hooks/useEnergyAnalytics';
+
 let capturedUseQueryArgs: Record<string, unknown> | null = null;
 
 jest.mock('@tanstack/react-query', () => ({
@@ -21,9 +24,6 @@ jest.mock('@/lib/api/v2-client', () => ({
     },
   },
 }));
-
-import { v2Api } from '@/lib/api/v2-client';
-import { useEnergyAnalytics } from '@/lib/query/hooks/useEnergyAnalytics';
 
 describe('queryKeys.analytics.energy', () => {
   it('should generate key without params', () => {

--- a/__tests__/unit/lib/useHealthAnalytics.test.ts
+++ b/__tests__/unit/lib/useHealthAnalytics.test.ts
@@ -9,6 +9,9 @@
 
 import { queryKeys } from '@/lib/query/queryClient';
 
+import { v2Api } from '@/lib/api/v2-client';
+import { useHealthAnalytics, useInvalidateHealth } from '@/lib/query/hooks/useHealthAnalytics';
+
 // Track what useQuery receives
 let capturedUseQueryArgs: Record<string, unknown> | null = null;
 const mockInvalidateQueries = jest.fn();
@@ -32,9 +35,6 @@ jest.mock('@/lib/api/v2-client', () => ({
     },
   },
 }));
-
-import { v2Api } from '@/lib/api/v2-client';
-import { useHealthAnalytics, useInvalidateHealth } from '@/lib/query/hooks/useHealthAnalytics';
 
 describe('queryKeys.health', () => {
   it('should generate key without params', () => {

--- a/__tests__/unit/lib/useMaintenanceForecast.test.ts
+++ b/__tests__/unit/lib/useMaintenanceForecast.test.ts
@@ -1,5 +1,8 @@
 import { queryKeys } from '@/lib/query/queryClient';
 
+import { v2Api } from '@/lib/api/v2-client';
+import { useMaintenanceForecast } from '@/lib/query/hooks/useMaintenanceForecast';
+
 let capturedUseQueryArgs: Record<string, unknown> | null = null;
 
 jest.mock('@tanstack/react-query', () => ({
@@ -24,9 +27,6 @@ jest.mock('@/lib/api/v2-client', () => ({
     },
   },
 }));
-
-import { v2Api } from '@/lib/api/v2-client';
-import { useMaintenanceForecast } from '@/lib/query/hooks/useMaintenanceForecast';
 
 describe('queryKeys.analytics.maintenanceForecast', () => {
   it('should generate key without params', () => {

--- a/__tests__/unit/lib/useMetadata.test.ts
+++ b/__tests__/unit/lib/useMetadata.test.ts
@@ -1,5 +1,8 @@
 import { queryKeys } from '@/lib/query/queryClient';
 
+import { v2Api } from '@/lib/api/v2-client';
+import { useMetadata } from '@/lib/query/hooks/useMetadata';
+
 let capturedUseQueryArgs: Record<string, unknown> | null = null;
 
 jest.mock('@tanstack/react-query', () => ({
@@ -28,9 +31,6 @@ jest.mock('@/lib/api/v2-client', () => ({
     },
   },
 }));
-
-import { v2Api } from '@/lib/api/v2-client';
-import { useMetadata } from '@/lib/query/hooks/useMetadata';
 
 describe('queryKeys.metadata', () => {
   it('should be a static array key', () => {

--- a/__tests__/unit/lib/useSchedules.test.ts
+++ b/__tests__/unit/lib/useSchedules.test.ts
@@ -1,5 +1,15 @@
 import { queryKeys } from '@/lib/query/queryClient';
 
+import { v2Api } from '@/lib/api/v2-client';
+import {
+  useSchedulesList,
+  useScheduleDetail,
+  useCreateSchedule,
+  useUpdateSchedule,
+  useCompleteSchedule,
+  useCancelSchedule,
+} from '@/lib/query/hooks/useSchedules';
+
 // Track captured args for useQuery and useMutation
 let capturedUseQueryArgs: Record<string, unknown> | null = null;
 let capturedMutationArgs: Record<string, unknown> | null = null;
@@ -51,16 +61,6 @@ jest.mock('@/lib/api/v2-client', () => ({
     },
   },
 }));
-
-import { v2Api } from '@/lib/api/v2-client';
-import {
-  useSchedulesList,
-  useScheduleDetail,
-  useCreateSchedule,
-  useUpdateSchedule,
-  useCompleteSchedule,
-  useCancelSchedule,
-} from '@/lib/query/hooks/useSchedules';
 
 // ============================================================================
 // QUERY KEY TESTS

--- a/__tests__/unit/lib/validateRequest.test.ts
+++ b/__tests__/unit/lib/validateRequest.test.ts
@@ -4,7 +4,7 @@
  * Tests for combined request validation.
  */
 
-import { NextRequest } from 'next/server';
+import type { NextRequest } from 'next/server';
 import {
   validateRequest,
   withRequestValidation,
@@ -20,14 +20,14 @@ const createMockNextRequest = (
   searchParams: Record<string, string> = {}
 ): NextRequest => {
   const url = new URL(`http://localhost${pathname}`);
-  for (const [key, value] of Object.entries(searchParams)) {
+  for (const [key, value] of Object.entries(searchParams)) 
     url.searchParams.set(key, value);
-  }
+  
 
   const h = new Headers();
-  for (const [key, value] of Object.entries(headers)) {
+  for (const [key, value] of Object.entries(headers)) 
     h.set(key, value);
-  }
+  
 
   return {
     method,

--- a/__tests__/unit/lib/validator.test.ts
+++ b/__tests__/unit/lib/validator.test.ts
@@ -17,7 +17,6 @@ import {
   formatErrorMessage,
   createSchema,
   mergeSchemas,
-  type ValidationResult,
   type ValidationError,
 } from '@/lib/validations/validator';
 import { ApiError } from '@/lib/errors/ApiError';
@@ -167,18 +166,18 @@ describe('Validator Utilities', () => {
       const result = validateInput({ name: 'John', age: 30 }, schema);
 
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success) 
         expect(result.data).toEqual({ name: 'John', age: 30 });
-      }
+      
     });
 
     it('should return errors for invalid input', () => {
       const result = validateInput({ name: 123, age: -1 }, schema);
 
       expect(result.success).toBe(false);
-      if (!result.success) {
+      if (!result.success) 
         expect(result.errors.length).toBeGreaterThan(0);
-      }
+      
     });
 
     it('should sanitize input by default', () => {
@@ -206,9 +205,9 @@ describe('Validator Utilities', () => {
       );
 
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success) 
         expect(result.data).not.toHaveProperty('extra');
-      }
+      
     });
 
     it('should handle null input gracefully', () => {
@@ -266,9 +265,9 @@ describe('Validator Utilities', () => {
       const result = validateQuery(params, schema);
 
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success) 
         expect(result.data).toEqual({ page: 1, limit: 10, status: 'active' });
-      }
+      
     });
 
     it('should validate URL object', () => {
@@ -277,18 +276,18 @@ describe('Validator Utilities', () => {
       const result = validateQuery(url, schema);
 
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success) 
         expect(result.data?.page).toBe(2);
-      }
+      
     });
 
     it('should validate URL string', () => {
       const result = validateQuery('http://localhost/api?page=3', schema);
 
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success) 
         expect(result.data?.page).toBe(3);
-      }
+      
     });
 
     it('should handle query string without URL', () => {
@@ -310,9 +309,9 @@ describe('Validator Utilities', () => {
       const result = validateQuery(params, arraySchema);
 
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success) 
         expect(result.data?.tags).toEqual(['a', 'b', 'c']);
-      }
+      
     });
   });
 
@@ -362,9 +361,9 @@ describe('Validator Utilities', () => {
       const result = await validateBody(request, schema);
 
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success) 
         expect(result.data).toEqual({ name: 'Test', value: 42 });
-      }
+      
     });
 
     it('should return errors for invalid body', async () => {
@@ -395,9 +394,9 @@ describe('Validator Utilities', () => {
       const result = await validateBody(request, schema);
 
       expect(result.success).toBe(false);
-      if (!result.success) {
+      if (!result.success) 
         expect(result.errors[0].code).toBe('parse_error');
-      }
+      
     });
   });
 
@@ -453,9 +452,9 @@ describe('Validator Utilities', () => {
       const result = validateValue('test@example.com', schema);
 
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success) 
         expect(result.data).toBe('test@example.com');
-      }
+      
     });
 
     it('should return error for invalid value', () => {
@@ -472,9 +471,9 @@ describe('Validator Utilities', () => {
       const result = validateValue('invalid', schema, 'userEmail');
 
       expect(result.success).toBe(false);
-      if (!result.success) {
+      if (!result.success) 
         expect(result.errors[0].path).toBe('userEmail');
-      }
+      
     });
   });
 
@@ -509,9 +508,9 @@ describe('Validator Utilities', () => {
       const result = schema.safeParse({ name: 'John', age: 30, extra: 'field' });
 
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success) 
         expect(result.data).not.toHaveProperty('extra');
-      }
+      
     });
 
     it('should make all fields required', () => {
@@ -540,9 +539,9 @@ describe('Validator Utilities', () => {
       const result = merged.safeParse({ name: 'John', age: 30 });
 
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success) 
         expect(result.data).toEqual({ name: 'John', age: 30 });
-      }
+      
     });
 
     it('should fail when merged schema requirements not met', () => {

--- a/__tests__/unit/models/DeviceV2.test.ts
+++ b/__tests__/unit/models/DeviceV2.test.ts
@@ -79,14 +79,14 @@ describe('DeviceV2 Model', () => {
 
     it('should validate device type enum', async () => {
       const invalidTypeData = createDeviceInput({ _id: 'device_invalid_type' });
-      (invalidTypeData as Record<string, unknown>).type = 'invalid_type';
+      (invalidTypeData as unknown as Record<string, unknown>).type = 'invalid_type';
 
       await expect(DeviceV2.create(invalidTypeData)).rejects.toThrow(/validation/i);
     });
 
     it('should validate device status enum', async () => {
       const invalidStatusData = createDeviceInput({ _id: 'device_invalid_status' });
-      (invalidStatusData as Record<string, unknown>).status = 'invalid_status';
+      (invalidStatusData as unknown as Record<string, unknown>).status = 'invalid_status';
 
       await expect(DeviceV2.create(invalidStatusData)).rejects.toThrow(/validation/i);
     });
@@ -135,7 +135,7 @@ describe('DeviceV2 Model', () => {
 
     it('should use default sampling interval', async () => {
       const deviceData = createDeviceInput({ _id: 'device_sampling_default' });
-      delete (deviceData.configuration as Record<string, unknown>).sampling_interval;
+      delete (deviceData.configuration as unknown as Record<string, unknown>).sampling_interval;
 
       const device = await DeviceV2.create(deviceData);
       expect(device.configuration.sampling_interval).toBe(60);

--- a/__tests__/unit/models/ScheduleV2.test.ts
+++ b/__tests__/unit/models/ScheduleV2.test.ts
@@ -9,12 +9,10 @@
  */
 
 import ScheduleV2, { ScheduleTransitionError } from '@/models/v2/ScheduleV2';
-import DeviceV2 from '@/models/v2/DeviceV2';
 import {
   createScheduleInput,
   createScheduleInputs,
   createScheduleOfType,
-  createDeviceInput,
   resetCounters,
   VALID_SERVICE_TYPES,
   VALID_SCHEDULE_STATUSES,
@@ -74,7 +72,7 @@ describe('ScheduleV2 Model', () => {
 
     it('should default status to scheduled', async () => {
       const data = createScheduleInput();
-      delete (data as Record<string, unknown>).status;
+      delete (data as unknown as Record<string, unknown>).status;
       const schedule = await ScheduleV2.create(data);
 
       expect(schedule.status).toBe('scheduled');
@@ -107,28 +105,28 @@ describe('ScheduleV2 Model', () => {
 
     it('should enforce required device_id', async () => {
       const data = createScheduleInput();
-      delete (data as Record<string, unknown>).device_id;
+      delete (data as unknown as Record<string, unknown>).device_id;
 
       await expect(ScheduleV2.create(data)).rejects.toThrow();
     });
 
     it('should enforce required service_type', async () => {
       const data = createScheduleInput();
-      delete (data as Record<string, unknown>).service_type;
+      delete (data as unknown as Record<string, unknown>).service_type;
 
       await expect(ScheduleV2.create(data)).rejects.toThrow();
     });
 
     it('should enforce required scheduled_date', async () => {
       const data = createScheduleInput();
-      delete (data as Record<string, unknown>).scheduled_date;
+      delete (data as unknown as Record<string, unknown>).scheduled_date;
 
       await expect(ScheduleV2.create(data)).rejects.toThrow();
     });
 
     it('should enforce required audit', async () => {
       const data = createScheduleInput();
-      delete (data as Record<string, unknown>).audit;
+      delete (data as unknown as Record<string, unknown>).audit;
 
       await expect(ScheduleV2.create(data)).rejects.toThrow();
     });
@@ -146,7 +144,7 @@ describe('ScheduleV2 Model', () => {
 
     it('should reject invalid service type', async () => {
       const data = createScheduleInput();
-      (data as Record<string, unknown>).service_type = 'invalid_type';
+      (data as unknown as Record<string, unknown>).service_type = 'invalid_type';
 
       await expect(ScheduleV2.create(data)).rejects.toThrow(/validation/i);
     });
@@ -165,7 +163,7 @@ describe('ScheduleV2 Model', () => {
 
     it('should reject invalid status', async () => {
       const data = createScheduleInput();
-      (data as Record<string, unknown>).status = 'invalid_status';
+      (data as unknown as Record<string, unknown>).status = 'invalid_status';
 
       await expect(ScheduleV2.create(data)).rejects.toThrow(/validation/i);
     });
@@ -293,11 +291,11 @@ describe('ScheduleV2 Model', () => {
       it('should sort by scheduled_date ascending', async () => {
         const schedules = await ScheduleV2.findUpcoming(60);
 
-        for (let i = 1; i < schedules.length; i++) {
+        for (let i = 1; i < schedules.length; i++) 
           expect(schedules[i].scheduled_date.getTime()).toBeGreaterThanOrEqual(
             schedules[i - 1].scheduled_date.getTime()
           );
-        }
+        
       });
     });
 

--- a/__tests__/unit/validations/device.validation.test.ts
+++ b/__tests__/unit/validations/device.validation.test.ts
@@ -39,9 +39,9 @@ describe('Device Validation Schemas', () => {
       for (const status of invalidStatuses) {
         const result = deviceStatusSchema.safeParse(status);
         expect(result.success).toBe(false);
-        if (!result.success) {
+        if (!result.success) 
           expect(result.error.issues[0]?.code).toBe('invalid_value');
-        }
+        
       }
     });
   });

--- a/__tests__/unit/validations/reading-validation-transforms.test.ts
+++ b/__tests__/unit/validations/reading-validation-transforms.test.ts
@@ -32,9 +32,9 @@ describe('listReadingsQuerySchema string transforms', () => {
     });
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success) 
       expect(result.data.type).toEqual(['temperature', 'humidity']);
-    }
+    
   });
 
   it('should transform comma-separated source string into array', () => {
@@ -44,9 +44,9 @@ describe('listReadingsQuerySchema string transforms', () => {
     });
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success) 
       expect(result.data.source).toEqual(['sensor', 'manual']);
-    }
+    
   });
 
   it('should transform string min_confidence to number', () => {
@@ -56,9 +56,9 @@ describe('listReadingsQuerySchema string transforms', () => {
     });
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success) 
       expect(result.data.min_confidence).toBe(0.85);
-    }
+    
   });
 
   it('should transform string min_anomaly_score to number', () => {
@@ -68,9 +68,9 @@ describe('listReadingsQuerySchema string transforms', () => {
     });
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success) 
       expect(result.data.min_anomaly_score).toBe(0.7);
-    }
+    
   });
 });
 
@@ -86,9 +86,9 @@ describe('latestReadingsQuerySchema string transforms', () => {
     });
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success) 
       expect(result.data.type).toEqual(['temperature', 'humidity', 'power']);
-    }
+    
   });
 });
 
@@ -103,9 +103,9 @@ describe('readingAnalyticsQuerySchema string transforms', () => {
     });
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success) 
       expect(result.data.device_id).toEqual(['device_001', 'device_002']);
-    }
+    
   });
 
   it('should transform comma-separated type string into array', () => {
@@ -115,9 +115,9 @@ describe('readingAnalyticsQuerySchema string transforms', () => {
     });
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success) 
       expect(result.data.type).toEqual(['temperature', 'humidity']);
-    }
+    
   });
 
   it('should transform string floor to number', () => {
@@ -127,9 +127,9 @@ describe('readingAnalyticsQuerySchema string transforms', () => {
     });
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success) 
       expect(result.data.floor).toBe(3);
-    }
+    
   });
 });
 
@@ -144,9 +144,9 @@ describe('anomalyAnalyticsQuerySchema string transforms', () => {
     });
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success) 
       expect(result.data.device_id).toEqual(['device_001', 'device_002', 'device_003']);
-    }
+    
   });
 
   it('should transform comma-separated type string into array', () => {
@@ -155,8 +155,8 @@ describe('anomalyAnalyticsQuerySchema string transforms', () => {
     });
 
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success) 
       expect(result.data.type).toEqual(['temperature', 'power', 'energy']);
-    }
+    
   });
 });

--- a/__tests__/unit/validations/schedule.validation.test.ts
+++ b/__tests__/unit/validations/schedule.validation.test.ts
@@ -194,9 +194,9 @@ describe('Schedule Validation Schemas', () => {
     it('should transform string dates to Date objects', () => {
       const result = createScheduleSchema.safeParse(validInput);
       expect(result.success).toBe(true);
-      if (result.success) {
+      if (result.success) 
         expect(result.data.scheduled_date).toBeInstanceOf(Date);
-      }
+      
     });
   });
 

--- a/app/api/v2/analytics/energy/route.ts
+++ b/app/api/v2/analytics/energy/route.ts
@@ -177,7 +177,7 @@ export async function GET(request: NextRequest) {
         .lean();
 
       const ids = floorDeviceIds.map(d => d._id);
-      if (ids.length === 0) {
+      if (ids.length === 0) 
         // No devices on this floor — return empty results immediately
         return jsonSuccess({
           results: [],
@@ -192,7 +192,7 @@ export async function GET(request: NextRequest) {
             compare_with: query.compare_with || null,
           },
         });
-      }
+      
 
       matchStage['metadata.device_id'] = ids.length === 1 ? ids[0] : { $in: ids };
     }
@@ -282,14 +282,14 @@ export async function GET(request: NextRequest) {
 
       // When floor filter was deferred (N+1 elimination), apply it after $lookup/$unwind
       // instead of making a separate pre-query to the devices collection
-      if (deferFloorFilter) {
+      if (deferFloorFilter) 
         pipeline.push({
           $match: {
             'device.location.floor': query.floor,
             'device.audit.deleted_at': { $exists: false },
           },
         } as PipelineStage.Match);
-      }
+      
     }
 
     pipeline.push(
@@ -405,14 +405,14 @@ export async function GET(request: NextRequest) {
         );
 
         // Apply deferred floor filter after $lookup in comparison pipeline too
-        if (deferFloorFilter) {
+        if (deferFloorFilter) 
           comparisonPipeline.push({
             $match: {
               'device.location.floor': query.floor,
               'device.audit.deleted_at': { $exists: false },
             },
           } as PipelineStage.Match);
-        }
+        
       }
 
       comparisonPipeline.push(

--- a/app/api/v2/reports/device-health/route.ts
+++ b/app/api/v2/reports/device-health/route.ts
@@ -97,9 +97,9 @@ async function aggregateDeviceData(
     status: { $ne: 'decommissioned' },
   };
 
-  if (scope === 'building' && buildingId) {
+  if (scope === 'building' && buildingId) 
     activeMatch['location.building_id'] = buildingId;
-  }
+  
 
   // Aggregate active devices by building, floor, and status
   const activeAggregation = await DeviceV2.aggregate([
@@ -122,9 +122,9 @@ async function aggregateDeviceData(
     $or: [{ status: 'decommissioned' }, { 'audit.deleted_at': { $exists: true } }],
   };
 
-  if (scope === 'building' && buildingId) {
+  if (scope === 'building' && buildingId) 
     deletedMatch['location.building_id'] = buildingId;
-  }
+  
 
   const deletedAggregation = await DeviceV2.aggregate([
     { $match: deletedMatch },
@@ -159,21 +159,21 @@ async function aggregateDeviceData(
     addToSummary(globalSummary, status, count);
 
     // Get or create building entry
-    if (!buildingMap.has(building_id)) {
+    if (!buildingMap.has(building_id)) 
       buildingMap.set(building_id, {
         summary: createEmptySummary(),
         floors: new Map(),
       });
-    }
+    
     const building = buildingMap.get(building_id)!;
 
     // Update building summary
     addToSummary(building.summary, status, count);
 
     // Get or create floor entry
-    if (!building.floors.has(floor)) {
+    if (!building.floors.has(floor)) 
       building.floors.set(floor, createEmptySummary());
-    }
+    
     const floorSummary = building.floors.get(floor)!;
 
     // Update floor summary
@@ -190,12 +190,12 @@ async function aggregateDeviceData(
     globalSummary.total += count;
 
     // Get or create building entry
-    if (!buildingMap.has(building_id)) {
+    if (!buildingMap.has(building_id)) 
       buildingMap.set(building_id, {
         summary: createEmptySummary(),
         floors: new Map(),
       });
-    }
+    
     const building = buildingMap.get(building_id)!;
 
     // Update building decommissioned count
@@ -204,9 +204,9 @@ async function aggregateDeviceData(
 
     // Get or create floor entry (only for building scope)
     if (scope === 'building') {
-      if (!building.floors.has(floor)) {
+      if (!building.floors.has(floor)) 
         building.floors.set(floor, createEmptySummary());
-      }
+      
       const floorSummary = building.floors.get(floor)!;
       floorSummary.decommissioned += count;
       floorSummary.total += count;
@@ -221,9 +221,9 @@ async function aggregateDeviceData(
 
     // Only include per-floor breakdown for building scope
     if (scope === 'building') {
-      for (const [floor, summary] of data.floors) {
+      for (const [floor, summary] of data.floors) 
         floors.push({ floor, summary });
-      }
+      
       // Sort floors by floor number
       floors.sort((a, b) => a.floor - b.floor);
     }
@@ -330,11 +330,11 @@ async function generatePdf(data: ReportData): Promise<Uint8Array> {
   if (data.breakdowns.length > 0) {
     addNewPageIfNeeded(50);
 
-    if (data.scope === 'all') {
+    if (data.scope === 'all') 
       drawText('Per-Building Breakdown', margin, yPosition, 14, true);
-    } else {
+     else 
       drawText('Per-Floor Breakdown', margin, yPosition, 14, true);
-    }
+    
     yPosition -= 25;
 
     for (const building of data.breakdowns) {
@@ -350,7 +350,7 @@ async function generatePdf(data: ReportData): Promise<Uint8Array> {
       yPosition -= 20;
 
       // Floor breakdowns (only for building scope)
-      if (data.scope === 'building' && building.floors.length > 0) {
+      if (data.scope === 'building' && building.floors.length > 0) 
         for (const floor of building.floors) {
           addNewPageIfNeeded(40);
 
@@ -361,7 +361,7 @@ async function generatePdf(data: ReportData): Promise<Uint8Array> {
           drawText(floorSummaryText, margin + 30, yPosition, 9);
           yPosition -= lineHeight;
         }
-      }
+      
 
       yPosition -= 15;
     }
@@ -397,14 +397,14 @@ export async function GET(request: NextRequest) {
 
     // Validate query parameters
     const validationResult = validateQuery(searchParams, reportGenerateQuerySchema);
-    if (!validationResult.success) {
+    if (!validationResult.success) 
       throw new ApiError(
         ErrorCodes.VALIDATION_ERROR,
         400,
         validationResult.errors.map(e => e.message).join(', '),
         { errors: validationResult.errors }
       );
-    }
+    
 
     const { scope, building_id } = validationResult.data;
 

--- a/app/api/v2/schedules/[id]/route.ts
+++ b/app/api/v2/schedules/[id]/route.ts
@@ -71,13 +71,13 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     // Find schedule
     const schedule = await ScheduleV2.findById(id).lean();
 
-    if (!schedule) {
+    if (!schedule) 
       throw new ApiError(
         ErrorCodes.SCHEDULE_NOT_FOUND,
         404,
         `Schedule '${id}' not found`
       );
-    }
+    
 
     // Build response
     const response: Record<string, unknown> = { ...schedule };
@@ -88,7 +88,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
         .select('_id serial_number type location')
         .lean();
 
-      if (device) {
+      if (device) 
         response.device = {
           _id: device._id,
           serial_number: device.serial_number,
@@ -99,7 +99,7 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
             room_name: device.location?.room_name,
           },
         };
-      } else {
+       else {
         logger.warn('Device not found for schedule', {
           scheduleId: id,
           deviceId: schedule.device_id,
@@ -192,9 +192,9 @@ async function handleUpdateSchedule(
     // Handle status transitions via static methods for consistency
     if (updateData.status === 'completed') {
       const completedSchedule = await ScheduleV2.complete(id, auditUser).catch(rethrowAsApiError);
-      if (!completedSchedule) {
+      if (!completedSchedule) 
         throw new ApiError(ErrorCodes.SCHEDULE_NOT_FOUND, 404, `Schedule '${id}' not found`);
-      }
+      
 
       const duration = timer.elapsed();
       recordRequest('PATCH', '/api/v2/schedules/[id]', 200, duration);
@@ -205,9 +205,9 @@ async function handleUpdateSchedule(
 
     if (updateData.status === 'cancelled') {
       const cancelledSchedule = await ScheduleV2.cancel(id, auditUser).catch(rethrowAsApiError);
-      if (!cancelledSchedule) {
+      if (!cancelledSchedule) 
         throw new ApiError(ErrorCodes.SCHEDULE_NOT_FOUND, 404, `Schedule '${id}' not found`);
-      }
+      
 
       const duration = timer.elapsed();
       recordRequest('PATCH', '/api/v2/schedules/[id]', 200, duration);
@@ -218,29 +218,29 @@ async function handleUpdateSchedule(
 
     // For non-status updates (scheduled_date, notes), check schedule exists and is modifiable
     const existingSchedule = await ScheduleV2.findById(id);
-    if (!existingSchedule) {
+    if (!existingSchedule) 
       throw new ApiError(
         ErrorCodes.SCHEDULE_NOT_FOUND,
         404,
         `Schedule '${id}' not found`
       );
-    }
+    
 
-    if (existingSchedule.status === 'completed') {
+    if (existingSchedule.status === 'completed') 
       throw new ApiError(
         ErrorCodes.SCHEDULE_ALREADY_COMPLETED,
         422,
         'Cannot modify a completed schedule'
       );
-    }
+    
 
-    if (existingSchedule.status === 'cancelled') {
+    if (existingSchedule.status === 'cancelled') 
       throw new ApiError(
         ErrorCodes.SCHEDULE_ALREADY_CANCELLED,
         422,
         'Cannot modify a cancelled schedule'
       );
-    }
+    
 
     // Build update object for non-status fields
     const updateObj: Record<string, unknown> = {
@@ -248,13 +248,13 @@ async function handleUpdateSchedule(
       'audit.updated_by': auditUser,
     };
 
-    if (updateData.scheduled_date) {
+    if (updateData.scheduled_date) 
       updateObj.scheduled_date = updateData.scheduled_date;
-    }
+    
 
-    if (updateData.notes !== undefined) {
+    if (updateData.notes !== undefined) 
       updateObj.notes = updateData.notes;
-    }
+    
 
     // Perform update
     const updatedSchedule = await ScheduleV2.findByIdAndUpdate(
@@ -263,13 +263,13 @@ async function handleUpdateSchedule(
       { new: true, runValidators: true }
     ).lean();
 
-    if (!updatedSchedule) {
+    if (!updatedSchedule) 
       throw new ApiError(
         ErrorCodes.SCHEDULE_NOT_FOUND,
         404,
         `Schedule '${id}' not found`
       );
-    }
+    
 
     // Record metrics
     const duration = timer.elapsed();
@@ -322,9 +322,9 @@ async function handleCancelSchedule(
 
     const cancelledSchedule = await ScheduleV2.cancel(id, auditUser).catch(rethrowAsApiError);
 
-    if (!cancelledSchedule) {
+    if (!cancelledSchedule) 
       throw new ApiError(ErrorCodes.SCHEDULE_NOT_FOUND, 404, `Schedule '${id}' not found`);
-    }
+    
 
     // Record metrics
     const duration = timer.elapsed();

--- a/app/api/v2/schedules/route.ts
+++ b/app/api/v2/schedules/route.ts
@@ -70,17 +70,17 @@ export async function GET(request: NextRequest) {
     const filter: Record<string, unknown> = {};
 
     // Device ID filter
-    if (query.device_id) {
+    if (query.device_id) 
       filter.device_id = query.device_id;
-    }
+    
 
     // Status filter - default to only 'scheduled' unless include_all is true
     if (query.status) {
       const statuses = Array.isArray(query.status) ? query.status : [query.status];
       filter.status = statuses.length === 1 ? statuses[0] : { $in: statuses };
-    } else if (!query.include_all) {
+    } else if (!query.include_all) 
       filter.status = 'scheduled';
-    }
+    
 
     // Service type filter
     if (query.service_type) {
@@ -91,12 +91,12 @@ export async function GET(request: NextRequest) {
     // Date range filter for scheduled_date
     if (query.startDate || query.endDate) {
       filter.scheduled_date = {};
-      if (query.startDate) {
+      if (query.startDate) 
         (filter.scheduled_date as Record<string, Date>).$gte = new Date(query.startDate);
-      }
-      if (query.endDate) {
+      
+      if (query.endDate) 
         (filter.scheduled_date as Record<string, Date>).$lte = new Date(query.endDate);
-      }
+      
     }
 
     // Build sort
@@ -185,14 +185,14 @@ async function handleCreateSchedules(request: NextRequest) {
     const existingDeviceIds = new Set(existingDevices.map(d => d._id));
     const missingDeviceIds = deviceIds.filter(id => !existingDeviceIds.has(id));
 
-    if (missingDeviceIds.length > 0) {
+    if (missingDeviceIds.length > 0) 
       throw new ApiError(
         ErrorCodes.DEVICE_NOT_FOUND,
         404,
         `Device(s) not found or deleted: ${missingDeviceIds.join(', ')}`,
         { missing_device_ids: missingDeviceIds }
       );
-    }
+    
 
     // Create one schedule document per device
     const now = new Date();

--- a/components/AnomalyChart.tsx
+++ b/components/AnomalyChart.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useCallback, useMemo } from 'react';
-import { usePusherReadings } from '@/lib/pusher-context';
-import type { PusherReading } from '@/lib/pusher-context';
+import { usePusherReadings, type PusherReading } from '@/lib/pusher-context';
 import { useEnergyAnalytics } from '@/lib/query/hooks';
 import {
   AreaChart,

--- a/components/DeviceGrid.tsx
+++ b/components/DeviceGrid.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useEffect, useState, useMemo, useCallback } from 'react';
-import { usePusherReadings } from '@/lib/pusher-context';
-import type { PusherReading } from '@/lib/pusher-context';
+import { usePusherReadings, type PusherReading } from '@/lib/pusher-context';
 import { v2Api } from '@/lib/api/v2-client';
 import type { DeviceV2Response } from '@/types/v2';
 import {

--- a/components/FloorPlan.tsx
+++ b/components/FloorPlan.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { usePusherReadings } from '@/lib/pusher-context';
-import type { PusherReading } from '@/lib/pusher-context';
+import { usePusherReadings, type PusherReading } from '@/lib/pusher-context';
 import { v2Api } from '@/lib/api/v2-client';
 import type { DeviceV2Response } from '@/types/v2';
 import {

--- a/components/GenerateReportModal.tsx
+++ b/components/GenerateReportModal.tsx
@@ -71,9 +71,9 @@ export default function GenerateReportModal({ isOpen, onClose }: GenerateReportM
               value={scope}
               onValueChange={val => {
                 setScope(val as 'all' | 'building');
-                if (val === 'all') {
+                if (val === 'all') 
                   setSelectedBuildingId('');
-                }
+                
               }}
               options={[
                 { value: 'all', label: 'All Buildings' },

--- a/components/ScheduleServiceModal.tsx
+++ b/components/ScheduleServiceModal.tsx
@@ -98,7 +98,7 @@ export function ScheduleServiceModal({
       onClose();
     },
     onError: (err) => {
-      if (err instanceof ApiClientError) {
+      if (err instanceof ApiClientError) 
         switch (err.errorCode) {
           case 'VALIDATION_ERROR':
             setGeneralError(err.message);
@@ -112,7 +112,7 @@ export function ScheduleServiceModal({
           default:
             setGeneralError(err.message || 'Failed to create schedule');
         }
-      } else {
+       else {
         console.error('Unexpected error creating schedule:', err);
         setGeneralError('An unexpected error occurred');
       }

--- a/components/dashboard/CriticalIssuesPanel.tsx
+++ b/components/dashboard/CriticalIssuesPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useRef } from 'react';
+import { useMemo, useState } from 'react';
 import { useHealthAnalytics, useMaintenanceForecast } from '@/lib/query/hooks';
 import {
   AlertTriangle,
@@ -43,15 +43,13 @@ export default function CriticalIssuesPanel({
   const error = healthError || forecastError ? 'Failed to load issues' : null;
 
   // Stable reference time for fallback timestamps - initialized lazily
-  const fallbackTimeRef = useRef<number | null>(null);
-  if (fallbackTimeRef.current === null) fallbackTimeRef.current = Date.now();
+  const [fallbackTime] = useState(() => Date.now());
 
   // Calculate issues using useMemo (only recalculate when data changes)
   const issues = useMemo(() => {
     if (!health || !forecast) return [];
 
     const collectedIssues: CriticalIssue[] = [];
-    const fallbackTime = fallbackTimeRef.current ?? 0;
 
     // Offline devices - Critical
     health.alerts?.offline_devices?.devices?.forEach(d => {
@@ -121,7 +119,7 @@ export default function CriticalIssuesPanel({
     });
 
     return collectedIssues.slice(0, maxItems);
-  }, [health, forecast, maxItems]);
+  }, [health, forecast, maxItems, fallbackTime]);
 
   const getIssueIcon = (type: CriticalIssue['type']) => {
     switch (type) {

--- a/components/dashboard/MaintenanceWidget.tsx
+++ b/components/dashboard/MaintenanceWidget.tsx
@@ -43,7 +43,7 @@ export default function MaintenanceWidget({ onItemClick, maxItems = 4 }: Mainten
 
         const maintenanceItems: MaintenanceItem[] = allDevices
           .filter(d => d.metadata?.next_maintenance)
-          .map((d, index) => {
+          .map(d => {
             // Determine maintenance type based on device type or serial
             let maintType: MaintenanceItem['type'] = 'inspection';
 

--- a/components/devices/CreateDeviceModal.tsx
+++ b/components/devices/CreateDeviceModal.tsx
@@ -186,9 +186,9 @@ export function CreateDeviceModal({
     value: typeof formData[K]
   ) => {
     setFormData((prev) => ({ ...prev, [key]: value }));
-    if (errors[key]) {
+    if (errors[key]) 
       setErrors((prev) => ({ ...prev, [key]: undefined }));
-    }
+    
   };
 
   const updateNestedField = <
@@ -203,9 +203,9 @@ export function CreateDeviceModal({
       [parent]: { ...prev[parent], [key]: value },
     }));
     const errorKey = `${parent}.${String(key)}`;
-    if (errors[errorKey]) {
+    if (errors[errorKey]) 
       setErrors((prev) => ({ ...prev, [errorKey]: undefined }));
-    }
+    
   };
 
   // Validation
@@ -241,7 +241,7 @@ export function CreateDeviceModal({
       onSuccess(response.data);
       onClose();
     } catch (err) {
-      if (err instanceof ApiClientError) {
+      if (err instanceof ApiClientError) 
         // Handle specific error codes
         switch (err.errorCode) {
           case 'SERIAL_NUMBER_EXISTS':
@@ -258,9 +258,9 @@ export function CreateDeviceModal({
                 newErrors[path] = error.message;
               }
               setErrors(newErrors);
-            } else {
+            } else 
               setGeneralError(err.message);
-            }
+            
             break;
           case 'RATE_LIMIT_EXCEEDED':
             setGeneralError('Too many requests. Please try again later.');
@@ -271,9 +271,9 @@ export function CreateDeviceModal({
           default:
             setGeneralError(err.message || 'An error occurred. Please try again.');
         }
-      } else {
+       else 
         setGeneralError('An unexpected error occurred. Please try again.');
-      }
+      
     } finally {
       setIsSubmitting(false);
     }

--- a/components/devices/TagInput.tsx
+++ b/components/devices/TagInput.tsx
@@ -47,9 +47,9 @@ export function TagInput({
     if (e.key === 'Enter') {
       e.preventDefault();
       addTag(inputValue);
-    } else if (e.key === 'Backspace' && !inputValue && value.length > 0) {
+    } else if (e.key === 'Backspace' && !inputValue && value.length > 0) 
       removeTag(value[value.length - 1]);
-    }
+    
   };
 
   return (

--- a/e2e/device-detail.spec.ts
+++ b/e2e/device-detail.spec.ts
@@ -127,9 +127,9 @@ test.describe('Device Detail', () => {
         '[data-testid="device-status"], [class*="badge"], [class*="Badge"]'
       );
 
-      if ((await statusBadge.count()) > 0) {
+      if ((await statusBadge.count()) > 0) 
         await expect(statusBadge.first()).toBeVisible();
-      }
+      
     });
 
     test('should show device location information', async ({ page }) => {
@@ -303,11 +303,11 @@ test.describe('Device Detail', () => {
         const input = filterInput.first();
         const tagName = await input.evaluate((el) => el.tagName.toLowerCase());
 
-        if (tagName === 'input') {
+        if (tagName === 'input') 
           await input.fill('temperature');
-        } else if (tagName === 'select') {
+         else if (tagName === 'select') 
           await input.selectOption({ index: 1 });
-        }
+        
 
         // Wait for filter to apply
         await page.waitForTimeout(1000);

--- a/e2e/error-handling.spec.ts
+++ b/e2e/error-handling.spec.ts
@@ -31,9 +31,9 @@ test.describe('Error Handling', () => {
           !error.message.includes('fetch') &&
           !error.message.includes('network') &&
           !error.message.includes('Failed to fetch')
-        ) {
+        ) 
           errors.push(error.message);
-        }
+        
       });
 
       await page.waitForTimeout(2000);
@@ -175,11 +175,6 @@ test.describe('Error Handling', () => {
       await page.goto('/');
       await page.waitForLoadState('load');
 
-      // Should show empty state or message
-      const emptyIndicators = page.locator(
-        '[data-testid="empty-state"], text=/no device|no data|empty|no results/i'
-      );
-
       // Page should be usable with empty data
       const mainContent = page.locator('main, body');
       await expect(mainContent.first()).toBeVisible();
@@ -262,15 +257,15 @@ test.describe('Error Handling', () => {
           error.message.includes('Unhandled') ||
           error.message.includes('uncaught') ||
           error.message.includes('INTERNAL_ERROR')
-        ) {
+        ) 
           // Filter common dev-mode issues
           if (
             !error.message.includes('ResizeObserver') &&
             !error.message.includes('hydration')
-          ) {
+          ) 
             unhandledErrors.push(error.message);
-          }
-        }
+          
+        
       });
 
       await page.goto('/');
@@ -283,11 +278,6 @@ test.describe('Error Handling', () => {
       }
 
       // Should not have unhandled errors visible to user
-      const errorUI = page.locator(
-        'text=/something went wrong|error occurred|unexpected error/i'
-      );
-
-      // Error UI may appear but shouldn't crash
       expect(unhandledErrors.length).toBe(0);
     });
 
@@ -303,9 +293,9 @@ test.describe('Error Handling', () => {
       // No uncaught promise rejections
       const uncaughtRejections: string[] = [];
       page.on('pageerror', (error) => {
-        if (error.message.includes('promise') || error.message.includes('rejection')) {
+        if (error.message.includes('promise') || error.message.includes('rejection')) 
           uncaughtRejections.push(error.message);
-        }
+        
       });
 
       await page.waitForTimeout(2000);
@@ -397,9 +387,9 @@ test.describe('Error Handling', () => {
             !text.includes('Loading chunk') &&
             !text.includes('ChunkLoadError') &&
             !text.includes('Pusher') // Pusher connection issues expected in test
-          ) {
+          ) 
             consoleErrors.push(text);
-          }
+          
         }
       });
 
@@ -422,9 +412,9 @@ test.describe('Error Handling', () => {
             !text.includes('hydration') &&
             !text.includes('ResizeObserver') &&
             !text.includes('Pusher')
-          ) {
+          ) 
             consoleErrors.push(text);
-          }
+          
         }
       });
 
@@ -447,9 +437,9 @@ test.describe('Error Handling', () => {
             !text.includes('hydration') &&
             !text.includes('ResizeObserver') &&
             !text.includes('Pusher')
-          ) {
+          ) 
             consoleErrors.push(text);
-          }
+          
         }
       });
 

--- a/e2e/real-time-updates.spec.ts
+++ b/e2e/real-time-updates.spec.ts
@@ -21,9 +21,9 @@ test.describe('Real-time Updates', () => {
       });
 
       page.on('console', (msg) => {
-        if (msg.type() === 'error') {
+        if (msg.type() === 'error') 
           consoleMessages.push(msg.text());
-        }
+        
       });
 
       await page.goto('/');
@@ -52,12 +52,12 @@ test.describe('Real-time Updates', () => {
         if (
           msg.type() === 'error' &&
           (text.includes('websocket') || text.includes('socket'))
-        ) {
+        ) 
           // Ignore expected test environment connection issues
-          if (!text.includes('failed to connect') && !text.includes('timeout')) {
+          if (!text.includes('failed to connect') && !text.includes('timeout')) 
             wsErrors.push(msg.text());
-          }
-        }
+          
+        
       });
 
       await page.goto('/');
@@ -108,11 +108,6 @@ test.describe('Real-time Updates', () => {
 
     test('should show loading state during data refresh', async ({ page }) => {
       await page.goto('/');
-
-      // Look for loading indicators
-      const loadingIndicators = page.locator(
-        '[data-testid="loading"], [class*="loading"], [class*="spinner"], [class*="skeleton"]'
-      );
 
       // Loading state should appear briefly or content should load quickly
       // Wait for either loading to appear or content to be visible

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -83,6 +83,16 @@ const eslintConfig = [
     },
   },
   {
+    // Tests re-require modules after jest.resetModules() to re-evaluate them
+    // under different env/mock conditions -- ESM `import` cannot express this.
+    files: ['__tests__/**/*.ts', '__tests__/**/*.tsx'],
+    rules: {
+      '@typescript-eslint/no-require-imports': 'off',
+      // Tests stub and assert on console output
+      'no-console': 'off',
+    },
+  },
+  {
     // Allow console.log in monitoring and logging utilities
     files: ['lib/monitoring/**/*.ts', 'lib/redis/**/*.ts'],
     rules: {

--- a/lib/pusher-context.tsx
+++ b/lib/pusher-context.tsx
@@ -103,7 +103,10 @@ export function usePusherReadings(callback: ReadingsCallback): void {
   // Keep a mutable ref so the effect closure always calls the latest callback
   // without needing to re-subscribe on every render.
   const callbackRef = useRef<ReadingsCallback>(callback);
-  callbackRef.current = callback;
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
 
   useEffect(() => {
     if (!ctx) {

--- a/lib/query/hooks/useDevicesList.ts
+++ b/lib/query/hooks/useDevicesList.ts
@@ -21,9 +21,9 @@ export function useDevicesList(
         if (totalPages > 1) {
           // Fetch remaining pages in parallel
           const pagePromises = [];
-          for (let p = 2; p <= totalPages; p++) {
+          for (let p = 2; p <= totalPages; p++) 
             pagePromises.push(v2Api.devices.list({ ...filters, limit: 100, page: p }));
-          }
+          
           const results = await Promise.all(pagePromises);
           results.forEach(r => allDevices.push(...r.data));
         }

--- a/models/v2/ScheduleV2.ts
+++ b/models/v2/ScheduleV2.ts
@@ -1,4 +1,4 @@
-import mongoose, { Schema, type Document, type Model, Types } from 'mongoose';
+import mongoose, { Schema, type Document, type Model, type Types } from 'mongoose';
 
 // ============================================================================
 // CUSTOM ERRORS


### PR DESCRIPTION
`npx tsc --noEmit` reported 54 errors and `pnpm lint` reported 308 errors (plus 3 warnings). Both now exit clean, with the full Jest suite still passing.

```
tsc --noEmit  → exit 0   (was 54 errors)
pnpm lint     → exit 0   (was 308 errors, 3 warnings)
pnpm test     → 2173 passed, 85 suites
```

## Type errors

All 54 were in test files. Two were real bugs in the tests, not just type noise:

- **`analytics.integration.test.ts` set `health.last_communication`** on 13 device fixtures. No such field exists — the model has `health.last_seen` — so Mongoose silently dropped it. All 13 used `new Date()`, which matches the schema default, so behaviour is unchanged. Two of them already carried a real `last_seen` offset alongside it; those offsets were kept.
- **`logger.test.ts` called `logger.request({ method, path, statusCode, duration })`** but the API is positional (`request(method, path, statusCode, duration)`).

The rest were mechanical:

- `as unknown as Record<string, unknown>` for the "poke an invalid value into a typed object" pattern (12 sites).
- `NODE_ENV` writes cast through a mutable view — it is `readonly` in current `@types/node` (5 sites).
- Zod 4 dropped `received` on `invalid_type` issues in favour of `input`.
- `NextRequest`'s `RequestInit` is narrower than the DOM one (`signal` cannot be `null`).
- An explicit type argument for `createCursorFromItem(undefined, 'createdAt')`, since `keyof T` is otherwise inferred from the absent item.

## Lint errors

135 were autofixable (`curly: multi`, `import/first`, `consistent-type-imports`). The notable manual fixes were both in source, and both are genuine React correctness issues:

- **`lib/pusher-context.tsx`** wrote to a ref during render (`react-hooks/refs`). The sync now happens in its own `useEffect`, ordered ahead of the subscribe effect.
- **`components/dashboard/CriticalIssuesPanel.tsx`** called `Date.now()` during render (`react-hooks/purity`). The lazily-initialised ref is replaced with `useState(() => Date.now())`, added to the `useMemo` deps.

Also: merged split value+type imports of `@/lib/pusher-context` in three components, dropped an unused map param in `MaintenanceWidget`, and removed three dead locator variables in the e2e specs.

## Config change worth a look

145 errors were `@typescript-eslint/no-require-imports` in tests using the `jest.resetModules()` + `require()` pattern to re-evaluate modules under different env/mock conditions — something ESM `import` cannot express. Rather than rewrite 145 call sites, `eslint.config.mjs` now disables that rule for `__tests__/**`, along with `no-console` (these tests stub and assert on console output). Every other rule still applies to tests.

## One thing to flag

`factories.ts` omits `configuration.calibration_date`, which `IDeviceConfiguration` requires. The obvious fix — adding `calibration_date: null` — breaks 5 device POST tests, because the Zod schema is `pastDateSchema.optional()`, which accepts `undefined` but rejects `null`. The field therefore has to stay absent, so the factory's `DeviceInput` type was widened to make it optional instead. If the model and validator should instead agree on `null`, that is a source-side change not made here.
